### PR TITLE
Fix setting DocuSeal contracts for re-invited contractors

### DIFF
--- a/apps/next/trpc/routes/companies.ts
+++ b/apps/next/trpc/routes/companies.ts
@@ -274,15 +274,15 @@ export const companiesRouter = createRouter({
       });
       if (!response.ok) throw new TRPCError({ code: "BAD_REQUEST", message: await response.text() });
 
-      const { new_user_id, administrator_id } = z
-        .object({ new_user_id: z.number(), administrator_id: z.number() })
+      const { new_user_id, document_id } = z
+        .object({ new_user_id: z.number(), document_id: z.number() })
         .parse(await response.json());
       const user = assertDefined(await db.query.users.findFirst({ where: eq(users.id, BigInt(new_user_id)) }));
       const submission = await createSubmission(ctx, template.docusealId, user, "Signer");
       const [document] = await db
         .update(documents)
         .set({ docusealSubmissionId: submission.id })
-        .where(eq(documents.companyAdministratorId, BigInt(administrator_id)))
+        .where(eq(documents.id, document_id))
         .returning();
       // TODO remove this flag
       await db.update(users).set({ invitingCompany: false }).where(eq(users.id, ctx.user.id));

--- a/apps/next/trpc/routes/companies.ts
+++ b/apps/next/trpc/routes/companies.ts
@@ -282,7 +282,7 @@ export const companiesRouter = createRouter({
       const [document] = await db
         .update(documents)
         .set({ docusealSubmissionId: submission.id })
-        .where(eq(documents.id, document_id))
+        .where(eq(documents.id, BigInt(document_id)))
         .returning();
       // TODO remove this flag
       await db.update(users).set({ invitingCompany: false }).where(eq(users.id, ctx.user.id));

--- a/apps/next/trpc/routes/contractors/index.ts
+++ b/apps/next/trpc/routes/contractors/index.ts
@@ -179,7 +179,7 @@ export const contractorsRouter = createRouter({
       const [document] = await db
         .update(documents)
         .set({ docusealSubmissionId: submission.id })
-        .where(and(eq(documents.id, document_id)))
+        .where(and(eq(documents.id, BigInt(document_id))))
         .returning();
       return { documentId: document?.id };
     }),

--- a/apps/next/trpc/routes/contractors/index.ts
+++ b/apps/next/trpc/routes/contractors/index.ts
@@ -171,13 +171,15 @@ export const contractorsRouter = createRouter({
       });
       if (!response.ok) throw new TRPCError({ code: "BAD_REQUEST" });
       if (input.payRateType === PayRateType.Salary) return { documentId: null };
-      const { new_user_id } = z.object({ new_user_id: z.number() }).parse(await response.json());
+      const { new_user_id, document_id } = z
+        .object({ new_user_id: z.number(), document_id: z.number() })
+        .parse(await response.json());
       const user = assertDefined(await db.query.users.findFirst({ where: eq(users.id, BigInt(new_user_id)) }));
       const submission = await createSubmission(ctx, template.docusealId, user, "Company Representative");
       const [document] = await db
         .update(documents)
         .set({ docusealSubmissionId: submission.id })
-        .where(and(eq(documents.userId, user.id), eq(documents.companyId, ctx.company.id)))
+        .where(and(eq(documents.id, document_id)))
         .returning();
       return { documentId: document?.id };
     }),

--- a/apps/rails/app/controllers/internal/companies/workers_controller.rb
+++ b/apps/rails/app/controllers/internal/companies/workers_controller.rb
@@ -18,7 +18,7 @@ class Internal::Companies::WorkersController < Internal::Companies::BaseControll
     ).perform
 
     if result[:success]
-      render json: { success: true, new_user_id: result[:company_worker].user_id }, status: :ok
+      render json: { success: true, new_user_id: result[:company_worker].user_id, document_id: result[:document].id }, status: :ok
     else
       render json: result, status: :unprocessable_entity
     end

--- a/apps/rails/app/controllers/internal/company_invitations_controller.rb
+++ b/apps/rails/app/controllers/internal/company_invitations_controller.rb
@@ -18,7 +18,7 @@ class Internal::CompanyInvitationsController < Internal::BaseController
     ).perform
 
     if result[:success]
-      render json: { success: true, new_user_id: result[:administrator].id, administrator_id: result[:company_administrator].id }, status: :created
+      render json: { success: true, new_user_id: result[:administrator].id, document_id: result[:document].id }, status: :created
     else
       render json: { success: false, errors: result[:errors] }, status: :unprocessable_entity
     end

--- a/apps/rails/app/services/invite_company.rb
+++ b/apps/rails/app/services/invite_company.rb
@@ -48,11 +48,11 @@ class InviteCompany
       company_worker = company.company_workers.create!(company_worker_params.merge(user: worker, company_role:))
       company_administrator = company.company_administrators.find_by(user: administrator)
 
-      CreateConsultingContract.new(company_worker:, company_administrator:, current_user: company_worker.user).perform!
+      document = CreateConsultingContract.new(company_worker:, company_administrator:, current_user: company_worker.user).perform!
       ContractorProfile.find_or_create_by!(user: worker, available_hours_per_week: 1)
       CompanyWorkerMailer.invite_company(company_worker_id: company_worker.id, url: administrator.create_clerk_invitation).deliver_later
 
-      { success: true, administrator:, company_administrator: }
+      { success: true, administrator:, company_administrator:, document: }
     end
   rescue ActiveRecord::RecordInvalid => e
     Rails.logger.error("InviteCompany error: #{e}")

--- a/apps/rails/app/services/invite_worker.rb
+++ b/apps/rails/app/services/invite_worker.rb
@@ -46,12 +46,12 @@ class InviteWorker
     end
 
     if user.errors.blank?
-      CreateConsultingContract.new(company_worker:, company_administrator:, current_user:).perform!
+      document = CreateConsultingContract.new(company_worker:, company_administrator:, current_user:).perform!
       ContractorProfile.find_or_create_by(user:, available_hours_per_week: 1)
       GenerateContractorInvitationJob.perform_async(company_worker.id, is_existing_user)
       @application&.accepted!
 
-      { success: true, company_worker: }
+      { success: true, company_worker:, document: }
     else
       error_object = if company_worker.errors.any?
         company_worker

--- a/apps/rails/spec/services/invite_worker_spec.rb
+++ b/apps/rails/spec/services/invite_worker_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe InviteWorker do
 
   it "creates the record when all information is present" do
     expect do
-      expect(invite_contractor).to eq({ success: true, company_worker: CompanyWorker.last })
+      expect(invite_contractor).to eq({ success: true, company_worker: CompanyWorker.last, document: Document.last })
     end.to change { User.count }.by(1)
         .and change { CompanyWorker.count }.by(1)
         .and change { ContractorProfile.count }.by(1)
@@ -100,7 +100,7 @@ RSpec.describe InviteWorker do
 
       it "creates a new contractor record for this company" do
         expect do
-          expect(invite_contractor).to eq({ success: true, company_worker: CompanyWorker.last })
+          expect(invite_contractor).to eq({ success: true, company_worker: CompanyWorker.last, document: Document.last })
         end.to change { User.count }.by(0)
           .and change { CompanyWorker.count }.by(1)
           .and change { ContractorProfile.count }.by(0)
@@ -131,7 +131,7 @@ RSpec.describe InviteWorker do
       )
 
       expect do
-        expect(invite_contractor).to eq({ success: true, company_worker: company_worker })
+        expect(invite_contractor).to eq({ success: true, company_worker: company_worker, document: Document.last })
       end.to change { User.count }.by(0)
           .and change { CompanyWorker.count }.by(0)
           .and change { ContractorProfile.count }.by(0)


### PR DESCRIPTION
Fixes re-inviting contractors by not assuming that their _first_ contract is the correct one to use for DocuSeal.