### PR TITLE
Fix equity link breaking for Gumroad workers

### DIFF
--- a/apps/next/app/equity/index.ts
+++ b/apps/next/app/equity/index.ts
@@ -9,7 +9,9 @@ export const navLinks = (user: CurrentUser, company: Company): TabLink[] => {
     company.flags.includes("financing_rounds") && (isAdmin || isLawyer || isInvestor)
       ? { label: "Rounds", route: "/equity/financing_rounds" }
       : null,
-    company.flags.includes("cap_table") ? { label: "Cap table", route: "/equity/cap_table" } : null,
+    company.flags.includes("cap_table") && (isAdmin || isLawyer || isInvestor)
+      ? { label: "Cap table", route: "/equity/cap_table" }
+      : null,
     company.flags.includes("equity_grants") && (isAdmin || isLawyer)
       ? { label: "Option pools", route: "/equity/option_pools" }
       : null,

--- a/apps/next/trpc/routes/capTable.ts
+++ b/apps/next/trpc/routes/capTable.ts
@@ -3,7 +3,6 @@ import { and, desc, eq, inArray, or, sql, sum } from "drizzle-orm";
 import { omit, pick } from "lodash-es";
 import { z } from "zod";
 import { db } from "@/db";
-import { PayRateType } from "@/db/enums";
 import {
   companyInvestorEntities,
   companyInvestors,
@@ -20,12 +19,7 @@ import { companyProcedure, createRouter } from "@/trpc";
 export const capTableRouter = createRouter({
   show: companyProcedure.input(z.object({ newSchema: z.boolean().optional() })).query(async ({ ctx, input }) => {
     const isAdminOrLawyer = !!(ctx.companyAdministrator || ctx.companyLawyer);
-    const isWorkerForGumroad =
-      ctx.companyContractor &&
-      ctx.companyContractor.endedAt === null &&
-      ctx.companyContractor.payRateType === PayRateType.Hourly &&
-      ctx.company.isGumroad;
-    if (!ctx.company.capTableEnabled || !(isAdminOrLawyer || ctx.companyInvestor || isWorkerForGumroad))
+    if (!ctx.company.capTableEnabled || !(isAdminOrLawyer || ctx.companyInvestor))
       throw new TRPCError({ code: "FORBIDDEN" });
 
     let upcomingDividendCents = 0n;


### PR DESCRIPTION
Currently, the cap table is hardcoded to allow Antiwork workers to view it. This is specific to hourly workers however, and is now breaking for project-based workers. Since this is probably now-obsolete legacy code as anyone working at Antiwork is also an investor, this PR just removes it.