### PR TITLE
Remove #pay_rate_type_cannot_change validation

### DIFF
--- a/apps/rails/app/models/company_worker.rb
+++ b/apps/rails/app/models/company_worker.rb
@@ -39,7 +39,6 @@ class CompanyWorker < ApplicationRecord
                              if: :hourly?
   validates :pay_rate_in_subunits, presence: true, numericality: { only_integer: true, greater_than: 0 }
   validate :only_hourly_contractor_can_be_on_trial
-  validate :pay_rate_type_cannot_change, on: :update
 
   scope :active, -> { where(ended_at: nil) }
   scope :active_as_of, ->(date) { active.or(where("ended_at > ?", date)) }
@@ -166,10 +165,6 @@ class CompanyWorker < ApplicationRecord
       if on_trial? && !hourly?
         errors.add(:base, "Can only set trials with hourly contracts")
       end
-    end
-
-    def pay_rate_type_cannot_change
-      errors.add(:base, "Cannot change role type for existing contractor") if pay_rate_type_changed?
     end
 
     def notify_rate_updated

--- a/apps/rails/spec/models/company_worker_spec.rb
+++ b/apps/rails/spec/models/company_worker_spec.rb
@@ -59,26 +59,6 @@ RSpec.describe CompanyWorker do
         expect(company_worker.errors.full_messages).to eq ["Can only set trials with hourly contracts"]
       end
     end
-
-    describe "#pay_rate_type_cannot_change" do
-      context "for an hourly-based contractor" do
-        let(:company_worker) { create(:company_worker) }
-
-        it "does not allow changing to a project-based role type" do
-          company_worker.update(pay_rate_type: :project_based)
-          expect(company_worker.errors.full_messages).to eq ["Cannot change role type for existing contractor"]
-        end
-      end
-
-      context "for a project-based contractor" do
-        let(:company_worker) { create(:company_worker, :project_based) }
-
-        it "does not allow changing to an hourly role type" do
-          company_worker.update(pay_rate_type: :hourly, hours_per_week: 20)
-          expect(company_worker.errors.full_messages).to eq ["Cannot change role type for existing contractor"]
-        end
-      end
-    end
   end
 
   describe "scopes" do


### PR DESCRIPTION
Currently, the `CompanyWorker` rails model has a validation to prevent changing the pay rate type. This legacy code is breaking some flows, so we should remove it.