### PR TITLE
fix: copying wrong env example file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,7 @@ tmp
 /apps/rails/config/credentials.yml.enc
 /apps/rails/config/credentials/*.yml.enc
 /apps/rails/config/credentials/*.key
+
+# IDE
+.vscode
+.idea

--- a/bin/setup
+++ b/bin/setup
@@ -43,7 +43,7 @@ if [ ! -f ".env" ]; then
     if [ "$answer" = "y" ] || [ "$answer" = "Y" ]; then
         pnpx vercel link && pnpx vercel env pull .env
     else
-      cp .env.sample .env
+      cp .env.example .env
       echo "A sample .env file has been created. Please fill it in with your own keys."
     fi
 fi


### PR DESCRIPTION
- [x] When first time developer runs `bin/setup`, and then he don't take env from vercel, it will try to copy `.env.sample` to `.env`. Which is not exist (I believe this should be .env.example) instead
- [x] Add .idea and .vscode to the .gitignore