### PR TITLE
Run CI on PRs from forks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,8 @@
 name: Rspec CI
 on:
   push:
+    branches:
+      - main
   pull_request:
 
 # Cancel builds for previous commits on the same branch unless the branch is "main"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,7 @@
 name: Rspec CI
-on: push
+on:
+  push:
+  pull_request:
 
 # Cancel builds for previous commits on the same branch unless the branch is "main"
 concurrency:

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -1,5 +1,7 @@
 name: Playwright CI
-on: push
+on:
+  push:
+  pull_request:
 
 # Cancel builds for previous commits on the same branch unless the branch is "main"
 concurrency:

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -1,6 +1,8 @@
 name: Playwright CI
 on:
   push:
+    branches:
+      - main
   pull_request:
 
 # Cancel builds for previous commits on the same branch unless the branch is "main"


### PR DESCRIPTION
Changes tests from being run on push to being run on PRs. This does mean CI won't be run unless a (draft) PR is opened on branches, but [there doesn't seem to be a good way](https://github.com/orgs/community/discussions/26276) to do both on GH without wasting a bunch of resources.

With the Clerk, Stripe, and Wise secrets configured in forks, we should be able to run CI on their PRs.