### PR TITLE
Use pull_request_target in CI scripts

### DIFF
--- a/.github/workflows/autofix.yml
+++ b/.github/workflows/autofix.yml
@@ -1,7 +1,7 @@
 name: autofix.ci
 
 on:
-  pull_request:
+  pull_request_target:
 permissions:
   contents: read
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,7 @@ on:
   push:
     branches:
       - main
-  pull_request:
+  pull_request_target:
 
 # Cancel builds for previous commits on the same branch unless the branch is "main"
 concurrency:

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -3,7 +3,7 @@ on:
   push:
     branches:
       - main
-  pull_request:
+  pull_request_target:
 
 # Cancel builds for previous commits on the same branch unless the branch is "main"
 concurrency:


### PR DESCRIPTION
This should allow us to run CI on external contributors' PRs with our own test secrets after manual approval. Can't test this on another branch because it needs to exist in main for it to trigger, but will revert/fix if it doesn't work.