### PR TITLE
Refactor document signing mechanism to be independent of legal names

### DIFF
--- a/apps/next/app/documents/List.tsx
+++ b/apps/next/app/documents/List.tsx
@@ -61,8 +61,8 @@ const List = ({ userId, documents }: { userId: string | null; documents: Documen
   const [signDocumentId, setSignDocumentId] = useState<bigint | null>(null);
   const isSignable = (document: Document): document is SignableDocument =>
     !!document.docusealSubmissionId &&
-    ((document.user.id === user.id && !document.contractorSignature) ||
-      (user.activeRole === "administrator" && !document.administratorSignature));
+    ((document.user.id === user.id && !document.signatories.includes(user.id)) ||
+      (user.activeRole === "administrator" && !document.signatories.includes(user.id)));
   const signDocument = signDocumentId
     ? documents.find((document): document is SignableDocument => document.id === signDocumentId && isSignable(document))
     : null;
@@ -154,7 +154,10 @@ const SignDocumentModal = ({ document, onClose }: { document: SignableDocument; 
           signDocument.mutate({
             companyId: company.id,
             id: document.id,
-            role: document.user.id === user.id && !document.contractorSignature ? "Signer" : "Company Representative",
+            role:
+              document.user.id === user.id && !document.signatories.includes(user.id)
+                ? "Signer"
+                : "Company Representative",
           })
         }
       />

--- a/apps/next/db/schema.ts
+++ b/apps/next/db/schema.ts
@@ -703,6 +703,15 @@ export const documents = pgTable(
   ],
 );
 
+export const documentSignatures = pgTable("document_signatures", {
+  documentId: bigint("document_id", { mode: "bigint" }).notNull(),
+  userId: bigint("user_id", { mode: "bigint" }).notNull(),
+  createdAt: timestamp("created_at", { precision: 6, mode: "date" }).defaultNow().notNull(),
+  updatedAt: timestamp("updated_at", { precision: 6, mode: "date" })
+    .notNull()
+    .$onUpdate(() => new Date()),
+});
+
 export const equityExerciseBankAccounts = pgTable(
   "equity_exercise_bank_accounts",
   {
@@ -2351,6 +2360,7 @@ export const usersRelations = relations(users, ({ many }) => ({
   tosAgreements: many(tosAgreements),
   userComplianceInfos: many(userComplianceInfos),
   wallets: many(wallets),
+  documentSignatures: many(documentSignatures),
 }));
 
 export const companiesRelations = relations(companies, ({ many }) => ({
@@ -2405,7 +2415,7 @@ export const companyContractorUpdatesRelations = relations(companyContractorUpda
   tasks: many(companyContractorUpdateTasks),
 }));
 
-export const documentsRelations = relations(documents, ({ one }) => ({
+export const documentsRelations = relations(documents, ({ one, many }) => ({
   company: one(companies, {
     fields: [documents.companyId],
     references: [companies.id],
@@ -2425,6 +2435,18 @@ export const documentsRelations = relations(documents, ({ one }) => ({
   equityGrant: one(equityGrants, {
     fields: [documents.equityGrantId],
     references: [equityGrants.id],
+  }),
+  signatures: many(documentSignatures),
+}));
+
+export const documentSignaturesRelations = relations(documentSignatures, ({ one }) => ({
+  document: one(documents, {
+    fields: [documentSignatures.documentId],
+    references: [documents.id],
+  }),
+  user: one(users, {
+    fields: [documentSignatures.userId],
+    references: [users.id],
   }),
 }));
 

--- a/apps/rails/app/models/document.rb
+++ b/apps/rails/app/models/document.rb
@@ -10,6 +10,8 @@ class Document < ApplicationRecord
   belongs_to :company_worker, optional: true, foreign_key: :company_contractor_id
   belongs_to :equity_grant, optional: true
 
+  has_and_belongs_to_many :signatories, class_name: "User", join_table: :document_signatures
+
   has_many_attached :attachments
 
   validates :name, presence: true
@@ -64,7 +66,7 @@ class Document < ApplicationRecord
     def signatures_and_completed_at_are_present
       return unless consulting_contract? || equity_plan_contract?
 
-      fully_signed = contractor_signature.present? && administrator_signature.present?
+      fully_signed = signatories.count >= 2
       if completed_at.blank?
         errors.add(:completed_at, "must be present") if fully_signed
       end

--- a/apps/rails/app/services/equity_exercising_service.rb
+++ b/apps/rails/app/services/equity_exercising_service.rb
@@ -58,9 +58,9 @@ class EquityExercisingService
       end
       company_administrator = company.primary_admin
       Document.create!(company_worker:, company_administrator:, company:, user: company_investor.user,
-                       administrator_signature: company_administrator.user.legal_name,
+                       signatories: [company_administrator.user, company_investor.user],
                        name: "Notice of Exercise", document_type: :exercise_notice,
-                       completed_at: current_time, contractor_signature: company_investor.user.legal_name, year: current_time.year,
+                       completed_at: current_time, year: current_time.year,
                        json_data: { equity_grant_exercise_id: exercise.id }, docuseal_submission_id: submission_id)
       CompanyInvestorMailer.stock_exercise_payment_instructions(company_investor.id, exercise_id: exercise.id).deliver_later
       if company.completed_onboarding?

--- a/apps/rails/app/services/seed_data_generator_from_template.rb
+++ b/apps/rails/app/services/seed_data_generator_from_template.rb
@@ -613,7 +613,9 @@ class SeedDataGeneratorFromTemplate
               ).process
               raise Error, error_message if error_message.present?
 
-              company_worker.uncompleted_contracts.reload.first.update!(contractor_signature: contractor.legal_name, completed_at: Time.current)
+              document = company_worker.uncompleted_contracts.reload.first
+              document.signatories << contractor
+              document.update!(completed_at: Time.current)
               user_legal_params = user_attributes.slice("street_address", "city", "state", "zip_code")
               error_message = UpdateUser.new(
                 user: contractor,

--- a/apps/rails/db/migrate/20250409021342_create_new_document_signatures.rb
+++ b/apps/rails/db/migrate/20250409021342_create_new_document_signatures.rb
@@ -1,0 +1,7 @@
+class CreateNewDocumentSignatures < ActiveRecord::Migration[8.0]
+  def change
+    create_join_table :documents, :users, table_name: :document_signatures do |t|
+      t.timestamps
+    end
+  end
+end

--- a/apps/rails/db/schema.rb
+++ b/apps/rails/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_03_21_231056) do
+ActiveRecord::Schema[8.0].define(version: 2025_04_09_021342) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -552,6 +552,13 @@ ActiveRecord::Schema[8.0].define(version: 2025_03_21_231056) do
     t.datetime "updated_at", null: false
     t.index ["dividend_id"], name: "index_dividends_dividend_payments_on_dividend_id"
     t.index ["dividend_payment_id"], name: "index_dividends_dividend_payments_on_dividend_payment_id"
+  end
+
+  create_table "document_signatures", id: false, force: :cascade do |t|
+    t.bigint "document_id", null: false
+    t.bigint "user_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
   create_table "document_templates", force: :cascade do |t|

--- a/apps/rails/spec/factories/documents.rb
+++ b/apps/rails/spec/factories/documents.rb
@@ -12,7 +12,7 @@ FactoryBot.define do
     document_type { Document.document_types[:consulting_contract] }
     company_administrator { create(:company_administrator, company:) }
     company_worker { create(:company_worker, company:) }
-    administrator_signature { company_administrator.user.legal_name }
+    signatories { [company_administrator.user] }
 
     factory :equity_plan_contract_doc do
       name { "Equity Incentive Plan #{Date.current.year}" }
@@ -21,8 +21,11 @@ FactoryBot.define do
     end
 
     trait :signed do
-      contractor_signature { user.legal_name }
       completed_at { Time.current }
+
+      after :build do |document|
+        document.signatories << document.user
+      end
     end
 
     trait :unsigned do
@@ -34,7 +37,6 @@ FactoryBot.define do
       name { TaxDocument::ALL_SUPPORTED_TAX_FORM_NAMES.sample }
       company_administrator { nil }
       company_worker { nil }
-      administrator_signature { nil }
       user_compliance_info { create(:user_compliance_info, user:) }
 
       trait :submitted do
@@ -75,7 +77,6 @@ FactoryBot.define do
       name { "Share Certificate" }
       company_administrator { nil }
       company_worker { nil }
-      administrator_signature { nil }
     end
 
     factory :exercise_notice do

--- a/apps/rails/spec/models/document_spec.rb
+++ b/apps/rails/spec/models/document_spec.rb
@@ -15,6 +15,7 @@ RSpec.describe Document do
     it { is_expected.to belong_to(:company_administrator).optional(true) }
     it { is_expected.to belong_to(:equity_grant).optional(true) }
     it { is_expected.to have_many_attached(:attachments) }
+    it { is_expected.to have_and_belong_to_many(:signatories).class_name("User").join_table(:document_signatures) }
   end
 
   describe "validations" do

--- a/apps/rails/spec/services/equity_exercising_service_spec.rb
+++ b/apps/rails/spec/services/equity_exercising_service_spec.rb
@@ -85,10 +85,9 @@ RSpec.describe EquityExercisingService do
       expect(document.year).to eq(exercise.signed_at.year)
       expect(document.company_administrator).to eq(company_administrator)
       expect(document.company).to eq(company)
-      expect(document.administrator_signature).to eq(company_administrator.user.legal_name)
+      expect(document.signatories).to eq([company_administrator.user, user])
       expect(document.name).to eq("Notice of Exercise")
       expect(document.completed_at).to eq(exercise.signed_at)
-      expect(document.contractor_signature).to eq(user.legal_name)
       expect(document.json_data).to eq({ equity_grant_exercise_id: exercise.id }.as_json)
     end
 

--- a/apps/rails/spec/system/contractor_and_investor_user_onboarding_spec.rb
+++ b/apps/rails/spec/system/contractor_and_investor_user_onboarding_spec.rb
@@ -87,7 +87,7 @@ RSpec.describe "Onboarding for a user with contractor and investor roles", :vcr 
       expect(page).to have_link("Documents")
       expect(page).to have_link("Account")
     end.to change { contract.reload.completed_at.present? }.from(false).to(true)
-       .and change { contract.contractor_signature }.from(nil).to(user.legal_name)
+       .and change { contract.signatories.count }.from(1).to(2)
        .and change { contract.attachment.present? }.from(false).to(true)
 
     expect(page).to have_current_path(spa_company_invoices_path(company.external_id))
@@ -146,7 +146,7 @@ RSpec.describe "Onboarding for a user with contractor and investor roles", :vcr 
         expect(page).to have_link("Documents")
         expect(page).to have_link("Account")
       end.to change { contract.reload.completed_at.present? }.from(false).to(true)
-         .and change { contract.contractor_signature }.from(nil).to("Marco Antônio")
+         .and change { contract.signatories.count }.from(1).to(2)
          .and change { contract.attachment.present? }.from(false).to(true)
 
       expect(page).to have_text("Invoicing")
@@ -224,8 +224,8 @@ RSpec.describe "Onboarding for a user with contractor and investor roles", :vcr 
         expect(page).to have_link("Documents")
         expect(page).to have_link("Account")
       end.to change { contract.reload.completed_at.present? }.from(false).to(true)
-        .and change { contract.contractor_signature }.from(nil).to("Marco Antônio")
-        .and change { contract.attachment.present? }.from(false).to(true)
+         .and change { contract.signatories.count }.from(1).to(2)
+         .and change { contract.attachment.present? }.from(false).to(true)
 
       expect(page).to have_text("Invoicing")
       expect(page).to have_current_path(spa_company_invoices_path(company.external_id))

--- a/e2e/factories/documents.ts
+++ b/e2e/factories/documents.ts
@@ -26,7 +26,6 @@ export const documentsFactory = {
         userId: user.id,
         name: "Consulting Agreement",
         type: DocumentType.ConsultingContract,
-        contractorSignature: options.signed ? user.legalName : null,
         completedAt: options.signed ? new Date() : null,
         year: new Date().getFullYear(),
         ...overrides,


### PR DESCRIPTION
This fixes a bug where if a company admin doesn't have a legal name set, the consulting agreement signing fails.