### PR TITLE
Add `sidekiq-pro` gem dependency to Gemfile.lock

### DIFF
--- a/apps/rails/Gemfile
+++ b/apps/rails/Gemfile
@@ -86,11 +86,11 @@ gem "devise_invitable", "~> 2.0"
 
 gem "money", "~> 6.16"
 
-if ENV["BUNDLE_GEMS__CONTRIBSYS__COM"]
+group :sidekiq_pro, optional: true do
   gem "sidekiq-pro", "~> 7", source: "https://gems.contribsys.com/"
-else
-  gem "sidekiq", "~> 7"
 end
+
+gem "sidekiq", "~> 7"
 
 gem "aws-sdk-s3", "~> 1.117"
 

--- a/apps/rails/Gemfile.lock
+++ b/apps/rails/Gemfile.lock
@@ -7,6 +7,12 @@ GIT
       capybara (~> 3.36)
 
 GEM
+  remote: https://gems.contribsys.com/
+  specs:
+    sidekiq-pro (7.3.6)
+      sidekiq (>= 7.3.7, < 8)
+
+GEM
   remote: https://rubygems.org/
   specs:
     actioncable (8.0.2)
@@ -754,8 +760,8 @@ DEPENDENCIES
   rubyXL (~> 3.4)
   selenium-webdriver (~> 4.30.0)
   shoulda-matchers (~> 6.0)
-  sidekiq (~> 7)
   sidekiq-cron (~> 2.0)
+  sidekiq-pro (~> 7)!
   slack-notifier (~> 2.4)
   sprockets (~> 4.0)
   sprockets-rails (~> 3.4)

--- a/apps/rails/Gemfile.lock
+++ b/apps/rails/Gemfile.lock
@@ -760,6 +760,7 @@ DEPENDENCIES
   rubyXL (~> 3.4)
   selenium-webdriver (~> 4.30.0)
   shoulda-matchers (~> 6.0)
+  sidekiq (~> 7)
   sidekiq-cron (~> 2.0)
   sidekiq-pro (~> 7)!
   slack-notifier (~> 2.4)


### PR DESCRIPTION
Heroku builds are currently broken because we still run Sidekiq Pro into production and the gem wasn't included in the `Gemfile.lock`.