### PR TITLE
Use default shadcn table hover & select style

### DIFF
--- a/apps/next/app/document_templates/page.tsx
+++ b/apps/next/app/document_templates/page.tsx
@@ -121,7 +121,7 @@ export default function TemplatesPage() {
       }
     >
       <div className="overflow-x-auto">
-        <DataTable table={table} hoverable />
+        <DataTable table={table} />
       </div>
     </DocumentsLayout>
   );

--- a/apps/next/components/DataTable.tsx
+++ b/apps/next/components/DataTable.tsx
@@ -63,11 +63,10 @@ export const useTable = <T extends RowData>(
 interface TableProps<T> {
   table: Table<T>;
   caption?: string;
-  hoverable?: boolean;
   onRowClicked?: ((row: T) => void) | undefined;
 }
 
-export default function DataTable<T extends RowData>({ table, caption, hoverable, onRowClicked }: TableProps<T>) {
+export default function DataTable<T extends RowData>({ table, caption, onRowClicked }: TableProps<T>) {
   const data = useMemo(() => {
     const headers = table
       .getHeaderGroups()
@@ -134,7 +133,8 @@ export default function DataTable<T extends RowData>({ table, caption, hoverable
         {data.rows.map((row) => (
           <TableRow
             key={row.id}
-            className={`translate-x-0 ${rowClasses} ${onRowClicked || hoverable ? "cursor-pointer hover:bg-gray-50" : ""} ${data.selectable ? "bg-linear-to-r from-blue-100 from-50% via-transparent via-50% bg-[length:200%] transition-all" : ""} ${!row.getIsSelected() ? "bg-[100%]" : ""}`}
+            className={`translate-x-0 ${rowClasses}`}
+            data-state={row.getIsSelected() ? "selected" : undefined}
             onClick={() => onRowClicked?.(row.original)}
           >
             {data.selectable ? (


### PR DESCRIPTION
Follow-up to #131.

Uses the default shadcn hover and selection style instead of our custom one:
**Before**
![image](https://github.com/user-attachments/assets/44d9de63-c0f9-4e89-9c1d-ef9c7134d9e2)

**After**
![image](https://github.com/user-attachments/assets/05922c87-9b0d-477b-8fe5-a5070c7d7bd7)

