### PR TITLE
fix: Table error for documents search

### DIFF
--- a/apps/next/app/documents/page.tsx
+++ b/apps/next/app/documents/page.tsx
@@ -379,7 +379,7 @@ export default function DocumentsPage() {
             <DataTable
               table={table}
               actions={isCompanyRepresentative ? <EditTemplates /> : undefined}
-              searchColumn="Signer"
+              {...(!(userId && user.activeRole === "contractorOrInvestor") && { searchColumn: "Signer" })}
             />
             {signDocument ? (
               <SignDocumentModal document={signDocument} onClose={() => setSignDocumentId(null)} />


### PR DESCRIPTION
**Issue**: When contractor opens documents page, Table throws error: "Column with id 'Signer' does not exist." 
**Reason**: The 'Signer' column is not shown to `contractorOrInvestor` role, but the `searchColumn` param for documents table doesn't handles this condition.

<img width="359" alt="table_error" src="https://github.com/user-attachments/assets/97321fc1-966e-4687-baf0-9c40ade2ee1f" />

--

This PR fixes above issue.

Issue is related to #23 documents section.

