### PR TITLE
Select the first combobox option when multiple options match

### DIFF
--- a/apps/next/app/documents/page.tsx
+++ b/apps/next/app/documents/page.tsx
@@ -3,6 +3,7 @@ import { ArrowDownTrayIcon, InformationCircleIcon } from "@heroicons/react/16/so
 import { BriefcaseIcon, CheckCircleIcon, PaperAirplaneIcon, PencilIcon } from "@heroicons/react/24/outline";
 import { skipToken, useMutation } from "@tanstack/react-query";
 import { getFilteredRowModel, getSortedRowModel } from "@tanstack/react-table";
+import { FileTextIcon, GavelIcon, PercentIcon } from "lucide-react";
 import type { Route } from "next";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
@@ -24,7 +25,6 @@ import type { RouterOutput } from "@/trpc";
 import { DocumentTemplateType, DocumentType, trpc } from "@/trpc/client";
 import { assertDefined } from "@/utils/assert";
 import { formatDate } from "@/utils/time";
-import { FileTextIcon, GavelIcon, PercentIcon } from "lucide-react";
 
 type Document = RouterOutput["documents"]["list"][number];
 type SignableDocument = Document & { docusealSubmissionId: number };

--- a/apps/next/components/ComboBox.tsx
+++ b/apps/next/components/ComboBox.tsx
@@ -1,10 +1,10 @@
 import { PopoverTrigger } from "@radix-ui/react-popover";
+import { Check, ChevronsUpDown } from "lucide-react";
 import React from "react";
 import { Command, CommandEmpty, CommandGroup, CommandInput, CommandItem, CommandList } from "@/components/ui/command";
 import { Popover, PopoverContent } from "@/components/ui/popover";
 import { cn } from "@/utils";
 import { Button } from "./ui/button";
-import { Check, ChevronsUpDown } from "lucide-react";
 
 const ComboBox = ({
   options,

--- a/apps/next/components/layouts/Main.tsx
+++ b/apps/next/components/layouts/Main.tsx
@@ -25,6 +25,7 @@ import {
 } from "@heroicons/react/24/solid";
 import { useQueryClient } from "@tanstack/react-query";
 import { capitalize } from "lodash-es";
+import { ChevronsUpDown } from "lucide-react";
 import Image from "next/image";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
@@ -57,7 +58,6 @@ import { type Company } from "@/models/user";
 import { trpc } from "@/trpc/client";
 import { request } from "@/utils/request";
 import { company_switch_path } from "@/utils/routes";
-import { ChevronsUpDown } from "lucide-react";
 
 type CompanyAccessRole = "administrator" | "worker" | "investor" | "lawyer";
 

--- a/apps/next/components/ui/form.tsx
+++ b/apps/next/components/ui/form.tsx
@@ -1,4 +1,5 @@
 import * as LabelPrimitive from "@radix-ui/react-label";
+import { Slot } from "@radix-ui/react-slot";
 import * as React from "react";
 import {
   Controller,
@@ -12,7 +13,6 @@ import {
 import { Label } from "@/components/ui/label";
 import { cn } from "@/utils";
 import { assertDefined } from "@/utils/assert";
-import { Slot } from "@radix-ui/react-slot";
 
 const Form = FormProvider;
 

--- a/e2e/helpers/index.ts
+++ b/e2e/helpers/index.ts
@@ -2,5 +2,5 @@ import type { Page } from "@playwright/test";
 
 export const selectComboboxOption = async (page: Page, name: string, option: string) => {
   await page.getByRole("combobox", { name }).click();
-  await page.getByRole("option", { name: option, exact: true }).click();
+  await page.getByRole("option", { name: option, exact: true }).first().click();
 };


### PR DESCRIPTION
## Changes

Updates the `selectComboboxOption` helper in `e2e/helpers/index.ts` to use `.first()` when selecting a combobox option.

## Reason

The previous locator `page.getByRole("option", { name: option, exact: true })` could fail or lead to flaky tests if multiple options with the exact same text exist in a combobox. By adding `.first()`, we ensure that Playwright clicks the first matching option it finds, making the selection deterministic and the helper function more robust.