### PR TITLE
Don't run lints on Vercel deploys

### DIFF
--- a/apps/next/trpc/routes/documents/index.ts
+++ b/apps/next/trpc/routes/documents/index.ts
@@ -3,8 +3,8 @@ import { TRPCError } from "@trpc/server";
 import { and, desc, eq, inArray, isNotNull, isNull, not, sql, type SQLWrapper } from "drizzle-orm";
 import { pick } from "lodash-es";
 import { z } from "zod";
-import { DocumentType } from "@/db/enums";
 import { byExternalId, db } from "@/db";
+import { DocumentType } from "@/db/enums";
 import {
   activeStorageAttachments,
   activeStorageBlobs,

--- a/apps/next/trpc/routes/documents/index.ts
+++ b/apps/next/trpc/routes/documents/index.ts
@@ -3,8 +3,8 @@ import { TRPCError } from "@trpc/server";
 import { and, desc, eq, inArray, isNotNull, isNull, not, sql, type SQLWrapper } from "drizzle-orm";
 import { pick } from "lodash-es";
 import { z } from "zod";
-import { byExternalId, db } from "@/db";
 import { DocumentType } from "@/db/enums";
+import { byExternalId, db } from "@/db";
 import {
   activeStorageAttachments,
   activeStorageBlobs,

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "typecheck:watch": "pnpm run typecheck --watch --preserveWatchOutput",
     "setup": "cd apps/rails && bundle exec rails js:routes:typescript",
     "lint-fast": "DISABLE_TYPE_CHECKED=1 pnpm eslint",
-    "build-next": "pnpm next build apps/next"
+    "build-next": "pnpm next build apps/next --no-lint"
   },
   "dependencies": {
     "@ai-sdk/openai": "^1.2.4",


### PR DESCRIPTION
Currently, linting errors block Vercel deployments. This PR fixes that.