### PR TITLE
Kill processes when running dev and test_server

### DIFF
--- a/bin/dev
+++ b/bin/dev
@@ -14,6 +14,15 @@ bundle install
 bin/rails db:prepare
 cd ../..
 
+function kill_process_listening_on_port {
+  lsof -i :$1 | grep LISTEN | awk '{print $2}' | xargs -r kill -9
+}
+
+echo "Starting application services"
+kill_process_listening_on_port 3000
+kill_process_listening_on_port 3001
+kill_process_listening_on_port 8288 # inngest
+
 export NODE_EXTRA_CA_CERTS="$(node docker/createCertificate.js)"
 make local
 foreman start -f Procfile.dev "$@"

--- a/bin/test_server
+++ b/bin/test_server
@@ -12,6 +12,7 @@ echo "Starting application services"
 kill_process_listening_on_port 3100
 kill_process_listening_on_port 3101
 kill_process_listening_on_port 3037
+kill_process_listening_on_port 8288 # inngest
 
 export NODE_TLS_REJECT_UNAUTHORIZED=0
 export RAILS_ENV=test


### PR DESCRIPTION
## What
I was running `pnpm playwright test` and cancelled midway. There were still dangling processes in the background which prevented me from running `bin/dev`. The only option was to restart my computer. This PR makes sure that certain processes are killed upon start bin/dev. @s3ththompson helped with this one. 

## Why
Wastes a lot of time in development trying to fix occupied port issues. 