### PR TITLE
Skip equity requirements for expense-only invoices

### DIFF
--- a/apps/rails/app/models/invoice.rb
+++ b/apps/rails/app/models/invoice.rb
@@ -179,7 +179,7 @@ class Invoice < ApplicationRecord
   end
 
   def equity_requirements_met?
-    !company.equity_compensation_enabled? || company_worker.equity_allocation_for(invoice_date.year)&.approved?
+    equity_amount_in_cents.zero? || !company.equity_compensation_enabled? || company_worker.equity_allocation_for(invoice_date.year)&.approved? == true
   end
 
   def payment_expected_by

--- a/apps/rails/spec/models/invoice_spec.rb
+++ b/apps/rails/spec/models/invoice_spec.rb
@@ -593,6 +593,74 @@ RSpec.describe Invoice do
         end
       end
     end
+
+    context "equity requirements" do
+      let(:company_worker) { create(:company_worker) }
+      let(:invoice) { create(:invoice, :fully_approved, company_worker:) }
+      let!(:equity_allocation) { create(:equity_allocation, company_worker:, year: invoice.invoice_date.year) }
+
+      before { allow_any_instance_of(Invoice).to receive(:tax_requirements_met?).and_return(true) }
+
+      context "when invoice equity amount is zero" do
+        before { invoice.update!(total_amount_in_usd_cents: 100_00, cash_amount_in_cents: 100_00, equity_amount_in_cents: 0) }
+
+        it "returns true" do
+          expect(invoice.payable?).to eq(true)
+        end
+
+        context "when equity compensation is not enabled" do
+          before { invoice.company.update!(equity_compensation_enabled: false) }
+
+          it "returns true" do
+            expect(invoice.payable?).to eq(true)
+          end
+        end
+
+        context "when equity compensation is enabled" do
+          before { invoice.company.update!(equity_compensation_enabled: true) }
+
+          context "when equity allocation is approved" do
+            before { equity_allocation.update!(status: EquityAllocation.statuses[:approved]) }
+
+            it "returns true" do
+              expect(invoice.payable?).to eq(true)
+            end
+          end
+        end
+      end
+
+      context "when invoice equity amount is not zero" do
+        before { invoice.update!(total_amount_in_usd_cents: 100_00, cash_amount_in_cents: 80_00, equity_amount_in_cents: 20_00) }
+
+        context "when equity compensation is enabled" do
+          before { invoice.company.update!(equity_compensation_enabled: true) }
+
+          context "when equity allocation is not approved" do
+            before { equity_allocation.update!(status: EquityAllocation.statuses[:pending_grant_creation]) }
+
+            it "returns false" do
+              expect(invoice.payable?).to eq(false)
+            end
+          end
+
+          context "when no equity allocation exists for the invoice year" do
+            before { equity_allocation.destroy! }
+
+            it "returns false" do
+              expect(invoice.payable?).to eq(false)
+            end
+          end
+
+          context "when equity allocation is approved" do
+            before { equity_allocation.update!(status: EquityAllocation.statuses[:approved]) }
+
+            it "returns true" do
+              expect(invoice.payable?).to eq(true)
+            end
+          end
+        end
+      end
+    end
   end
 
   describe "#immediately_payable?" do


### PR DESCRIPTION
### What

- [x] skip equity requirements for expense-only invoices (have the `equity_amount_in_cents` column equal to `0`)

### Why

Currently, expense-only invoices are not payable for companies with equity compensation enabled when grants haven't been issued for the year.