### PR TITLE
Remove conditional rendering for settings payout method section

### DIFF
--- a/apps/next/app/settings/payouts/page.tsx
+++ b/apps/next/app/settings/payouts/page.tsx
@@ -191,8 +191,6 @@ const BankAccountsSection = () => {
     );
   };
 
-  if (!isFromSanctionedCountry && !showWalletPayoutMethod) return null;
-
   return (
     <FormSection title="Payout method">
       <CardContent>

--- a/apps/next/app/settings/payouts/page.tsx
+++ b/apps/next/app/settings/payouts/page.tsx
@@ -296,7 +296,7 @@ const BankAccountsSection = () => {
 
             {user.roles.investor ? (
               <>
-                <Separator />
+                {bankAccounts.length > 0 ? <Separator /> : null}
                 <div>
                   {addingBankAccount ? (
                     <BankAccountModal


### PR DESCRIPTION
Regression from #207.

Investors should be able to add a new bank account from `/settings/payout`.

### Before
<img width="1728" alt="image" src="https://github.com/user-attachments/assets/e0ed2f2c-c647-4dc5-bb09-3ebb63b78c33" />

### After
<img width="1728" alt="image" src="https://github.com/user-attachments/assets/607e71dc-d7a4-4e61-b83a-553f37954a73" />
