### PR TITLE
Add check for bank account presence in `PayInvestorDividends` before processing payments

### DIFF
--- a/apps/rails/app/services/pay_investor_dividends.rb
+++ b/apps/rails/app/services/pay_investor_dividends.rb
@@ -19,7 +19,7 @@ class PayInvestorDividends
     return if dividends.any? { !_1.status.in?([Dividend::ISSUED, Dividend::RETAINED]) } ||
               !company_investor.completed_onboarding? ||
               user.tax_information_confirmed_at.nil? ||
-              user.bank_account.nil?
+              user.bank_account_for_dividends.nil?
     return unless user.has_verified_tax_id?
 
     raise "Feature unsupported for company #{company.id}" unless company.dividends_allowed?

--- a/apps/rails/app/services/pay_investor_dividends.rb
+++ b/apps/rails/app/services/pay_investor_dividends.rb
@@ -18,7 +18,8 @@ class PayInvestorDividends
   def process
     return if dividends.any? { !_1.status.in?([Dividend::ISSUED, Dividend::RETAINED]) } ||
               !company_investor.completed_onboarding? ||
-              user.tax_information_confirmed_at.nil?
+              user.tax_information_confirmed_at.nil? ||
+              user.bank_account.nil?
     return unless user.has_verified_tax_id?
 
     raise "Feature unsupported for company #{company.id}" unless company.dividends_allowed?

--- a/apps/rails/app/sidekiq/investor_dividends_payment_job.rb
+++ b/apps/rails/app/sidekiq/investor_dividends_payment_job.rb
@@ -10,7 +10,7 @@ class InvestorDividendsPaymentJob
   def perform(company_investor_id)
     @company_investor = CompanyInvestor.find(company_investor_id)
 
-    return if !user.has_verified_tax_id? || tax_information_confirmed_at.nil?
+    return if !user.has_verified_tax_id? || tax_information_confirmed_at.nil? || user.bank_account_for_dividends.nil?
 
     update_dividend_tax_info
 

--- a/apps/rails/app/sidekiq/investor_dividends_payment_job.rb
+++ b/apps/rails/app/sidekiq/investor_dividends_payment_job.rb
@@ -10,7 +10,7 @@ class InvestorDividendsPaymentJob
   def perform(company_investor_id)
     @company_investor = CompanyInvestor.find(company_investor_id)
 
-    return if !user.has_verified_tax_id? || tax_information_confirmed_at.nil? || user.bank_account_for_dividends.nil?
+    return if !user.has_verified_tax_id? || tax_information_confirmed_at.nil?
 
     update_dividend_tax_info
 


### PR DESCRIPTION
This PR addresses a `NoMethodError` occurring in the `PayInvestorDividends`. The error `undefined method 'currency' for nil` happened when the job attempted to process dividend payments for investors who had completed tax verification but had not yet added a bank account for receiving dividends.

The fix involves adding a check for `user.bank_account_for_dividends.nil?` to the early return condition within the job's perform method. This ensures that the job does not proceed if the user lacks a designated bank account, preventing the downstream error.