### PR TITLE
Update validation error message for contractor invite in `invite_worker_spec.rb`

### DIFF
--- a/apps/rails/spec/services/invite_worker_spec.rb
+++ b/apps/rails/spec/services/invite_worker_spec.rb
@@ -150,7 +150,7 @@ RSpec.describe InviteWorker do
 
     it "returns contractor specific validation error messages" do
       expect do
-        expect(invite_contractor).to eq({ success: false, error_message: "Hours per week must be greater than 0 and Pay rate in subunits must be greater than 0" })
+        expect(invite_contractor).to eq({ success: false, error_message: "Role can't be blank, Hours per week must be greater than 0, and Pay rate in subunits must be greater than 0" })
       end.to change { User.count }.by(0)
          .and change { CompanyWorker.count }.by(0)
          .and change { Document.count }.by(0)


### PR DESCRIPTION
Fixes the [latest failing CI error](https://github.com/antiwork/flexile/actions/runs/14843773422).

Regression from #259.