### PR TITLE
Make city, state, street_address, and zip_code fields nullable in tax data schema

### DIFF
--- a/apps/next/app/documents/DocusealForm.tsx
+++ b/apps/next/app/documents/DocusealForm.tsx
@@ -92,7 +92,7 @@ export const customCss = `
   }
 
   .scrollbox {
-    height: 100vh;
+    min-height: 500px;
   }
 
   div:has(> .submitted-form-resubmit-button) {

--- a/apps/next/app/settings/tax/page.tsx
+++ b/apps/next/app/settings/tax/page.tsx
@@ -38,7 +38,7 @@ const dataSchema = z.object({
   business_type: z.number().nullable(),
   tax_classification: z.number().nullable(),
   citizenship_country_code: z.string(),
-  city: z.string(),
+  city: z.string().nullable(),
   country_code: z.string(),
   display_name: z.string(),
   business_entity: z.boolean(),
@@ -46,11 +46,11 @@ const dataSchema = z.object({
   is_tax_information_confirmed: z.boolean(),
   legal_name: z.string(),
   signature: z.string(),
-  state: z.string(),
-  street_address: z.string(),
+  state: z.string().nullable(),
+  street_address: z.string().nullable(),
   tax_id: z.string().nullable(),
   tax_id_status: z.enum(["verified", "invalid"]).nullable(),
-  zip_code: z.string(),
+  zip_code: z.string().nullable(),
   contractor_for_companies: z.array(z.string()),
 });
 

--- a/apps/next/app/settings/tax/page.tsx
+++ b/apps/next/app/settings/tax/page.tsx
@@ -104,7 +104,14 @@ export default function TaxPage() {
 
   const form = useForm({
     resolver: zodResolver(formSchema),
-    defaultValues: { ...data, tax_id: data.tax_id ?? "" },
+    defaultValues: {
+      ...data,
+      tax_id: data.tax_id ?? "",
+      city: data.city ?? "",
+      state: data.state ?? "",
+      zip_code: data.zip_code ?? "",
+      street_address: data.street_address ?? "",
+    },
   });
 
   const formValues = form.watch();


### PR DESCRIPTION
Bug fix.

### Before
<img width="1667" alt="image" src="https://github.com/user-attachments/assets/2a02c116-bd4d-429c-9c17-ec07cf5d59be" />

### After
<img width="1650" alt="image" src="https://github.com/user-attachments/assets/576dedbf-b1bf-4b8a-b1e7-8308ec2dd6fe" />

### Error

```
ZodError: [
  {
    "code": "invalid_type",
    "expected": "string",
    "received": "null",
    "path": [
      "city"
    ],
    "message": "Expected string, received null"
  },
  {
    "code": "invalid_type",
    "expected": "string",
    "received": "null",
    "path": [
      "state"
    ],
    "message": "Expected string, received null"
  },
  {
    "code": "invalid_type",
    "expected": "string",
    "received": "null",
    "path": [
      "street_address"
    ],
    "message": "Expected string, received null"
  },
  {
    "code": "invalid_type",
    "expected": "string",
    "received": "null",
    "path": [
      "zip_code"
    ],
    "message": "Expected string, received null"
  }
]
    at get error (index.mjs:587:1)
    at ZodObject.parse (index.mjs:663:1)
    at TaxPage.useSuspenseQuery (page.tsx:96:25)
```