### PR TITLE
Add `useEffect` to set default invoice equity percentage and update input disabled state based on equity allocation lock

### DIFF
--- a/apps/next/app/invoices/page.tsx
+++ b/apps/next/app/invoices/page.tsx
@@ -4,7 +4,7 @@ import { ArrowDownTrayIcon, ExclamationTriangleIcon } from "@heroicons/react/20/
 import { CheckCircleIcon, InformationCircleIcon, PencilIcon, PlusIcon } from "@heroicons/react/24/outline";
 import { getFilteredRowModel, getSortedRowModel } from "@tanstack/react-table";
 import Link from "next/link";
-import React, { Fragment, useMemo, useState } from "react";
+import React, { Fragment, useEffect, useMemo, useState } from "react";
 import StripeMicrodepositVerification from "@/app/administrator/settings/StripeMicrodepositVerification";
 import {
   ApproveButton,
@@ -585,6 +585,12 @@ const QuickInvoicesSection = () => {
     }
   });
 
+  useEffect(() => {
+    if (equityAllocation?.equityPercentage) {
+      form.setValue("invoiceEquityPercent", equityAllocation.equityPercentage);
+    }
+  }, [equityAllocation, form]);
+
   return (
     <Card className={canSubmitInvoices ? "" : "opacity-50"}>
       <CardContent className="p-8">
@@ -651,7 +657,7 @@ const QuickInvoicesSection = () => {
                           min={0}
                           max={MAX_EQUITY_PERCENTAGE}
                           unit="%"
-                          disabled={!canSubmitInvoices}
+                          disabled={!canSubmitInvoices || !!equityAllocation?.locked}
                           ariaLabel="Cash vs equity split"
                         />
                       </FormControl>


### PR DESCRIPTION
Bug fix for when the worker has already selected an equity split that's locked and approved for the invoice year.

### Before
<img width="1628" alt="image" src="https://github.com/user-attachments/assets/d05c8aa9-5a22-4207-b6df-53de07d0f9a1" />

### After
<img width="1634" alt="image" src="https://github.com/user-attachments/assets/61ede9be-3c9d-46d7-ae52-8a60c5794d54" />
