### PR TITLE
Replace `formatDate` with `formatServerDate` for dates in BuybackView

### DIFF
--- a/apps/next/app/equity/tender_offers/[id]/page.tsx
+++ b/apps/next/app/equity/tender_offers/[id]/page.tsx
@@ -22,7 +22,7 @@ import { useCurrentCompany, useCurrentUser } from "@/global";
 import type { RouterOutput } from "@/trpc";
 import { trpc } from "@/trpc/client";
 import { formatMoney, formatMoneyFromCents } from "@/utils/formatMoney";
-import { formatDate } from "@/utils/time";
+import { formatServerDate } from "@/utils/time";
 import { VESTED_SHARES_CLASS } from "../";
 import LetterOfTransmissal from "./LetterOfTransmissal";
 
@@ -152,11 +152,11 @@ export default function BuybackView() {
         <CardContent className="grid grid-cols-2 gap-4">
           <div>
             <Label>Start date</Label>
-            <p>{formatDate(data.startsAt)}</p>
+            <p>{formatServerDate(data.startsAt)}</p>
           </div>
           <div>
             <Label>End date</Label>
-            <p>{formatDate(data.endsAt)}</p>
+            <p>{formatServerDate(data.endsAt)}</p>
           </div>
           <div>
             <Label>Starting valuation</Label>


### PR DESCRIPTION
Fix showing incorrect dates for buy backs where timezone pushes the timestamp back in time.

### Before
<img width="1358" alt="image" src="https://github.com/user-attachments/assets/d4eb58c1-3949-4727-adfb-0755b5f610a3" />

### After
<img width="1371" alt="image" src="https://github.com/user-attachments/assets/150d971d-8422-4bc0-b836-336e1cbf33d9" />
