### PR TITLE
Fix processing scheduled vesting events only for accepted equity grants job

### DIFF
--- a/apps/rails/app/sidekiq/process_scheduled_vesting_for_equity_grants_job.rb
+++ b/apps/rails/app/sidekiq/process_scheduled_vesting_for_equity_grants_job.rb
@@ -7,6 +7,7 @@ class ProcessScheduledVestingForEquityGrantsJob
     EquityGrant
       .vesting_trigger_scheduled
       .period_not_ended
+      .accepted
       .find_each do
       ProcessEquityGrantScheduledVestingJob.perform_async(_1.id)
     end

--- a/apps/rails/spec/sidekiq/process_scheduled_vesting_for_equity_grants_job_spec.rb
+++ b/apps/rails/spec/sidekiq/process_scheduled_vesting_for_equity_grants_job_spec.rb
@@ -7,6 +7,7 @@ RSpec.describe ProcessScheduledVestingForEquityGrantsJob do
     let!(:equity_grant_vests_as_per_schedule2) { create(:equity_grant, :vests_as_per_schedule, vesting_schedule:, period_ended_at: 1.day.ago) }
     let!(:equity_grant_vests_as_per_schedule3) { create(:equity_grant, :vests_as_per_schedule, vesting_schedule:, period_ended_at: 5.hours.from_now) }
     let!(:equity_grant_vests_as_per_schedule4) { create(:equity_grant, :vests_as_per_schedule, vesting_schedule:, period_ended_at: 1.day.from_now) }
+    let!(:equity_grant_vests_as_per_schedule5) { create(:equity_grant, :vests_as_per_schedule, vesting_schedule:, period_ended_at: 1.month.from_now, accepted_at: nil) }
     let!(:equity_grant_vests_on_invoice_payment) { create(:equity_grant, :vests_on_invoice_payment) }
 
     it "enqueues ProcessEquityGrantScheduledVestingJob for scheduled equity grants that have not ended" do
@@ -16,6 +17,7 @@ RSpec.describe ProcessScheduledVestingForEquityGrantsJob do
       expect(ProcessEquityGrantScheduledVestingJob).to have_enqueued_sidekiq_job(equity_grant_vests_as_per_schedule4.id)
       expect(ProcessEquityGrantScheduledVestingJob).not_to have_enqueued_sidekiq_job(equity_grant_vests_as_per_schedule2.id)
       expect(ProcessEquityGrantScheduledVestingJob).not_to have_enqueued_sidekiq_job(equity_grant_vests_on_invoice_payment.id)
+      expect(ProcessEquityGrantScheduledVestingJob).not_to have_enqueued_sidekiq_job(equity_grant_vests_as_per_schedule5.id)
     end
   end
 end


### PR DESCRIPTION
### What

- [x] only process `accepted` equity grants with vesting trigger scheduled in `ProcessScheduledVestingForEquityGrantsJob`

### Why
Fixes a bug where equity grants with a vesting schedule were being processed by `ProcessScheduledVestingForEquityGrantsJob` even though the board consent wasn't approved and the equity grant marked as accepted.