### PR TITLE
Enable DocuSeal rememberSignature option

### DIFF
--- a/apps/next/app/documents/DocusealForm.tsx
+++ b/apps/next/app/documents/DocusealForm.tsx
@@ -111,6 +111,7 @@ export default function Form(props: Omit<React.ComponentProps<typeof DocusealFor
       sendCopyEmail={false}
       withTitle={false}
       withSendCopyButton={false}
+      rememberSignature
       {...props}
     />
   );


### PR DESCRIPTION
Makes it so people don't have to type their signature into the DocuSeal signing form every time.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for remembering user signatures in the form.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->