### PR TITLE
Don't generate S3 download URLs ahead of time

### DIFF
--- a/apps/next/app/administrator/settings/billing/page.tsx
+++ b/apps/next/app/administrator/settings/billing/page.tsx
@@ -11,6 +11,7 @@ import type { RouterOutput } from "@/trpc";
 import { trpc } from "@/trpc/client";
 import { formatMoneyFromCents } from "@/utils/formatMoney";
 import { formatDate } from "@/utils/time";
+import Link from "next/link";
 
 const columnHelper = createColumnHelper<RouterOutput["consolidatedInvoices"]["list"][number]>();
 const columns = [
@@ -43,16 +44,16 @@ const columns = [
         );
     }
   }),
-  columnHelper.accessor("receiptUrl", {
+  columnHelper.accessor("attachment", {
     id: "actions",
     header: "",
     cell: (info) => {
-      const receiptUrl = info.getValue();
-      return receiptUrl ? (
+      const attachment = info.getValue();
+      return attachment ? (
         <Button asChild variant="outline" size="small">
-          <a href={receiptUrl} download>
+          <Link href={`/download/${attachment.key}/${attachment.filename}`} download>
             <ArrowDownTrayIcon className="size-4" /> Download
-          </a>
+          </Link>
         </Button>
       ) : null;
     },

--- a/apps/next/app/cap_table_uploads/page.tsx
+++ b/apps/next/app/cap_table_uploads/page.tsx
@@ -5,6 +5,7 @@ import DataTable, { createColumnHelper, useTable } from "@/components/DataTable"
 import MainLayout from "@/components/layouts/Main";
 import { trpc } from "@/trpc/client";
 import { formatDate } from "@/utils/time";
+import Link from "next/link";
 
 export default function CapTableUploadsPage() {
   const [data] = trpc.capTableUploads.list.useSuspenseQuery();
@@ -40,15 +41,15 @@ export default function CapTableUploadsPage() {
       cell: (info) => (
         <div className="flex flex-col gap-2">
           {info.getValue().map((attachment) => (
-            <a
-              key={attachment.url}
-              href={attachment.url}
+            <Link
+              key={attachment.key}
+              href={`/download/${attachment.key}/${attachment.filename}`}
               download={attachment.filename}
               className="inline-flex items-center gap-1 text-blue-600 hover:text-blue-800"
             >
               <ArrowDownTrayIcon className="h-4 w-4" />
               {attachment.filename}
-            </a>
+            </Link>
           ))}
         </div>
       ),

--- a/apps/next/app/documents/page.tsx
+++ b/apps/next/app/documents/page.tsx
@@ -318,10 +318,10 @@ export default function DocumentsPage() {
                 ) : null}
                 {document.attachment ? (
                   <Button variant="outline" size="small" asChild>
-                    <a href={document.attachment} download>
+                    <Link href={`/download/${document.attachment.key}/${document.attachment.filename}`} download>
                       <ArrowDownTrayIcon className="size-4" />
                       Download
-                    </a>
+                    </Link>
                   </Button>
                 ) : document.docusealSubmissionId && document.signatories.every((signatory) => signatory.signedAt) ? (
                   <Button variant="outline" size="small" onClick={() => setDownloadDocument(document.id)}>

--- a/apps/next/app/download/[key]/[name]/route.ts
+++ b/apps/next/app/download/[key]/[name]/route.ts
@@ -1,0 +1,15 @@
+import stream from "node:stream";
+import { GetObjectCommand } from "@aws-sdk/client-s3";
+import { notFound } from "next/navigation";
+import { s3Client } from "@/trpc";
+import env from "@/env";
+
+export async function GET(_: Request, { params }: { params: Promise<{ key: string; name: string }> }) {
+  const { key, name } = await params;
+  const command = new GetObjectCommand({ Bucket: env.S3_PRIVATE_BUCKET, Key: key });
+  const { Body } = await s3Client.send(command);
+  if (!(Body instanceof stream.Readable)) notFound();
+  return new Response(Body.transformToWebStream(), {
+    headers: { "Content-Disposition": `attachment; filename="${name}"` },
+  });
+}

--- a/apps/next/app/invoices/[id]/page.tsx
+++ b/apps/next/app/invoices/[id]/page.tsx
@@ -295,11 +295,15 @@ export default function InvoicePage() {
                     <Fragment key={i}>
                       <Separator />
                       <div className="flex justify-between gap-2">
-                        <a href={expense.attachment} download className={linkClasses}>
+                        <Link
+                          href={`/download/${expense.attachment?.key}/${expense.attachment?.filename}`}
+                          download
+                          className={linkClasses}
+                        >
                           <PaperClipIcon className="inline size-4" />
                           {expenseCategories.find((category) => category.id === expense.expenseCategoryId)?.name} –{" "}
                           {expense.description}
-                        </a>
+                        </Link>
                         <span>{formatMoneyFromCents(expense.totalAmountInCents)}</span>
                       </div>
                     </Fragment>

--- a/apps/next/app/invoices/page.tsx
+++ b/apps/next/app/invoices/page.tsx
@@ -334,7 +334,11 @@ export default function InvoicesPage() {
               />
             </div>
 
-            <DataTable table={table} onRowClicked={setDetailInvoice} searchColumn="billFrom" />
+            <DataTable
+              table={table}
+              onRowClicked={setDetailInvoice}
+              searchColumn={user.roles.administrator ? "billFrom" : undefined}
+            />
           </>
         ) : (
           <Placeholder icon={CheckCircleIcon}>No invoices to display.</Placeholder>

--- a/apps/next/components/DataTable.tsx
+++ b/apps/next/components/DataTable.tsx
@@ -83,7 +83,7 @@ interface TableProps<T> {
   caption?: string;
   onRowClicked?: ((row: T) => void) | undefined;
   actions?: React.ReactNode;
-  searchColumn?: string;
+  searchColumn?: string | undefined;
 }
 
 export default function DataTable<T extends RowData>({

--- a/apps/next/trpc/index.ts
+++ b/apps/next/trpc/index.ts
@@ -1,6 +1,5 @@
 import "server-only";
-import { GetObjectCommand, S3Client } from "@aws-sdk/client-s3";
-import { getSignedUrl } from "@aws-sdk/s3-request-presigner";
+import { S3Client } from "@aws-sdk/client-s3";
 import { getSchema } from "@tiptap/core";
 import { generateHTML, generateJSON } from "@tiptap/html";
 import { Node } from "@tiptap/pm/model";
@@ -63,15 +62,6 @@ export const s3Client = new S3Client({
   region: env.AWS_REGION,
   credentials: { accessKeyId: env.AWS_ACCESS_KEY_ID, secretAccessKey: env.AWS_SECRET_ACCESS_KEY },
 });
-
-export const getS3Url = (key: string, downloadFilename?: string) => {
-  const command = new GetObjectCommand({
-    Key: key,
-    Bucket: env.S3_PRIVATE_BUCKET,
-    ...(downloadFilename ? { ResponseContentDisposition: `attachment; filename=${downloadFilename}` } : {}),
-  });
-  return getSignedUrl(s3Client, command, { expiresIn: 86400 * 7 });
-};
 
 // TODO switch all stored HTML to use JSON - we should only have to call generateHTML here
 export const renderTiptap = (html: string) => generateHTML(generateJSON(html, richTextExtensions), richTextExtensions);

--- a/apps/next/tsconfig.json
+++ b/apps/next/tsconfig.json
@@ -2,8 +2,8 @@
   "compilerOptions": {
     "noEmit": true,
     "moduleResolution": "bundler",
-    "target": "es2023",
-    "lib": ["dom", "dom.iterable", "es2023"],
+    "target": "es2024",
+    "lib": ["dom", "dom.iterable", "es2024"],
     "module": "esnext",
     "strict": true,
     "allowUnreachableCode": false,


### PR DESCRIPTION
Currently, the `/documents` page is slow in part because we pre-generate S3 download URLs for every single row. This PR removes this generation and instead adds an endpoint to explicitly redirect to the download.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a secure download route for file attachments, allowing users to download files via a new URL format.

- **Improvements**
  - Updated all download links for attachments and documents to use the new secure download route, enhancing consistency and security.
  - Improved the display and conditional rendering of download buttons across billing, cap table uploads, documents, invoices, and tender offers.
  - Adjusted form integration and display logic on the tender offers page for better usability.

- **Bug Fixes**
  - Ensured download links are only shown when attachments exist.

- **Tests**
  - Extended end-to-end tests to verify the presence and correctness of download links for document attachments.

- **Chores**
  - Updated TypeScript configuration to target ECMAScript 2024 for improved language support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->