### PR TITLE
Remove pull_request_target from CI to fix rspec issues

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,15 +1,11 @@
 name: CI
-on:
-  push:
-    branches:
-      - main
-  pull_request_target:
+on: push
 permissions:
   contents: read
 
 concurrency:
-  group: ${{ github.head_ref || github.ref }}-ci
-  cancel-in-progress: ${{ !!github.head_ref }}
+  group: ${{ github.ref }}-rspec
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 env:
   CLERK_SECRET_KEY: ${{ secrets.CLERK_SECRET_KEY }}
@@ -51,16 +47,7 @@ jobs:
         ci_node_index: [0, 1]
 
     steps:
-      - uses: actions-cool/check-user-permission@7b90a27f92f3961b368376107661682c441f6103
-        if: ${{ github.event.pull_request && github.event.pull_request.head.user.login != 'antiwork' }}
-        with:
-          require: write
-          username: ${{ github.triggering_actor }}
-          error-if-missing: true
-
       - uses: actions/checkout@v4
-        with:
-          ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Build setup
         uses: ./.github/common/
@@ -75,8 +62,6 @@ jobs:
           KNAPSACK_PRO_CI_NODE_TOTAL: ${{ matrix.ci_node_total }}
           KNAPSACK_PRO_CI_NODE_INDEX: ${{ matrix.ci_node_index }}
           KNAPSACK_PRO_LOG_LEVEL: info
-          GITHUB_REF: ${{ github.event.pull_request.head.ref }}
-          GITHUB_SHA: ${{ github.event.pull_request.head.sha }}
         run: cd backend && bundle exec rake "knapsack_pro:queue:rspec[--format RSpec::Github::Formatter --tag ~skip --tag ~type:system --format progress]"
         timeout-minutes: 20
 
@@ -85,16 +70,7 @@ jobs:
     runs-on: ubicloud-standard-4
 
     steps:
-      - uses: actions-cool/check-user-permission@7b90a27f92f3961b368376107661682c441f6103
-        if: ${{ github.event.pull_request && github.event.pull_request.head.user.login != 'antiwork' }}
-        with:
-          require: write
-          username: ${{ github.triggering_actor }}
-          error-if-missing: true
-
       - uses: actions/checkout@v4
-        with:
-          ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Build setup
         uses: ./.github/common/


### PR DESCRIPTION
In #87, we changed the CI scripts' trigger from `push` to `pull_request_target` in order to more easily be able to run external contributors' workflows with our secrets. Unfortunately, GitHub does not provide a good solution for this, and the one we ended up using has been causing lots of issues with Rspec (like [this one](https://github.com/antiwork/flexile/actions/runs/15008154337/job/42171663206), where it tries to use the config and list of tests from `main` on the feature branch).

Thus, as a short-term solution, this PR removes the `pull_request_target` trigger. This will mean OSS contributors have to set up the secrets (that they also need locally to run the app) in their forks for CI to be able to run on their PRs. Alternatively, we can test them locally as needed. Either way, once secrets are no longer required to run tests, this will be the best and simplest solution.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated workflow triggers and concurrency settings for continuous integration.
  - Removed user permission checks and pull request-specific handling from test jobs.
  - Streamlined checkout and environment variable usage in test steps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->