### PR TITLE
sidebar-ui

### DIFF
--- a/frontend/components/layouts/Main.tsx
+++ b/frontend/components/layouts/Main.tsx
@@ -229,7 +229,7 @@ const NavLinks = ({ company }: { company: Company }) => {
           filledIcon={Rss}
           active={!!active && pathname.startsWith("/updates")}
         >
-          Newsroom
+          Updates
         </NavLink>
       ) : null}
       {routes.has("Invoices") && (

--- a/frontend/components/layouts/Main.tsx
+++ b/frontend/components/layouts/Main.tsx
@@ -1,29 +1,19 @@
 import { SignOutButton } from "@clerk/nextjs";
 import {
-  ArrowRightStartOnRectangleIcon,
-  BriefcaseIcon,
-  ChartPieIcon,
-  Cog6ToothIcon,
-  CurrencyDollarIcon,
-  DocumentDuplicateIcon,
-  DocumentTextIcon,
-  MegaphoneIcon,
-  UserIcon,
-  UsersIcon,
-} from "@heroicons/react/24/outline";
-import {
-  BriefcaseIcon as SolidBriefcaseIcon,
-  ChartPieIcon as SolidChartPieIcon,
-  Cog6ToothIcon as SolidCog6ToothIcon,
-  CurrencyDollarIcon as SolidCurrencyDollarIcon,
-  DocumentDuplicateIcon as SolidDocumentDuplicateIcon,
-  DocumentTextIcon as SolidDocumentTextIcon,
-  MegaphoneIcon as SolidMegaphoneIcon,
-  UserIcon as SolidUserIcon,
-  UsersIcon as SolidUsersIcon,
-} from "@heroicons/react/24/solid";
+  Rss,
+  ChevronsUpDown,
+  ReceiptIcon,
+  Files,
+  Users,
+  BookUser,
+  Settings,
+  ChartPie,
+  BriefcaseBusiness,
+  CircleUserRound,
+  CircleDollarSign,
+  LogOut,
+} from "lucide-react";
 import { useQueryClient } from "@tanstack/react-query";
-import { ChevronsUpDown } from "lucide-react";
 import Image from "next/image";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
@@ -155,25 +145,19 @@ export default function MainLayout({
                 {!user.companies.length && (
                   <NavLink
                     href="/company_invitations"
-                    icon={BriefcaseIcon}
-                    filledIcon={SolidBriefcaseIcon}
+                    icon={BriefcaseBusiness}
                     active={pathname.startsWith("/company_invitations")}
                   >
                     Invite companies
                   </NavLink>
                 )}
-                <NavLink
-                  href="/settings"
-                  icon={UserIcon}
-                  filledIcon={SolidUserIcon}
-                  active={pathname.startsWith("/settings")}
-                >
+                <NavLink href="/settings" icon={CircleUserRound} active={pathname.startsWith("/settings")}>
                   Account
                 </NavLink>
                 <SidebarMenuItem>
                   <SignOutButton>
                     <SidebarMenuButton className="cursor-pointer">
-                      <ArrowRightStartOnRectangleIcon className="size-6" />
+                      <LogOut className="size-6" />
                       <span>Log out</span>
                     </SidebarMenuButton>
                   </SignOutButton>
@@ -215,11 +199,11 @@ export default function MainLayout({
 
 const CompanyName = ({ company }: { company: Company }) => (
   <>
-    <div className="relative size-8">
-      <Image src={company.logo_url || defaultCompanyLogo} fill className="rounded-xs" alt="" />
+    <div className="relative size-6">
+      <Image src={company.logo_url || defaultCompanyLogo} fill className="rounded-sm" alt="" />
     </div>
     <div>
-      <span className="line-clamp-1 font-bold" title={company.name ?? ""}>
+      <span className="line-clamp-1 text-sm font-bold" title={company.name ?? ""}>
         {company.name}
       </span>
     </div>
@@ -241,11 +225,11 @@ const NavLinks = ({ company }: { company: Company }) => {
       {updatesPath ? (
         <NavLink
           href="/updates/company"
-          icon={MegaphoneIcon}
-          filledIcon={SolidMegaphoneIcon}
+          icon={Rss}
+          filledIcon={Rss}
           active={!!active && pathname.startsWith("/updates")}
         >
-          Updates
+          Newsroom
         </NavLink>
       ) : null}
       {routes.has("Invoices") && (
@@ -254,8 +238,7 @@ const NavLinks = ({ company }: { company: Company }) => {
       {routes.has("Expenses") && (
         <NavLink
           href={`/companies/${company.id}/expenses`}
-          icon={CurrencyDollarIcon}
-          filledIcon={SolidCurrencyDollarIcon}
+          icon={CircleDollarSign}
           active={!!active && pathname.startsWith(`/companies/${company.id}/expenses`)}
         >
           Expenses
@@ -264,8 +247,7 @@ const NavLinks = ({ company }: { company: Company }) => {
       {routes.has("Documents") && (
         <NavLink
           href="/documents"
-          icon={DocumentDuplicateIcon}
-          filledIcon={SolidDocumentDuplicateIcon}
+          icon={Files}
           active={!!active && (pathname.startsWith("/documents") || pathname.startsWith("/document_templates"))}
         >
           Documents
@@ -274,28 +256,21 @@ const NavLinks = ({ company }: { company: Company }) => {
       {routes.has("People") && (
         <NavLink
           href="/people"
-          icon={UsersIcon}
-          filledIcon={SolidUsersIcon}
+          icon={Users}
           active={!!active && (pathname.startsWith("/people") || pathname.includes("/investor_entities/"))}
         >
           People
         </NavLink>
       )}
       {routes.has("Roles") && (
-        <NavLink
-          href="/roles"
-          icon={BriefcaseIcon}
-          filledIcon={SolidBriefcaseIcon}
-          active={!!active && pathname.startsWith("/roles")}
-        >
+        <NavLink href="/roles" icon={BookUser} active={!!active && pathname.startsWith("/roles")}>
           Roles
         </NavLink>
       )}
       {routes.has("Equity") && equityNavLink ? (
         <NavLink
           href={equityNavLink.route}
-          icon={ChartPieIcon}
-          filledIcon={SolidChartPieIcon}
+          icon={ChartPie}
           active={!!active && (pathname.startsWith("/equity") || pathname.includes("/equity_grants"))}
         >
           Equity
@@ -305,8 +280,7 @@ const NavLinks = ({ company }: { company: Company }) => {
         <NavLink
           href={user.roles.administrator ? `/administrator/settings` : `/settings`}
           active={!!active && (pathname.startsWith("/administrator/settings") || pathname.startsWith("/settings"))}
-          icon={Cog6ToothIcon}
-          filledIcon={SolidCog6ToothIcon}
+          icon={Settings}
         >
           Settings
         </NavLink>
@@ -361,13 +335,7 @@ function InvoicesNavLink({ companyId, active }: { companyId: string; active: boo
   );
 
   return (
-    <NavLink
-      href="/invoices"
-      icon={DocumentTextIcon}
-      filledIcon={SolidDocumentTextIcon}
-      active={active}
-      badge={data?.length}
-    >
+    <NavLink href="/invoices" icon={ReceiptIcon} active={active} badge={data?.length}>
       Invoices
     </NavLink>
   );

--- a/frontend/components/ui/sidebar.tsx
+++ b/frontend/components/ui/sidebar.tsx
@@ -223,7 +223,7 @@ function Sidebar({
         <div
           data-sidebar="sidebar"
           data-slot="sidebar-inner"
-          className="group-data-[variant=floating]:border-sidebar-border flex h-full w-full flex-col bg-gray-50 group-data-[variant=floating]:rounded-lg group-data-[variant=floating]:border group-data-[variant=floating]:shadow-sm"
+          className="group-data-[variant=floating]:border-sidebar-border flex h-full w-full flex-col bg-gray-50/50 group-data-[variant=floating]:rounded-lg group-data-[variant=floating]:border group-data-[variant=floating]:shadow-sm"
         >
           {children}
         </div>
@@ -355,7 +355,7 @@ function SidebarGroup({ className, ...props }: React.ComponentProps<"div">) {
     <div
       data-slot="sidebar-group"
       data-sidebar="group"
-      className={cn("relative flex w-full min-w-0 flex-col p-2", className)}
+      className={cn("relative flex w-full min-w-0 flex-col px-3 py-2", className)}
       {...props}
     />
   );
@@ -439,11 +439,11 @@ function SidebarMenuItem({ className, ...props }: React.ComponentProps<"li">) {
 }
 
 const sidebarMenuButtonVariants = cva(
-  "peer/menu-button flex w-full items-center gap-2 overflow-hidden rounded-md p-2 text-left text-sm outline-hidden ring-sidebar-ring transition-[width,height,padding] hover:text-accent-foreground focus-visible:ring-2 active:text-accent-foreground disabled:pointer-events-none disabled:opacity-50 group-has-data-[sidebar=menu-action]/menu-item:pr-8 aria-disabled:pointer-events-none aria-disabled:opacity-50 data-[active=true]:font-medium data-[active=true]:text-accent-foreground cursor-pointer data-[state=open]:hover:text-accent-foreground hover:bg-gray-100 active:bg-gray-100 data-[active=true]:bg-gray-100 data-[state=open]:hover:bg-gray-100 group-data-[collapsible=icon]:size-8! group-data-[collapsible=icon]:p-2! [&>span:last-child]:truncate [&>svg]:size-4 [&>svg]:shrink-0",
+  "peer/menu-button flex w-full items-center gap-3 overflow-hidden rounded-sm p-2 text-left text-sm outline-hidden ring-sidebar-ring transition-[width,height,padding] hover:text-accent-foreground focus-visible:ring-2 active:text-accent-foreground disabled:pointer-events-none disabled:opacity-50 group-has-data-[sidebar=menu-action]/menu-item:pr-8 aria-disabled:pointer-events-none aria-disabled:opacity-50 data-[active=true]:font-medium data-[active=true]:text-accent-foreground cursor-pointer data-[state=open]:hover:text-accent-foreground hover:bg-gray-100 active:bg-gray-100/50 data-[active=true]:bg-gray-100/30 data-[state=open]:hover:bg-gray-100 group-data-[collapsible=icon]:size-8! group-data-[collapsible=icon]:p-2! [&>span:last-child]:truncate [&>svg]:size-4 [&>svg]:shrink-0",
   {
     variants: {
       variant: {
-        default: "hover:text-accent-foreground hover:bg-gray-100",
+        default: "hover:text-accent-foreground hover:bg-gray-100/30",
         outline:
           "bg-background shadow-[0_0_0_1px_hsl(var(--sidebar-border))] hover:text-accent-foreground hover:shadow-[0_0_0_1px_hsl(var(--sidebar-accent))] hover:bg-gray-100",
       },
@@ -611,7 +611,7 @@ function SidebarMenuSubButton({
       data-size={size}
       data-active={isActive}
       className={cn(
-        "text-foreground ring-sidebar-ring hover:text-accent-foreground active:text-accent-foreground [&>svg]:text-accent-foreground flex h-7 min-w-0 -translate-x-px items-center gap-2 overflow-hidden rounded-md px-2 outline-hidden hover:bg-gray-100 focus-visible:ring-2 active:bg-gray-100 disabled:pointer-events-none disabled:opacity-50 aria-disabled:pointer-events-none aria-disabled:opacity-50 [&>span:last-child]:truncate [&>svg]:size-4 [&>svg]:shrink-0",
+        "text-foreground ring-sidebar-ring hover:text-accent-foreground active:text-accent-foreground [&>svg]:text-accent-foreground flex h-7 min-w-0 -translate-x-px items-center gap-2 overflow-hidden rounded-md px-2 outline-hidden hover:bg-gray-100 focus-visible:ring-2 active:bg-gray-100/50 disabled:pointer-events-none disabled:opacity-50 aria-disabled:pointer-events-none aria-disabled:opacity-50 [&>span:last-child]:truncate [&>svg]:size-4 [&>svg]:shrink-0",
         "data-[active=true]:text-accent-foreground data-[active=true]:bg-gray-100",
         size === "sm" && "text-xs",
         size === "md" && "text-sm",


### PR DESCRIPTION
Before|After
-|-
<img width="1257" alt="Screenshot 2025-05-15 at 14 37 58" src="https://github.com/user-attachments/assets/1cff17e0-ba96-4cdb-bb63-650681b06415" />|<img width="1255" alt="Screenshot 2025-05-15 at 14 36 23" src="https://github.com/user-attachments/assets/7c912bbf-728c-4dc6-ac28-bf352146f441" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **Style**
  - Updated all sidebar and navigation icons to use Lucide icons for a refreshed appearance.
  - Adjusted sidebar and navigation styles, including background transparency, padding, spacing, and border radius, for a lighter and more modern look.
  - Reduced the company logo size and slightly changed its border styling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->