### PR TITLE
Fix freelancer onboarding redirecting to the wrong URL

### DIFF
--- a/frontend/app/companies/[companyId]/investor/onboarding/page.tsx
+++ b/frontend/app/companies/[companyId]/investor/onboarding/page.tsx
@@ -10,7 +10,7 @@ export default function Page() {
       title="Let's get to know you"
       subtitle="We're eager to learn more about you, starting with your legal name and the place where you reside."
     >
-      <PersonalDetails nextLinkTo="/dashboard" />
+      <PersonalDetails />
     </OnboardingLayout>
   );
 }

--- a/frontend/app/companies/[companyId]/worker/onboarding/page.tsx
+++ b/frontend/app/companies/[companyId]/worker/onboarding/page.tsx
@@ -10,7 +10,7 @@ export default function Page() {
       title="Let's get to know you"
       subtitle="We're eager to learn more about you, starting with your legal name and the place where you reside."
     >
-      <PersonalDetails nextLinkTo="/dashboard" />
+      <PersonalDetails />
     </OnboardingLayout>
   );
 }

--- a/frontend/app/onboarding/PersonalDetails.tsx
+++ b/frontend/app/onboarding/PersonalDetails.tsx
@@ -1,7 +1,6 @@
 "use client";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useMutation, useSuspenseQuery } from "@tanstack/react-query";
-import type { Route } from "next";
 import { useRouter } from "next/navigation";
 import { useState } from "react";
 import { useForm } from "react-hook-form";
@@ -24,7 +23,7 @@ const formSchema = z.object({
   citizenship_country_code: z.string().min(1, "This field is required"),
 });
 
-const PersonalDetails = <T extends string>({ nextLinkTo }: { nextLinkTo: Route<T> }) => {
+const PersonalDetails = () => {
   const user = useCurrentUser();
   const router = useRouter();
   const { data } = useSuspenseQuery({
@@ -64,7 +63,7 @@ const PersonalDetails = <T extends string>({ nextLinkTo }: { nextLinkTo: Route<T
         jsonData: { user: form.getValues() },
         assertOk: true,
       });
-      router.push(nextLinkTo);
+      router.push("/dashboard");
     },
   });
 

--- a/frontend/app/onboarding/page.tsx
+++ b/frontend/app/onboarding/page.tsx
@@ -10,7 +10,7 @@ export default function OnboardingPage() {
       title="Let's get to know you"
       subtitle="We're eager to learn more about you, starting with your legal name and the place where you reside."
     >
-      <PersonalDetails nextLinkTo="/dashboard" />
+      <PersonalDetails />
     </OnboardingLayout>
   );
 }

--- a/frontend/app/onboarding/type/page.tsx
+++ b/frontend/app/onboarding/type/page.tsx
@@ -29,13 +29,7 @@ export default function SignUp() {
           ]}
         />
       </div>
-      <Suspense>
-        {accessRole === "administrator" ? (
-          <CompanyDetails />
-        ) : (
-          <PersonalDetails nextLinkTo="/onboarding/bank_account" />
-        )}
-      </Suspense>
+      <Suspense>{accessRole === "administrator" ? <CompanyDetails /> : <PersonalDetails />}</Suspense>
     </OnboardingLayout>
   );
 }


### PR DESCRIPTION
Fixes the issue reported by a user trying to sign up as a freelancer who got redirected to a no-longer-existent page.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Simplified the onboarding process by removing the need to specify a destination route after submitting personal details; users are now always redirected to the dashboard.
  - Streamlined the PersonalDetails form and its usage across onboarding pages for a more consistent experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->