### PR TITLE
Fix board consents being incorrectly signable by any company admin

### DIFF
--- a/frontend/app/documents/page.tsx
+++ b/frontend/app/documents/page.tsx
@@ -259,9 +259,7 @@ export default function DocumentsPage() {
       document.signatories.some(
         (signatory) =>
           !signatory.signedAt &&
-          (signatory.id === user.id ||
-            ((signatory.title === "Company Representative" || signatory.title === "Board member") &&
-              isCompanyRepresentative)),
+          (signatory.id === user.id || (signatory.title === "Company Representative" && isCompanyRepresentative)),
       )
     );
   };
@@ -523,21 +521,11 @@ const SignDocumentModal = ({ document, onClose }: { document: SignableDocument; 
           preview={document.type === DocumentType.BoardConsent && !document.lawyerApproved}
           customCss={customCss}
           onComplete={() => {
-            const userIsSigner = document.signatories.some(
-              (signatory) => signatory.id === user.id && signatory.title === "Signer",
-            );
-            const role = userIsSigner
-              ? "Signer"
-              : document.type === DocumentType.BoardConsent
-                ? assertDefined(
-                    document.signatories.find((signatory) => signatory.id === user.id)?.title,
-                    "User is not a board member",
-                  )
-                : "Company Representative";
             signDocument.mutate({
               companyId: company.id,
               id: document.id,
-              role,
+              role:
+                document.signatories.find((signatory) => signatory.id === user.id)?.title ?? "Company Representative",
             });
           }}
         />

--- a/frontend/trpc/routes/documents/index.ts
+++ b/frontend/trpc/routes/documents/index.ts
@@ -101,11 +101,7 @@ export const documentsRouter = createRouter({
   }),
   // TODO set up a DocuSeal webhook instead
   sign: companyProcedure.input(z.object({ id: z.bigint(), role: z.string() })).mutation(async ({ ctx, input }) => {
-    if (
-      (input.role === "Company Representative" || input.role === "Board member") &&
-      !ctx.companyAdministrator &&
-      !ctx.companyLawyer
-    )
+    if (input.role === "Company Representative" && !ctx.companyAdministrator && !ctx.companyLawyer)
       throw new TRPCError({ code: "FORBIDDEN" });
     const [document] = await db
       .select()
@@ -114,10 +110,7 @@ export const documentsRouter = createRouter({
       .where(
         and(
           eq(documents.id, input.id),
-          visibleDocuments(
-            ctx.company.id,
-            input.role === "Company Representative" || input.role === "Board member" ? undefined : ctx.user.id,
-          ),
+          visibleDocuments(ctx.company.id, input.role === "Company Representative" ? undefined : ctx.user.id),
           eq(documentSignatures.title, input.role),
           isNull(documentSignatures.signedAt),
         ),


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Simplified logic for determining signable documents and user roles, focusing only on "Company Representative" and excluding "Board member" from related conditions.
	- Adjusted access control and document visibility rules to apply specifically to "Company Representative" roles, providing more precise role-based restrictions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->