### PR TITLE
Fix business type validation for foreign businesses

### DIFF
--- a/e2e/settings/tax.spec.ts
+++ b/e2e/settings/tax.spec.ts
@@ -417,7 +417,7 @@ test.describe("Tax settings", () => {
       await expect(page.getByLabel("Tax ID (SSN or ITIN)")).toHaveValue("123-45-6789");
     });
 
-    test("allows legal names with two spaces", async ({ page }) => {
+    test("allows legal names with two spaces", async ({ page, sentEmails: _ }) => {
       await page.goto("/settings/tax");
 
       await page.getByLabel("Full legal name (must match your ID)").fill("John Middle Doe");

--- a/e2e/settings/tax.spec.ts
+++ b/e2e/settings/tax.spec.ts
@@ -421,17 +421,14 @@ test.describe("Tax settings", () => {
       await page.goto("/settings/tax");
 
       await page.getByLabel("Full legal name (must match your ID)").fill("John Middle Doe");
-
       await page.getByLabel("Tax ID (SSN or ITIN)").fill("123456789");
-      await page.getByLabel("Residential address (street name, number, apartment)").fill("123 Main St");
-      await page.getByLabel("City").fill("Anytown");
-      await page.getByLabel("ZIP code").fill("12345");
 
       await page.getByRole("button", { name: "Save changes" }).click();
+      await page.getByRole("button", { name: "Save", exact: true }).click();
+      await expect(page.getByRole("dialog")).not.toBeVisible();
 
-      await expect(page.getByText("This doesn't look like a complete full name.")).not.toBeVisible();
-
-      await expect(page.getByText("W-9 Certification and Tax Forms Delivery")).toBeVisible();
+      const updatedUser = await db.query.users.findFirst({ where: eq(users.id, user.id) }).then(takeOrThrow);
+      expect(updatedUser.legalName).toBe("John Middle Doe");
     });
   });
 

--- a/e2e/settings/tax.spec.ts
+++ b/e2e/settings/tax.spec.ts
@@ -230,6 +230,34 @@ test.describe("Tax settings", () => {
         await expect(page.getByText("Review your tax information")).not.toBeVisible();
       });
 
+      test("only requires setting a business type for US citizens", async ({ page, sentEmails: _ }) => {
+        await db.update(users).set({ countryCode: "GB", citizenshipCountryCode: "GB" }).where(eq(users.id, user.id));
+
+        await page.goto("/settings/tax");
+
+        await page.locator("label").filter({ hasText: "Business" }).click();
+        await page.getByLabel("Business legal name").fill("Test Business LLC");
+        await page.getByLabel("Foreign tax ID").fill("123456789");
+        await page.getByLabel("Full legal name (must match your ID)").fill("John Smith");
+        await expect(page.getByLabel("Type")).not.toBeVisible();
+        await page.getByRole("button", { name: "Save changes" }).click();
+        await expect(page.getByText("W-8BEN-E Certification and Tax Forms Delivery")).toBeVisible();
+        await page.getByRole("button", { name: "Save", exact: true }).click();
+        await expect(page.getByRole("dialog")).not.toBeVisible();
+        await page.goto("/settings/tax", { waitUntil: "load" });
+
+        await selectComboboxOption(page, "Country of citizenship", "United States");
+        await selectComboboxOption(page, "Country of incorporation", "United States");
+
+        await selectComboboxOption(page, "Type", "LLC");
+        await selectComboboxOption(page, "Tax classification", "Partnership");
+        await page.getByRole("button", { name: "Save changes" }).click();
+
+        await page.getByLabel("Full legal name (must match your ID)").fill("John Smith");
+        await expect(page.getByText("W-9 Certification and Tax Forms Delivery")).toBeVisible();
+        await page.getByRole("button", { name: "Save", exact: true }).click();
+      });
+
       test("allows US citizen in Australia to set a 4-digit postal code", async ({ page, sentEmails }) => {
         await db.update(users).set({ countryCode: "AU", citizenshipCountryCode: "US" }).where(eq(users.id, user.id));
 


### PR DESCRIPTION
Fixes a bug where non-US-based businesses would not be able to submit the legal details form as the business type field is not shown for them but the validation incorrectly required it to be set. Also adds a test for it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved tax form validation to better support users with non-US citizenship, allowing business type to be optional for foreign users.
  - Enhanced user experience by displaying the appropriate tax certification dialog (W-8BEN-E or W-9) based on citizenship and business type selections.

- **Bug Fixes**
  - Adjusted modal behavior so that the certification dialog only closes immediately if no document ID is returned, ensuring smoother workflow after saving tax settings.

- **Tests**
  - Added end-to-end tests verifying tax form behavior and certification dialog display for US and non-US users.
  - Updated tests to confirm legal name updates and dialog closure after saving.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->