### PR TITLE
Fix invoice badge showing invoices not actionable by the current user

### DIFF
--- a/e2e/tests/company/invoices/list.spec.ts
+++ b/e2e/tests/company/invoices/list.spec.ts
@@ -205,6 +205,7 @@ test.describe("Invoices admin flow", () => {
           await targetInvoiceRow.getByRole("button", { name: "Approve" }).click();
           await expect(targetInvoiceRow.getByText("Approved!")).toBeVisible();
           const approvalButton = targetInvoiceRow.getByText("Awaiting approval (1/2)");
+          await expect(page.getByRole("link", { name: "Invoices" }).getByRole("status")).toContainText("1");
 
           const updatedTargetInvoice = await db.query.invoices.findFirst({
             where: eq(invoices.id, targetInvoice.id),

--- a/frontend/components/layouts/Main.tsx
+++ b/frontend/components/layouts/Main.tsx
@@ -47,6 +47,7 @@ import { trpc } from "@/trpc/client";
 import { request } from "@/utils/request";
 import { company_switch_path } from "@/utils/routes";
 import type { Route } from "next";
+import { useIsActionable } from "@/app/invoices";
 
 export default function MainLayout({
   children,
@@ -329,9 +330,10 @@ function InvoicesNavLink({ companyId, active }: { companyId: string; active: boo
     { companyId, status: ["received", "approved", "failed"] },
     { refetchInterval: 30_000, enabled: !!user.roles.administrator },
   );
+  const isActionable = useIsActionable();
 
   return (
-    <NavLink href="/invoices" icon={ReceiptIcon} active={active} badge={data?.length}>
+    <NavLink href="/invoices" icon={ReceiptIcon} active={active} badge={data?.filter(isActionable).length}>
       Invoices
     </NavLink>
   );


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - The "Invoices" navigation link now displays a badge count reflecting only actionable invoices instead of all invoices.

- **Tests**
  - Added a test assertion to verify that the "Invoices" link badge updates correctly after approving an invoice.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->