### PR TITLE
Fix dividend email ROI and add a test for it

### DIFF
--- a/backend/app/mailers/company_investor_mailer.rb
+++ b/backend/app/mailers/company_investor_mailer.rb
@@ -12,10 +12,10 @@ class CompanyInvestorMailer < ApplicationMailer
     @user = @company_investor.user
     @company = @company_investor.company
     @gross_amount_in_cents = dividends.sum(:total_amount_in_cents)
-    @roi = @gross_amount_in_cents / @company_investor.investment_amount_in_cents.to_d
+    @roi = @company_investor.dividends.sum(:total_amount_in_cents) / @company_investor.investment_amount_in_cents.to_d
 
     # Calculate ROI note based on dividend years
-    dividend_years = dividends.map { |d| d.created_at.year }.uniq.sort
+    dividend_years = @company_investor.dividends.map { |d| d.created_at.year }.uniq.sort
     @roi_note = dividend_years.size > 1 ? " (#{dividend_years.first} and #{dividend_years.last} Distributions)" : ""
 
     mail(to: @user.email,
@@ -29,10 +29,10 @@ class CompanyInvestorMailer < ApplicationMailer
     @user = @company_investor.user
     @company = @company_investor.company
     @gross_amount_in_cents = dividends.sum(:total_amount_in_cents)
-    @roi = @gross_amount_in_cents / @company_investor.investment_amount_in_cents.to_d
+    @roi = @company_investor.dividends.sum(:total_amount_in_cents) / @company_investor.investment_amount_in_cents.to_d
 
     # Calculate ROI note based on dividend years
-    dividend_years = dividends.map { |d| d.created_at.year }.uniq.sort
+    dividend_years = @company_investor.dividends.map { |d| d.created_at.year }.uniq.sort
     @roi_note = dividend_years.size > 1 ? " (#{dividend_years.first} and #{dividend_years.last} Distributions)" : ""
 
     # If an investor is missing tax information, calculate the tax withholding and net amount

--- a/backend/app/views/company_investor_mailer/return_of_capital_issued.html.erb
+++ b/backend/app/views/company_investor_mailer/return_of_capital_issued.html.erb
@@ -12,7 +12,7 @@
   <dt>Investment amount</dt>
   <dd><%= cents_format(@company_investor.investment_amount_in_cents, no_cents_if_whole: false) %></dd>
 
-  <dt>Cumulative ROI</dt>
+  <dt>Cumulative ROI <%= @roi_note %></dt>
   <dd>
     <%= (@roi * 100.0).round(2) %>%
   </dd>

--- a/backend/spec/mailers/company_investor_mailer_spec.rb
+++ b/backend/spec/mailers/company_investor_mailer_spec.rb
@@ -1,0 +1,69 @@
+# frozen_string_literal: true
+
+RSpec.describe CompanyInvestorMailer do
+  describe "#return_of_capital_issued" do
+    let(:user) { create(:user) }
+    let(:company) { create(:company) }
+    let(:company_investor) { create(:company_investor, user: user, company: company, investment_amount_in_cents: 100_000) }
+    let!(:dividend1) { create(:dividend, company_investor: company_investor, total_amount_in_cents: 5000, net_amount_in_cents: 4000, withheld_tax_cents: 1000, created_at: 1.year.ago) }
+    let!(:dividend2) { create(:dividend, company_investor: company_investor, total_amount_in_cents: 5000, net_amount_in_cents: 4000, withheld_tax_cents: 1000, created_at: Time.current) }
+    let!(:investor_dividend_round) { create(:investor_dividend_round, company_investor: company_investor, dividend_round: dividend2.dividend_round) }
+
+    it "sends return of capital email with correct attributes" do
+      mail = described_class.return_of_capital_issued(investor_dividend_round_id: investor_dividend_round.id)
+      plaintext = ActionView::Base.full_sanitizer.sanitize(mail.body.encoded).gsub("\r\n", " ").gsub(/\s+/, " ").strip
+
+      expect(mail.to).to eq([user.email])
+      expect(mail.subject).to eq("Upcoming distribution from #{company.name}")
+      expect(plaintext).to include(company.name)
+      expect(plaintext).to include("you've been issued a return of capital amounting to $50.00. Investment amount $1,000.00 Cumulative ROI (2024 and 2025 Distributions) 10.0% Distribution amount $50.00 Taxes withheld $0.00 (Return of capital - no tax withholding applies) Total to be paid $50.00")
+    end
+  end
+
+  describe "#dividend_issued" do
+    let(:user) { create(:user) }
+    let(:company) { create(:company) }
+    let(:company_investor) { create(:company_investor, user: user, company: company, investment_amount_in_cents: 100_000) }
+    let!(:dividend1) { create(:dividend, company_investor: company_investor, total_amount_in_cents: 5000, net_amount_in_cents: 4000, withheld_tax_cents: 1000, created_at: 1.year.ago) }
+    let!(:dividend2) { create(:dividend, company_investor: company_investor, total_amount_in_cents: 5000, net_amount_in_cents: 4000, withheld_tax_cents: 1000, created_at: Time.current) }
+    let!(:investor_dividend_round) { create(:investor_dividend_round, company_investor: company_investor, dividend_round: dividend2.dividend_round) }
+
+    it "sends dividend email with correct attributes" do
+      mail = described_class.dividend_issued(investor_dividend_round_id: investor_dividend_round.id)
+      plaintext = ActionView::Base.full_sanitizer.sanitize(mail.body.encoded).gsub("\r\n", " ").gsub(/\s+/, " ").strip
+
+      expect(mail.to).to eq([user.email])
+      expect(mail.subject).to eq("Upcoming distribution from #{company.name}")
+      expect(plaintext).to include(company.name)
+      expect(plaintext).to include("Based on your investment of $1,000.00, you've received a distribution of $50.00. Investment amount $1,000.00 Cumulative ROI (2024 and 2025 Distributions) 10.0% Distribution amount $50.00 Taxes withheld $10.00 Total to be paid $40.00")
+    end
+
+    context "when there is only one dividend" do
+      it "does not include the years in the ROI" do
+        dividend1.destroy!
+        mail = described_class.dividend_issued(investor_dividend_round_id: investor_dividend_round.id)
+        plaintext = ActionView::Base.full_sanitizer.sanitize(mail.body.encoded).gsub("\r\n", " ").gsub(/\s+/, " ").strip
+
+        expect(mail.to).to eq([user.email])
+        expect(mail.subject).to eq("Upcoming distribution from #{company.name}")
+        expect(plaintext).to include("Cumulative ROI 5.0%")
+      end
+    end
+
+    context "when tax information is missing" do
+      let!(:dividend1) { create(:dividend, company_investor: company_investor, total_amount_in_cents: 5000, created_at: 1.year.ago, withheld_tax_cents: nil, net_amount_in_cents: nil) }
+      let!(:dividend2) { create(:dividend, company_investor: company_investor, total_amount_in_cents: 5000, created_at: Time.current, withheld_tax_cents: nil, net_amount_in_cents: nil) }
+      let!(:investor_dividend_round) { create(:investor_dividend_round, company_investor: company_investor, dividend_round: dividend2.dividend_round) }
+
+      it "calculates tax withholding and net amount" do
+        allow_any_instance_of(DividendTaxWithholdingCalculator).to receive(:net_cents).and_return(4000)
+        allow_any_instance_of(DividendTaxWithholdingCalculator).to receive(:cents_to_withhold).and_return(1000)
+
+        mail = described_class.dividend_issued(investor_dividend_round_id: investor_dividend_round.id)
+        plaintext = ActionView::Base.full_sanitizer.sanitize(mail.body.encoded).gsub("\r\n", " ").gsub(/\s+/, " ").strip
+
+        expect(plaintext).to include("Distribution amount $50.00 Taxes withheld $10.00 Total to be paid $40.00")
+      end
+    end
+  end
+end

--- a/backend/spec/spec_helper.rb
+++ b/backend/spec/spec_helper.rb
@@ -136,13 +136,6 @@ RSpec.configure do |config|
     allow_any_instance_of(CreatePdf).to receive(:perform).and_return("pdf")
   end
 
-  config.after(:each, type: :mailer) do |example|
-    raise "No mail subject found. Did you forget to add `subject(:mail) { ... }`?" unless defined?(mail)
-
-    mailer_delivery_count = example.metadata[:does_not_send_email] ? 0 : 1
-    expect { mail.deliver_now rescue nil }.to change { ActionMailer::Base.deliveries.size }.by(mailer_delivery_count)
-  end
-
   config.before(:each, type: :system) do
     if page.driver.browser.respond_to?(:execute_cdp)
       page.driver.browser.execute_cdp("Emulation.setTimezoneOverride", timezoneId: "GMT")


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved the calculation of cumulative ROI and dividend years in investor email notifications, ensuring all relevant dividends are included.
	- Updated the "Cumulative ROI" label in investor emails to display additional context.

- **Tests**
	- Added comprehensive tests for investor email notifications, verifying correct content and handling of various scenarios.

- **Chores**
	- Removed automatic checks for mail delivery and subject presence in mailer tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->