### PR TITLE
Filter invoices to actionable items by default

### DIFF
--- a/e2e/tests/company/invoices/complete-flow.spec.ts
+++ b/e2e/tests/company/invoices/complete-flow.spec.ts
@@ -113,12 +113,11 @@ test.describe("Invoice submission, approval and rejection", () => {
     await expect(thirdRow).toContainText("Nov 1, 2024");
     await expect(thirdRow).toContainText("$870");
     await expect(thirdRow).toContainText("Awaiting approval");
-    await expect(thirdRow.getByRole("button", { name: "Pay now" })).toBeVisible();
+    await thirdRow.getByRole("button", { name: "Pay now" }).click();
 
     await expect(thirdRow).not.toBeVisible();
     await page.getByRole("button", { name: "Filter" }).click();
     await page.getByRole("menuitem", { name: "Clear all filters" }).click();
-    await thirdRow.getByRole("button", { name: "Pay now" }).click();
     await expect(thirdRow).toContainText("Payment scheduled");
     await expect(openInvoicesBadge).toContainText("2");
 

--- a/e2e/tests/company/invoices/complete-flow.spec.ts
+++ b/e2e/tests/company/invoices/complete-flow.spec.ts
@@ -193,7 +193,7 @@ test.describe("Invoice submission, approval and rejection", () => {
     await login(page, adminUser);
 
     await expect(locateOpenInvoicesBadge(page)).toContainText("1");
-    await expect(page.locator("tbody tr")).toHaveCount(3);
+    await expect(page.locator("tbody tr")).toHaveCount(1);
     const fixedInvoiceRow = page
       .locator("tbody tr")
       .filter({ hasText: workerUserA.legalName ?? "never" })

--- a/e2e/tests/company/invoices/complete-flow.spec.ts
+++ b/e2e/tests/company/invoices/complete-flow.spec.ts
@@ -115,6 +115,9 @@ test.describe("Invoice submission, approval and rejection", () => {
     await expect(thirdRow).toContainText("Awaiting approval");
     await expect(thirdRow.getByRole("button", { name: "Pay now" })).toBeVisible();
 
+    await expect(thirdRow).not.toBeVisible();
+    await page.getByRole("button", { name: "Filter" }).click();
+    await page.getByRole("menuitem", { name: "Clear all filters" }).click();
     await thirdRow.getByRole("button", { name: "Pay now" }).click();
     await expect(thirdRow).toContainText("Payment scheduled");
     await expect(openInvoicesBadge).toContainText("2");

--- a/e2e/tests/company/invoices/list.spec.ts
+++ b/e2e/tests/company/invoices/list.spec.ts
@@ -287,6 +287,8 @@ test.describe("Invoices admin flow", () => {
       await page.getByRole("button", { name: "Reject selected" }).click();
 
       await page.getByRole("button", { name: "Yes, reject" }).click();
+      await page.getByRole("button", { name: "Filter" }).click();
+      await page.getByRole("menuitem", { name: "Clear all filters" }).click();
       await expect(page.getByText("Rejected")).toHaveCount(2);
 
       const updatedInvoices = await db.query.invoices.findMany({ where: eq(invoices.companyId, company.id) });
@@ -311,6 +313,8 @@ test.describe("Invoices admin flow", () => {
         .getByLabel("Explain why the invoice was rejected and how to fix it (optional)")
         .fill("Invoice issue date mismatch");
       await page.getByRole("button", { name: "Yes, reject" }).click();
+      await page.getByRole("button", { name: "Filter" }).click();
+      await page.getByRole("menuitem", { name: "Clear all filters" }).click();
       await expect(page.getByText("Rejected")).toHaveCount(2);
 
       const updatedInvoices = await db.query.invoices.findMany({ where: eq(invoices.companyId, company.id) });

--- a/e2e/tests/company/invoices/one-off-payments.spec.ts
+++ b/e2e/tests/company/invoices/one-off-payments.spec.ts
@@ -379,6 +379,8 @@ test.describe("One-off payments", () => {
       await expect(page.getByRole("row", { name: "$123.45" })).toBeVisible();
 
       await page.getByRole("button", { name: "Pay now" }).click();
+      await page.getByRole("button", { name: "Filter" }).click();
+      await page.getByRole("menuitem", { name: "Clear all filters" }).click();
 
       await expect(page.getByRole("row", { name: "$123.45 Payment scheduled" })).toBeVisible();
     });

--- a/frontend/app/invoices/page.tsx
+++ b/frontend/app/invoices/page.tsx
@@ -144,7 +144,7 @@ export default function InvoicesPage() {
     getRowId: (invoice) => invoice.id,
     initialState: {
       sorting: [{ id: user.roles.administrator ? "actions" : "invoiceDate", desc: true }],
-      columnFilters: [{ id: "Status", value: ["Awaiting approval", "Failed"] }],
+      columnFilters: user.roles.administrator ? [{ id: "Status", value: ["Awaiting approval", "Failed"] }] : [],
     },
     getSortedRowModel: getSortedRowModel(),
     getFilteredRowModel: getFilteredRowModel(),

--- a/frontend/app/invoices/page.tsx
+++ b/frontend/app/invoices/page.tsx
@@ -144,6 +144,7 @@ export default function InvoicesPage() {
     getRowId: (invoice) => invoice.id,
     initialState: {
       sorting: [{ id: user.roles.administrator ? "actions" : "invoiceDate", desc: true }],
+      columnFilters: [{ id: "Status", value: ["Awaiting approval", "Failed"] }],
     },
     getSortedRowModel: getSortedRowModel(),
     getFilteredRowModel: getFilteredRowModel(),

--- a/frontend/components/DataTable.tsx
+++ b/frontend/components/DataTable.tsx
@@ -219,7 +219,7 @@ export default function DataTable<T extends RowData>({
                   {activeFilterCount > 0 && (
                     <>
                       <DropdownMenuSeparator />
-                      <DropdownMenuItem variant="destructive" onSelect={() => table.resetColumnFilters()}>
+                      <DropdownMenuItem variant="destructive" onSelect={() => table.resetColumnFilters(true)}>
                         Clear all filters
                       </DropdownMenuItem>
                     </>

--- a/frontend/components/DataTable.tsx
+++ b/frontend/components/DataTable.tsx
@@ -77,6 +77,14 @@ export const useTable = <T extends RowData>(
     autoResetPageIndex: false, // work around https://github.com/TanStack/table/issues/5026
     ...options,
     getCoreRowModel: getCoreRowModel(),
+    defaultColumn: {
+      filterFn: (row, columnId, filterValue, addMeta) => {
+        const fn = row._getAllCellsByColumnId()[columnId]?.column.getAutoFilterFn();
+        if (!fn) return true;
+        const filter = (value: unknown) => fn(row, columnId, value, addMeta);
+        return Array.isArray(filterValue) ? filterValue.some(filter) : filter(filterValue);
+      },
+    },
   });
 
 interface TableProps<T> {


### PR DESCRIPTION
Re-creation of #413.

Filters invoices to only actionable (received, partially approved, failed) items by default.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Administrators now see invoices filtered by "Awaiting approval" and "Failed" statuses by default in the invoice table.

* **Bug Fixes**
  * Improved handling of column filters, allowing support for multiple filter values per column.
  * Enhanced reliability of invoice-related actions by ensuring filters are cleared before key operations in the UI and end-to-end tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->