### PR TITLE
feat: add skeleton loading to documents page

### DIFF
--- a/frontend/app/documents/page.tsx
+++ b/frontend/app/documents/page.tsx
@@ -15,7 +15,7 @@ import type { Route } from "next";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { useQueryState } from "nuqs";
-import React, { useEffect, useMemo, useState } from "react";
+import React, { Suspense, useEffect, useMemo, useState } from "react";
 import DocusealForm, { customCss } from "@/app/documents/DocusealForm";
 import DataTable, { createColumnHelper, filterValueSchema, useTable } from "@/components/DataTable";
 import { Input } from "@/components/ui/input";
@@ -37,6 +37,7 @@ import { z } from "zod";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useForm } from "react-hook-form";
 import { Form, FormControl, FormField, FormItem, FormLabel, FormMessage } from "@/components/ui/form";
+import DocumentTableSkeleton from "@/components/DocumentTableSkeleton";
 
 type Document = RouterOutput["documents"]["list"][number];
 type SignableDocument = Document & { docusealSubmissionId: number };
@@ -375,20 +376,22 @@ export default function DocumentsPage() {
             </AlertDescription>
           </Alert>
         ) : null}
-        {documents.length > 0 ? (
-          <>
-            <DataTable
-              table={table}
-              actions={isCompanyRepresentative ? <EditTemplates /> : undefined}
-              {...(isCompanyRepresentative && { searchColumn: "Signer" })}
-            />
-            {signDocument ? (
-              <SignDocumentModal document={signDocument} onClose={() => setSignDocumentId(null)} />
-            ) : null}
-          </>
-        ) : (
-          <Placeholder icon={CircleCheck}>No documents yet.</Placeholder>
-        )}
+        <Suspense fallback={<DocumentTableSkeleton />}>
+          {documents.length > 0 ? (
+            <>
+              <DataTable
+                table={table}
+                actions={isCompanyRepresentative ? <EditTemplates /> : undefined}
+                {...(isCompanyRepresentative && { searchColumn: "Signer" })}
+              />
+              {signDocument ? (
+                <SignDocumentModal document={signDocument} onClose={() => setSignDocumentId(null)} />
+              ) : null}
+            </>
+          ) : (
+            <Placeholder icon={CircleCheck}>No documents yet.</Placeholder>
+          )}
+        </Suspense>
       </div>
       <Dialog open={showInviteModal} onOpenChange={setShowInviteModal}>
         <DialogContent>

--- a/frontend/components/DocumentTableSkeleton.tsx
+++ b/frontend/components/DocumentTableSkeleton.tsx
@@ -1,0 +1,35 @@
+import { Skeleton } from "@/components/ui/skeleton";
+import { Table, TableBody, TableCell, TableRow } from "@/components/ui/table";
+
+export default function DocumentTableSkeleton() {
+  return (
+    <div className="bg-white">
+      <Table className="caption-top not-print:max-md:grid">
+        <TableBody className="not-print:max-md:contents">
+          {Array.from({ length: 5 }).map((_, i) => (
+            <TableRow
+              key={i}
+              className="py-2 not-print:max-md:grid not-print:max-md:grid-cols-1 not-print:max-md:gap-2"
+            >
+              <TableCell className="px-4 py-2">
+                <Skeleton className="h-4 w-24 rounded" />
+              </TableCell>
+              <TableCell className="px-4 py-2">
+                <Skeleton className="h-4 w-36 rounded" />
+              </TableCell>
+              <TableCell className="px-4 py-2">
+                <Skeleton className="h-4 w-24 rounded" />
+              </TableCell>
+              <TableCell className="px-4 py-2">
+                <Skeleton className="h-4 w-20 rounded" />
+              </TableCell>
+              <TableCell className="px-4 py-2">
+                <Skeleton className="h-6 w-24 rounded" />
+              </TableCell>
+            </TableRow>
+          ))}
+        </TableBody>
+      </Table>
+    </div>
+  );
+}


### PR DESCRIPTION
**Description**

### Skeleton Loader to `/documents` Page

Fixes #411 
This PR introduces a responsive skeleton loader for the documents table on the `/documents` page. 

### Changes made
-  new `DocumentTableSkeleton` component using shadcn tables.
- The skeleton is shown as a Suspense fallback while documents are loading.

#### Demo

https://github.com/user-attachments/assets/d048de5d-644c-43a0-9bfa-049d5034ad01

- Happy to iterate on the design, placement, or code structure based on feedback.
- Once approved, the same approach can be extended to other data-heavy pages.
