### PR TITLE
feat: new mobile menu

### DIFF
--- a/frontend/components/layouts/Main.tsx
+++ b/frontend/components/layouts/Main.tsx
@@ -1,17 +1,10 @@
 import { SignOutButton } from "@clerk/nextjs";
 import { ChevronsUpDown, LogOut, ChevronRight } from "lucide-react";
-import { useQueryClient } from "@tanstack/react-query";
-import Image from "next/image";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 import React from "react";
 import { Badge } from "@/components/ui/badge";
-import {
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuTrigger,
-} from "@/components/ui/dropdown-menu";
+import { DropdownMenu, DropdownMenuContent, DropdownMenuTrigger } from "@/components/ui/dropdown-menu";
 import {
   Sidebar,
   SidebarContent,
@@ -28,14 +21,12 @@ import {
   SidebarProvider,
   SidebarTrigger,
 } from "@/components/ui/sidebar";
-import { useCurrentCompany, useCurrentUser, useUserStore } from "@/global";
-import defaultCompanyLogo from "@/images/default-company-logo.svg";
-import { request } from "@/utils/request";
-import { company_switch_path } from "@/utils/routes";
+import { useCurrentUser } from "@/global";
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "@radix-ui/react-collapsible";
 import { MobileBottomNav } from "@/components/navigation/MobileBottomNav";
 import { useIsMobile } from "@/utils/use-mobile";
 import { hasSubItems, useNavLinks, type NavLinkInfo } from "@/lib/useNavLinks";
+import { CompanySwitcherList, CompanySwitcherHeader } from "@/components/navigation/CompanySwitcher";
 
 export default function MainLayout({
   children,
@@ -55,18 +46,6 @@ export default function MainLayout({
   const user = useCurrentUser();
   const isMobile = useIsMobile();
 
-  const queryClient = useQueryClient();
-  const switchCompany = async (companyId: string) => {
-    useUserStore.setState((state) => ({ ...state, pending: true }));
-    await request({
-      method: "POST",
-      url: company_switch_path(companyId),
-      accept: "json",
-    });
-    await queryClient.resetQueries({ queryKey: ["currentUser"] });
-    useUserStore.setState((state) => ({ ...state, pending: false }));
-  };
-
   return (
     <SidebarProvider>
       {isMobile ? (
@@ -80,39 +59,19 @@ export default function MainLayout({
                   <DropdownMenu>
                     <DropdownMenuTrigger asChild>
                       <SidebarMenuButton size="lg" className="text-base" aria-label="Switch company">
-                        <CompanyName />
+                        <CompanySwitcherHeader />
                         <ChevronsUpDown className="ml-auto" />
                       </SidebarMenuButton>
                     </DropdownMenuTrigger>
                     <DropdownMenuContent className="w-(radix-dropdown-menu-trigger-width)" align="start">
-                      {user.companies.map((company) => (
-                        <DropdownMenuItem
-                          key={company.id}
-                          onSelect={() => {
-                            if (user.currentCompanyId !== company.id) void switchCompany(company.id);
-                          }}
-                          className="flex items-center gap-2"
-                        >
-                          <Image
-                            src={company.logo_url || defaultCompanyLogo}
-                            width={20}
-                            height={20}
-                            className="rounded-xs"
-                            alt=""
-                          />
-                          <span className="line-clamp-1">{company.name}</span>
-                          {company.id === user.currentCompanyId && (
-                            <div className="ml-auto size-2 rounded-full bg-blue-500"></div>
-                          )}
-                        </DropdownMenuItem>
-                      ))}
+                      <CompanySwitcherList className="p-1" />
                     </DropdownMenuContent>
                   </DropdownMenu>
                 </SidebarMenuItem>
               </SidebarMenu>
             ) : (
               <div className="flex items-center gap-2 p-2">
-                <CompanyName />
+                <CompanySwitcherHeader />
               </div>
             )}
           </SidebarHeader>
@@ -170,22 +129,6 @@ export default function MainLayout({
     </SidebarProvider>
   );
 }
-
-const CompanyName = () => {
-  const company = useCurrentCompany();
-  return (
-    <>
-      <div className="relative size-6">
-        <Image src={company.logo_url || defaultCompanyLogo} fill className="rounded-sm" alt="" />
-      </div>
-      <div>
-        <span className="line-clamp-1 text-sm font-bold" title={company.name ?? ""}>
-          {company.name}
-        </span>
-      </div>
-    </>
-  );
-};
 
 const NavLinks = () => {
   const pathname = usePathname();

--- a/frontend/components/layouts/Main.tsx
+++ b/frontend/components/layouts/Main.tsx
@@ -196,6 +196,7 @@ const NavLinks = () => {
   return (
     <SidebarMenu>
       {navLinks.map((link) => {
+        const Icon = link.icon;
         if (link.subItems) {
           return (
             <Collapsible
@@ -210,7 +211,7 @@ const NavLinks = () => {
               <SidebarMenuItem>
                 <CollapsibleTrigger asChild>
                   <SidebarMenuButton>
-                    <link.icon />
+                    <Icon />
                     <span>{link.label}</span>
                     <ChevronRight className="ml-auto h-4 w-4 transition-transform duration-200 group-data-[state=open]/collapsible:rotate-90" />
                   </SidebarMenuButton>

--- a/frontend/components/layouts/Main.tsx
+++ b/frontend/components/layouts/Main.tsx
@@ -69,75 +69,79 @@ export default function MainLayout({
 
   return (
     <SidebarProvider>
-      <Sidebar collapsible="offcanvas" className={isMobile ? "hidden" : ""}>
-        <SidebarHeader>
-          {user.companies.length > 1 ? (
-            <SidebarMenu>
-              <SidebarMenuItem>
-                <DropdownMenu>
-                  <DropdownMenuTrigger asChild>
-                    <SidebarMenuButton size="lg" className="text-base" aria-label="Switch company">
-                      <CompanyName />
-                      <ChevronsUpDown className="ml-auto" />
-                    </SidebarMenuButton>
-                  </DropdownMenuTrigger>
-                  <DropdownMenuContent className="w-(radix-dropdown-menu-trigger-width)" align="start">
-                    {user.companies.map((company) => (
-                      <DropdownMenuItem
-                        key={company.id}
-                        onSelect={() => {
-                          if (user.currentCompanyId !== company.id) void switchCompany(company.id);
-                        }}
-                        className="flex items-center gap-2"
-                      >
-                        <Image
-                          src={company.logo_url || defaultCompanyLogo}
-                          width={20}
-                          height={20}
-                          className="rounded-xs"
-                          alt=""
-                        />
-                        <span className="line-clamp-1">{company.name}</span>
-                        {company.id === user.currentCompanyId && (
-                          <div className="ml-auto size-2 rounded-full bg-blue-500"></div>
-                        )}
-                      </DropdownMenuItem>
-                    ))}
-                  </DropdownMenuContent>
-                </DropdownMenu>
-              </SidebarMenuItem>
-            </SidebarMenu>
-          ) : (
-            <div className="flex items-center gap-2 p-2">
-              <CompanyName />
-            </div>
-          )}
-        </SidebarHeader>
-        <SidebarContent>
-          {user.currentCompanyId ? (
-            <SidebarGroup>
-              <SidebarGroupContent>
-                <NavLinks />
-              </SidebarGroupContent>
-            </SidebarGroup>
-          ) : null}
-
-          <SidebarGroup className="mt-auto">
-            <SidebarGroupContent>
+      {isMobile ? (
+        <MobileBottomNav />
+      ) : (
+        <Sidebar collapsible="offcanvas">
+          <SidebarHeader>
+            {user.companies.length > 1 ? (
               <SidebarMenu>
                 <SidebarMenuItem>
-                  <SignOutButton>
-                    <SidebarMenuButton className="cursor-pointer">
-                      <LogOut className="size-6" />
-                      <span>Log out</span>
-                    </SidebarMenuButton>
-                  </SignOutButton>
+                  <DropdownMenu>
+                    <DropdownMenuTrigger asChild>
+                      <SidebarMenuButton size="lg" className="text-base" aria-label="Switch company">
+                        <CompanyName />
+                        <ChevronsUpDown className="ml-auto" />
+                      </SidebarMenuButton>
+                    </DropdownMenuTrigger>
+                    <DropdownMenuContent className="w-(radix-dropdown-menu-trigger-width)" align="start">
+                      {user.companies.map((company) => (
+                        <DropdownMenuItem
+                          key={company.id}
+                          onSelect={() => {
+                            if (user.currentCompanyId !== company.id) void switchCompany(company.id);
+                          }}
+                          className="flex items-center gap-2"
+                        >
+                          <Image
+                            src={company.logo_url || defaultCompanyLogo}
+                            width={20}
+                            height={20}
+                            className="rounded-xs"
+                            alt=""
+                          />
+                          <span className="line-clamp-1">{company.name}</span>
+                          {company.id === user.currentCompanyId && (
+                            <div className="ml-auto size-2 rounded-full bg-blue-500"></div>
+                          )}
+                        </DropdownMenuItem>
+                      ))}
+                    </DropdownMenuContent>
+                  </DropdownMenu>
                 </SidebarMenuItem>
               </SidebarMenu>
-            </SidebarGroupContent>
-          </SidebarGroup>
-        </SidebarContent>
-      </Sidebar>
+            ) : (
+              <div className="flex items-center gap-2 p-2">
+                <CompanyName />
+              </div>
+            )}
+          </SidebarHeader>
+          <SidebarContent>
+            {user.currentCompanyId ? (
+              <SidebarGroup>
+                <SidebarGroupContent>
+                  <NavLinks />
+                </SidebarGroupContent>
+              </SidebarGroup>
+            ) : null}
+
+            <SidebarGroup className="mt-auto">
+              <SidebarGroupContent>
+                <SidebarMenu>
+                  <SidebarMenuItem>
+                    <SignOutButton>
+                      <SidebarMenuButton className="cursor-pointer">
+                        <LogOut className="size-6" />
+                        <span>Log out</span>
+                      </SidebarMenuButton>
+                    </SignOutButton>
+                  </SidebarMenuItem>
+                </SidebarMenu>
+              </SidebarGroupContent>
+            </SidebarGroup>
+          </SidebarContent>
+        </Sidebar>
+      )}
       <SidebarInset>
         <div className="flex flex-col not-print:h-screen not-print:overflow-hidden">
           <main className={`flex flex-1 flex-col pb-4 not-print:overflow-y-auto ${isMobile ? "pb-20" : ""}`}>
@@ -163,7 +167,6 @@ export default function MainLayout({
           {footer ? <div className="mt-auto">{footer}</div> : null}
         </div>
       </SidebarInset>
-      {isMobile ? <MobileBottomNav /> : null}
     </SidebarProvider>
   );
 }

--- a/frontend/components/navigation/CompanySwitcher.tsx
+++ b/frontend/components/navigation/CompanySwitcher.tsx
@@ -1,0 +1,68 @@
+"use client";
+
+import { cn } from "@/utils/index";
+import Image from "next/image";
+import defaultCompanyLogo from "@/images/default-company-logo.svg";
+import { useCurrentUser } from "@/global";
+import { useCompanySwitcher } from "@/lib/useCompanySwitcher";
+
+export interface CompanySwitcherProps {
+  onCompanySelect?: (companyId: string) => void;
+  className?: string;
+  itemClassName?: string;
+}
+
+export function CompanySwitcherList({ onCompanySelect, className, itemClassName }: CompanySwitcherProps) {
+  const user = useCurrentUser();
+  const { switchCompany } = useCompanySwitcher();
+
+  const handleCompanySelect = async (companyId: string) => {
+    if (user.currentCompanyId !== companyId) {
+      await switchCompany(companyId);
+      onCompanySelect?.(companyId);
+    }
+  };
+
+  return (
+    <div className={cn("space-y-1", className)}>
+      {user.companies.map((company) => {
+        const isSelected = company.id === user.currentCompanyId;
+
+        return (
+          <button
+            key={company.id}
+            onClick={() => void handleCompanySelect(company.id)}
+            className={cn(
+              "hover:bg-accent flex w-full items-center gap-3 rounded-md px-3 py-2 text-left transition-colors",
+              isSelected && "bg-accent text-accent-foreground",
+              itemClassName,
+            )}
+            aria-label={`Switch to ${company.name}`}
+            aria-current={isSelected ? "true" : undefined}
+          >
+            <Image src={company.logo_url || defaultCompanyLogo} width={20} height={20} className="rounded-xs" alt="" />
+            <span className="line-clamp-1 flex-1">{company.name}</span>
+          </button>
+        );
+      })}
+    </div>
+  );
+}
+
+export function CompanySwitcherHeader() {
+  const user = useCurrentUser();
+  const company = user.companies.find((c) => c.id === user.currentCompanyId);
+
+  if (!company) return null;
+
+  return (
+    <div className="flex items-center gap-2">
+      <div className="relative size-6">
+        <Image src={company.logo_url || defaultCompanyLogo} fill className="rounded-sm" alt={company.name ?? ""} />
+      </div>
+      <span className="line-clamp-1 text-sm font-bold" title={company.name ?? ""}>
+        {company.name}
+      </span>
+    </div>
+  );
+}

--- a/frontend/components/navigation/MobileBottomNav.tsx
+++ b/frontend/components/navigation/MobileBottomNav.tsx
@@ -1,13 +1,17 @@
 "use client";
 
 import { cn } from "@/utils/index";
-import { MoreVertical } from "lucide-react";
+import { MoreVertical, LogOut } from "lucide-react";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { Badge } from "@/components/ui/badge";
 import { useNavLinks, type NavLinkInfo, hasSubItems } from "@/lib/useNavLinks";
 import { Sheet, SheetContent, SheetHeader, SheetTitle, SheetTrigger } from "@/components/ui/sheet";
 import React, { useMemo } from "react";
+import { useCurrentUser } from "@/global";
+import { SignOutButton } from "@clerk/nextjs";
+import { Separator } from "@/components/ui/separator";
+import { CompanySwitcherList } from "@/components/navigation/CompanySwitcher";
 
 const NAV_PRIORITIES: Record<string, number> = {
   Invoices: 1,
@@ -102,8 +106,9 @@ const NavItemWithSubmenu = ({ item }: { item: NavItem & { subItems: NonNullable<
 
 const OverflowMenu = ({ items }: { items: NavItem[] }) => {
   const pathname = usePathname();
+  const user = useCurrentUser();
 
-  if (items.length === 0) return null;
+  if (items.length === 0 && user.companies.length === 0) return null;
 
   return (
     <Sheet>
@@ -120,7 +125,16 @@ const OverflowMenu = ({ items }: { items: NavItem[] }) => {
         <SheetHeader>
           <SheetTitle>More Options</SheetTitle>
         </SheetHeader>
-        <div className="space-y-2">
+        <div>
+          {/* Company section */}
+          {user.companies.length > 0 && (
+            <>
+              <CompanySwitcherList itemClassName="px-6 py-3 font-medium" />
+              {items.length > 0 && <Separator className="my-0" />}
+            </>
+          )}
+
+          {/* Navigation items */}
           {items.map((item) => (
             <React.Fragment key={item.label}>
               {item.subItems ? (
@@ -130,6 +144,18 @@ const OverflowMenu = ({ items }: { items: NavItem[] }) => {
               ) : null}
             </React.Fragment>
           ))}
+
+          {/* Log out section */}
+          <Separator className="my-0" />
+          <SignOutButton>
+            <button
+              className="hover:bg-accent flex w-full items-center gap-3 rounded-md px-6 py-3 text-left transition-colors"
+              aria-label="Log out"
+            >
+              <LogOut className="h-5 w-5" />
+              <span className="font-medium">Log out</span>
+            </button>
+          </SignOutButton>
         </div>
       </SheetContent>
     </Sheet>

--- a/frontend/components/navigation/MobileBottomNav.tsx
+++ b/frontend/components/navigation/MobileBottomNav.tsx
@@ -5,7 +5,7 @@ import { MoreVertical } from "lucide-react";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { Badge } from "@/components/ui/badge";
-import { useNavLinks, type NavLinkInfo } from "@/lib/useNavLinks";
+import { useNavLinks, type NavLinkInfo, hasSubItems } from "@/lib/useNavLinks";
 import { Sheet, SheetContent, SheetHeader, SheetTitle, SheetTrigger } from "@/components/ui/sheet";
 import React, { useMemo } from "react";
 
@@ -26,9 +26,6 @@ const MAX_VISIBLE_ITEMS = 4;
 interface NavItem extends NavLinkInfo {
   priority: number;
 }
-
-const hasSubItems = (item: NavItem): item is NavItem & { subItems: NonNullable<NavItem["subItems"]> } =>
-  !!item.subItems && item.subItems.length > 0;
 
 const NavIconButton = ({ icon: Icon, label, isActive, badge, className }: NavItem & { className?: string }) => (
   <div

--- a/frontend/components/navigation/MobileBottomNav.tsx
+++ b/frontend/components/navigation/MobileBottomNav.tsx
@@ -108,8 +108,6 @@ const OverflowMenu = ({ items }: { items: NavItem[] }) => {
   const pathname = usePathname();
   const user = useCurrentUser();
 
-  if (items.length === 0 && user.companies.length === 0) return null;
-
   return (
     <Sheet>
       <SheetTrigger asChild>
@@ -237,11 +235,9 @@ export function MobileBottomNav() {
             {hasSubItems(item) ? <NavItemWithSubmenu item={item} /> : <SimpleNavItem item={item} />}
           </li>
         ))}
-        {overflowItems.length > 0 && (
-          <li className="flex-1">
-            <OverflowMenu items={overflowItems} />
-          </li>
-        )}
+        <li className="flex-1">
+          <OverflowMenu items={overflowItems} />
+        </li>
       </ul>
     </nav>
   );

--- a/frontend/components/navigation/MobileBottomNav.tsx
+++ b/frontend/components/navigation/MobileBottomNav.tsx
@@ -1,0 +1,225 @@
+"use client";
+
+import { cn } from "@/utils/index";
+import { MoreVertical } from "lucide-react";
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+import { Badge } from "@/components/ui/badge";
+import { useNavLinks, type NavLinkInfo } from "@/lib/useNavLinks";
+import { Sheet, SheetContent, SheetHeader, SheetTitle, SheetTrigger } from "@/components/ui/sheet";
+import React, { useMemo } from "react";
+
+const NAV_PRIORITIES: Record<string, number> = {
+  Invoices: 1,
+  People: 2,
+  Documents: 3,
+  Equity: 4,
+  Updates: 5,
+  Expenses: 6,
+  Roles: 7,
+  Settings: 8,
+};
+
+const DEFAULT_PRIORITY = 99;
+const MAX_VISIBLE_ITEMS = 4;
+
+interface NavItem extends NavLinkInfo {
+  priority: number;
+}
+
+const hasSubItems = (item: NavItem): item is NavItem & { subItems: NonNullable<NavItem["subItems"]> } =>
+  !!item.subItems && item.subItems.length > 0;
+
+const NavIconButton = ({ icon: Icon, label, isActive, badge, className }: NavItem & { className?: string }) => (
+  <div
+    className={cn(
+      "flex h-full flex-col items-center justify-center p-2",
+      "text-muted-foreground transition-all duration-200",
+      "hover:text-foreground active:scale-95",
+      "group relative",
+      isActive && "text-primary",
+      className,
+    )}
+  >
+    <Icon className={cn("mb-1 h-5 w-5 transition-transform duration-200", isActive && "scale-110")} />
+    <span className="text-xs font-medium">{label}</span>
+
+    {!!badge && (
+      <span className="absolute top-2 right-1/2 flex h-5 w-5 translate-x-4 -translate-y-1 items-center justify-center rounded-full bg-blue-500 text-xs text-white">
+        {badge > 10 ? "10+" : badge}
+      </span>
+    )}
+
+    {isActive ? (
+      <span className="bg-primary absolute -bottom-[1px] left-1/2 h-0.5 w-12 -translate-x-1/2 rounded-t-full" />
+    ) : null}
+  </div>
+);
+
+const SimpleNavItem = ({ item }: { item: NavItem }) => {
+  if (!item.href) return null;
+
+  return (
+    <Link
+      href={typeof item.href === "string" ? { pathname: item.href } : item.href}
+      aria-label={`Navigate to ${item.label}`}
+      aria-current={item.isActive ? "page" : undefined}
+    >
+      <NavIconButton {...item} />
+    </Link>
+  );
+};
+
+const NavItemWithSubmenu = ({ item }: { item: NavItem & { subItems: NonNullable<NavItem["subItems"]> } }) => {
+  const pathname = usePathname();
+
+  return (
+    <Sheet>
+      <SheetTrigger asChild>
+        <button aria-label={`${item.label} menu`} aria-current={item.isActive ? "page" : undefined} className="w-full">
+          <NavIconButton {...item} />
+        </button>
+      </SheetTrigger>
+      <SheetContent side="bottom" className="h-auto">
+        <SheetHeader>
+          <SheetTitle>{item.label}</SheetTitle>
+        </SheetHeader>
+        <div className="flex flex-col gap-1">
+          {item.subItems.map((subItem) => (
+            <Link
+              key={subItem.label}
+              href={{ pathname: subItem.route }}
+              className={cn(
+                "flex items-center px-6 py-2",
+                pathname === subItem.route && "bg-accent text-accent-foreground",
+              )}
+            >
+              <span className="font-medium">{subItem.label}</span>
+            </Link>
+          ))}
+        </div>
+      </SheetContent>
+    </Sheet>
+  );
+};
+
+const OverflowMenu = ({ items }: { items: NavItem[] }) => {
+  const pathname = usePathname();
+
+  if (items.length === 0) return null;
+
+  return (
+    <Sheet>
+      <SheetTrigger asChild>
+        <button
+          aria-label="More navigation options"
+          className="text-muted-foreground hover:text-foreground flex h-full w-full flex-col items-center justify-center p-2 transition-colors active:scale-95"
+        >
+          <MoreVertical className="mb-1 h-5 w-5" />
+          <span className="text-xs font-medium">More</span>
+        </button>
+      </SheetTrigger>
+      <SheetContent side="bottom" className="h-auto">
+        <SheetHeader>
+          <SheetTitle>More Options</SheetTitle>
+        </SheetHeader>
+        <div className="space-y-2">
+          {items.map((item) => (
+            <React.Fragment key={item.label}>
+              {item.subItems ? (
+                <SubmenuSection item={item} pathname={pathname} />
+              ) : item.href ? (
+                <OverflowLink item={item} />
+              ) : null}
+            </React.Fragment>
+          ))}
+        </div>
+      </SheetContent>
+    </Sheet>
+  );
+};
+
+const SubmenuSection = ({ item, pathname }: { item: NavItem; pathname: string }) => (
+  <>
+    <div className="text-muted-foreground flex items-center gap-3 font-medium">
+      <item.icon className="h-5 w-5" />
+      <span>{item.label}</span>
+    </div>
+    <div className="space-y-1">
+      {item.subItems?.map((subItem) => (
+        <Link
+          key={subItem.label}
+          href={{ pathname: subItem.route }}
+          className={cn(
+            "hover:bg-accent block rounded-md px-6 py-2 text-sm transition-colors",
+            pathname === subItem.route && "bg-accent text-accent-foreground",
+          )}
+        >
+          {subItem.label}
+        </Link>
+      ))}
+    </div>
+  </>
+);
+
+const OverflowLink = ({ item }: { item: NavItem }) => (
+  <Link
+    href={item.href ? (typeof item.href === "string" ? { pathname: item.href } : item.href) : {}}
+    className={cn(
+      "hover:bg-accent flex items-center gap-3 rounded-md px-6 py-3 transition-colors",
+      item.isActive && "bg-accent text-accent-foreground",
+    )}
+  >
+    <item.icon className="h-5 w-5" />
+    <span className="font-medium">{item.label}</span>
+    {item.badge ? (
+      <Badge className="ml-auto bg-blue-500 text-white">{item.badge > 10 ? "10+" : item.badge}</Badge>
+    ) : null}
+  </Link>
+);
+
+const getItemPriority = (label: string): number => NAV_PRIORITIES[label] ?? DEFAULT_PRIORITY;
+
+// Main navigation component
+export function MobileBottomNav() {
+  const allNavLinks = useNavLinks();
+
+  const { mainNavItems, overflowItems } = useMemo(() => {
+    const navItemsWithPriority: NavItem[] = allNavLinks.map((link) => ({
+      ...link,
+      priority: getItemPriority(link.label),
+    }));
+
+    const sorted = navItemsWithPriority.sort((a, b) => a.priority - b.priority);
+
+    return {
+      mainNavItems: sorted.slice(0, Math.min(MAX_VISIBLE_ITEMS, sorted.length)),
+      overflowItems: sorted.slice(MAX_VISIBLE_ITEMS),
+    };
+  }, [allNavLinks]);
+
+  return (
+    <nav
+      role="navigation"
+      aria-label="Mobile navigation"
+      className={cn(
+        "fixed right-0 bottom-0 left-0 z-50",
+        "bg-background/95 supports-[backdrop-filter]:bg-background/60 backdrop-blur",
+        "border-border border-t",
+      )}
+    >
+      <ul role="list" className="flex items-center justify-around">
+        {mainNavItems.map((item) => (
+          <li key={item.label} className="flex-1">
+            {hasSubItems(item) ? <NavItemWithSubmenu item={item} /> : <SimpleNavItem item={item} />}
+          </li>
+        ))}
+        {overflowItems.length > 0 && (
+          <li className="flex-1">
+            <OverflowMenu items={overflowItems} />
+          </li>
+        )}
+      </ul>
+    </nav>
+  );
+}

--- a/frontend/lib/useCompanySwitcher.ts
+++ b/frontend/lib/useCompanySwitcher.ts
@@ -1,0 +1,23 @@
+"use client";
+
+import { useQueryClient } from "@tanstack/react-query";
+import { useUserStore } from "@/global";
+import { request } from "@/utils/request";
+import { company_switch_path } from "@/utils/routes";
+
+export const useCompanySwitcher = () => {
+  const queryClient = useQueryClient();
+
+  const switchCompany = async (companyId: string) => {
+    useUserStore.setState((state) => ({ ...state, pending: true }));
+    await request({
+      method: "POST",
+      url: company_switch_path(companyId),
+      accept: "json",
+    });
+    await queryClient.resetQueries({ queryKey: ["currentUser"] });
+    useUserStore.setState((state) => ({ ...state, pending: false }));
+  };
+
+  return { switchCompany };
+};

--- a/frontend/lib/useCompanySwitcher.ts
+++ b/frontend/lib/useCompanySwitcher.ts
@@ -10,13 +10,16 @@ export const useCompanySwitcher = () => {
 
   const switchCompany = async (companyId: string) => {
     useUserStore.setState((state) => ({ ...state, pending: true }));
-    await request({
-      method: "POST",
-      url: company_switch_path(companyId),
-      accept: "json",
-    });
-    await queryClient.resetQueries({ queryKey: ["currentUser"] });
-    useUserStore.setState((state) => ({ ...state, pending: false }));
+    try {
+      await request({
+        method: "POST",
+        url: company_switch_path(companyId),
+        accept: "json",
+      });
+      await queryClient.resetQueries({ queryKey: ["currentUser"] });
+    } finally {
+      useUserStore.setState((state) => ({ ...state, pending: false }));
+    }
   };
 
   return { switchCompany };

--- a/frontend/lib/useNavLinks.ts
+++ b/frontend/lib/useNavLinks.ts
@@ -27,6 +27,11 @@ export interface NavLinkInfo {
   subItems?: { label: string; route: string }[];
 }
 
+export const hasSubItems = (
+  item: NavLinkInfo,
+): item is NavLinkInfo & { subItems: NonNullable<NavLinkInfo["subItems"]> } =>
+  !!item.subItems && item.subItems.length > 0;
+
 export const useNavLinks = (): NavLinkInfo[] => {
   const pathname = usePathname();
   const user = useCurrentUser();

--- a/frontend/lib/useNavLinks.ts
+++ b/frontend/lib/useNavLinks.ts
@@ -1,0 +1,132 @@
+"use client";
+
+import { useIsActionable } from "@/app/invoices";
+import { navLinks as equityNavLinks } from "@/app/equity";
+import { useCurrentCompany, useCurrentUser } from "@/global";
+import { trpc } from "@/trpc/client";
+import {
+  BookUser,
+  ChartPie,
+  CircleDollarSign,
+  Files,
+  type LucideIcon,
+  ReceiptIcon,
+  Rss,
+  Settings,
+  Users,
+} from "lucide-react";
+import { usePathname } from "next/navigation";
+import { skipToken } from "@tanstack/react-query";
+
+export interface NavLinkInfo {
+  label: string;
+  href?: string;
+  icon: LucideIcon;
+  isActive: boolean;
+  badge?: number;
+  subItems?: { label: string; route: string }[];
+}
+
+export const useNavLinks = (): NavLinkInfo[] => {
+  const pathname = usePathname();
+  const user = useCurrentUser();
+  const company = useCurrentCompany();
+
+  const routes = new Set(
+    company.routes.flatMap((route) => [route.label, ...(route.subLinks?.map((subLink) => subLink.label) || [])]),
+  );
+
+  const { data: invoicesData } = trpc.invoices.list.useQuery(
+    user.currentCompanyId && user.roles.administrator
+      ? { companyId: user.currentCompanyId, status: ["received", "approved", "failed"] }
+      : skipToken,
+    { refetchInterval: 30_000 },
+  );
+  const isInvoiceActionable = useIsActionable();
+
+  const { data: documentsData } = trpc.documents.list.useQuery(
+    user.currentCompanyId && user.id
+      ? { companyId: user.currentCompanyId, userId: user.id, signable: true }
+      : skipToken,
+    { refetchInterval: 30_000 },
+  );
+
+  const updatesPath = company.routes.find((route) => route.label === "Updates")?.name;
+  const equityLinks = equityNavLinks(user, company);
+
+  const navLinks: NavLinkInfo[] = [];
+
+  if (updatesPath) {
+    navLinks.push({
+      label: "Updates",
+      href: "/updates/company",
+      icon: Rss,
+      isActive: pathname.startsWith("/updates"),
+    });
+  }
+
+  if (routes.has("Invoices")) {
+    navLinks.push({
+      label: "Invoices",
+      href: "/invoices",
+      icon: ReceiptIcon,
+      isActive: pathname.startsWith("/invoices"),
+      badge: invoicesData?.filter(isInvoiceActionable).length ?? 0,
+    });
+  }
+
+  if (routes.has("Expenses") && company.id) {
+    navLinks.push({
+      label: "Expenses",
+      href: `/companies/${company.id}/expenses`,
+      icon: CircleDollarSign,
+      isActive: pathname.startsWith(`/companies/${company.id}/expenses`),
+    });
+  }
+
+  if (routes.has("Documents")) {
+    navLinks.push({
+      label: "Documents",
+      href: "/documents",
+      icon: Files,
+      isActive: pathname.startsWith("/documents") || pathname.startsWith("/document_templates"),
+      badge: documentsData?.length ?? 0,
+    });
+  }
+
+  if (routes.has("People")) {
+    navLinks.push({
+      label: "People",
+      href: "/people",
+      icon: Users,
+      isActive: pathname.startsWith("/people") || pathname.includes("/investor_entities/"),
+    });
+  }
+
+  if (routes.has("Roles")) {
+    navLinks.push({
+      label: "Roles",
+      href: "/roles",
+      icon: BookUser,
+      isActive: pathname.startsWith("/roles"),
+    });
+  }
+
+  if (routes.has("Equity") && equityLinks.length > 0) {
+    navLinks.push({
+      label: "Equity",
+      icon: ChartPie,
+      isActive: equityLinks.some((link) => pathname === link.route),
+      subItems: equityLinks,
+    });
+  }
+
+  navLinks.push({
+    label: "Settings",
+    href: "/settings",
+    icon: Settings,
+    isActive: pathname.startsWith("/settings"),
+  });
+
+  return navLinks;
+};


### PR DESCRIPTION
Fixes: https://github.com/antiwork/flexile/issues/449

Loom [iteration 2]: https://www.loom.com/share/bd67b7b7aed94d0fa61a5ad321937fe0

| Menu | Sub-menu | Other |
|--------|--------|--------|
| <img width="416" alt="Screenshot 2025-07-08 at 7 59 10 PM" src="https://github.com/user-attachments/assets/67929b09-46a1-4428-9fa3-d99b80b290f7" /> | <img width="416" alt="Screenshot 2025-07-08 at 7 59 22 PM" src="https://github.com/user-attachments/assets/182ba443-2fc6-4f2d-a25c-011841adf267" /> | <img width="363" alt="Screenshot 2025-07-08 at 10 11 38 PM" src="https://github.com/user-attachments/assets/bf13b4fb-6505-40cf-9a52-b5c90fec2e4e" /> | 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Introduced a mobile bottom navigation bar with overflow menu and nested submenus for enhanced mobile usability.
  * Added company switcher components for streamlined company selection within the navigation.
  * Dynamic navigation links now include badges and support collapsible groups with state persistence.

* **Refactor**
  * Sidebar replaced by mobile bottom nav on mobile devices; sidebar trigger hidden on mobile.
  * Navigation rendering logic modularized using custom hooks and components for better maintainability.
  * Sign-out button repositioned within sidebar content for improved layout consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->