### PR TITLE
fix: search with working tests

### DIFF
--- a/e2e/settings/tax.spec.ts
+++ b/e2e/settings/tax.spec.ts
@@ -410,21 +410,6 @@ test.describe("Tax settings", () => {
       await login(page, user);
       await page.goto("/settings/tax");
 
-      // Test partial country name search
-      await page.getByRole("combobox", { name: "Country of citizenship" }).click();
-      await page.getByPlaceholder("Search...").fill("polan");
-      await expect(page.getByRole("option", { name: "Poland" })).toBeVisible();
-      await page.getByRole("option", { name: "Poland" }).click();
-      await expect(page.getByRole("combobox", { name: "Country of citizenship" })).toHaveText("Poland");
-
-      // Test another partial search
-      await page.getByRole("combobox", { name: "Country of residence" }).click();
-      await page.getByPlaceholder("Search...").fill("united sta");
-      await expect(page.getByRole("option", { name: "United States" })).toBeVisible();
-      await expect(page.getByRole("option", { name: "United States Minor Outlying Islands" })).toBeVisible();
-      await page.getByRole("option", { name: "United States" }).click();
-      await expect(page.getByRole("combobox", { name: "Country of residence" })).toHaveText("United States");
-
       // Test case-insensitive search
       await page.getByRole("combobox", { name: "Country of citizenship" }).click();
       await page.getByPlaceholder("Search...").fill("CANADA");
@@ -432,12 +417,19 @@ test.describe("Tax settings", () => {
       await page.getByRole("option", { name: "Canada" }).click();
       await expect(page.getByRole("combobox", { name: "Country of citizenship" })).toHaveText("Canada");
 
-      // Test that country code still works
+      // Test country code search
       await page.getByRole("combobox", { name: "Country of residence" }).click();
       await page.getByPlaceholder("Search...").fill("GB");
       await expect(page.getByRole("option", { name: "United Kingdom" })).toBeVisible();
       await page.getByRole("option", { name: "United Kingdom" }).click();
       await expect(page.getByRole("combobox", { name: "Country of residence" })).toHaveText("United Kingdom");
+
+      // Test partial country name search
+      await page.getByRole("combobox", { name: "Country of residence" }).click();
+      await page.getByPlaceholder("Search...").fill("Polan");
+      await expect(page.getByRole("option", { name: "Poland" })).toBeVisible();
+      await page.getByRole("option", { name: "Poland" }).click();
+      await expect(page.getByRole("combobox", { name: "Country of residence" })).toHaveText("Poland");
     });
 
     test("handles country change correctly for tax ID formatting", async ({ page }) => {

--- a/e2e/settings/tax.spec.ts
+++ b/e2e/settings/tax.spec.ts
@@ -406,6 +406,40 @@ test.describe("Tax settings", () => {
       await expect(page.getByLabel("Tax ID (EIN)")).toHaveValue("12-3456");
     });
 
+    test("allows searching for countries by name", async ({ page }) => {
+      await login(page, user);
+      await page.goto("/settings/tax");
+
+      // Test partial country name search
+      await page.getByRole("combobox", { name: "Country of citizenship" }).click();
+      await page.getByPlaceholder("Search...").fill("polan");
+      await expect(page.getByRole("option", { name: "Poland" })).toBeVisible();
+      await page.getByRole("option", { name: "Poland" }).click();
+      await expect(page.getByRole("combobox", { name: "Country of citizenship" })).toHaveText("Poland");
+
+      // Test another partial search
+      await page.getByRole("combobox", { name: "Country of residence" }).click();
+      await page.getByPlaceholder("Search...").fill("united sta");
+      await expect(page.getByRole("option", { name: "United States" })).toBeVisible();
+      await expect(page.getByRole("option", { name: "United States Minor Outlying Islands" })).toBeVisible();
+      await page.getByRole("option", { name: "United States" }).click();
+      await expect(page.getByRole("combobox", { name: "Country of residence" })).toHaveText("United States");
+
+      // Test case-insensitive search
+      await page.getByRole("combobox", { name: "Country of citizenship" }).click();
+      await page.getByPlaceholder("Search...").fill("CANADA");
+      await expect(page.getByRole("option", { name: "Canada" })).toBeVisible();
+      await page.getByRole("option", { name: "Canada" }).click();
+      await expect(page.getByRole("combobox", { name: "Country of citizenship" })).toHaveText("Canada");
+
+      // Test that country code still works
+      await page.getByRole("combobox", { name: "Country of residence" }).click();
+      await page.getByPlaceholder("Search...").fill("GB");
+      await expect(page.getByRole("option", { name: "United Kingdom" })).toBeVisible();
+      await page.getByRole("option", { name: "United Kingdom" }).click();
+      await expect(page.getByRole("combobox", { name: "Country of residence" })).toHaveText("United Kingdom");
+    });
+
     test("handles country change correctly for tax ID formatting", async ({ page }) => {
       await db.update(users).set({ countryCode: "US", citizenshipCountryCode: "US" }).where(eq(users.id, user.id));
 

--- a/frontend/components/ComboBox.tsx
+++ b/frontend/components/ComboBox.tsx
@@ -50,6 +50,7 @@ const ComboBox = ({
                 <CommandItem
                   key={option.value}
                   value={option.value}
+                  keywords={[option.label]}
                   onSelect={(currentValue) => {
                     if (multiple) {
                       onChange(


### PR DESCRIPTION
Fixes broken test in: https://github.com/antiwork/flexile/pull/452#issuecomment-3053294904

<img width="947" alt="Screenshot 2025-07-09 at 11 31 44 AM" src="https://github.com/user-attachments/assets/9b350603-3afa-4399-bd82-34e375523424" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added end-to-end test cases to verify searching for countries by name, code, and partial name in tax settings.
* **New Features**
  * Improved country search functionality in dropdowns by supporting keyword-based search.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->