### PR TITLE
Fix Data Retention & Image Upload in Workspace Settings

### DIFF
--- a/e2e/tests/company/administrator/settings/workspace.spec.ts
+++ b/e2e/tests/company/administrator/settings/workspace.spec.ts
@@ -1,0 +1,71 @@
+import { db } from "@test/db";
+import { companiesFactory } from "@test/factories/companies";
+import { usersFactory } from "@test/factories/users";
+import { login } from "@test/helpers/auth";
+import { expect, test } from "@test/index";
+import { eq } from "drizzle-orm";
+import { companies } from "@/db/schema";
+import { clerk } from "@clerk/testing/playwright";
+
+test.describe.serial("Workspace settings", () => {
+  let company: typeof companies.$inferSelect;
+  let adminUser: Awaited<ReturnType<typeof usersFactory.create>>["user"];
+
+  test.beforeEach(async ({ page }) => {
+    clerk.signOut({ page });
+    ({ company, adminUser } = await companiesFactory.createCompletedOnboarding());
+    await login(page, adminUser);
+    await page.goto("/administrator/settings");
+    await page.waitForTimeout(1000);
+  });
+
+  test("allows updating workspace settings", async ({ page }) => {
+    await page.getByLabel("Company name").clear();
+    await page.getByLabel("Company name").fill("Updated Company Name");
+
+    await page.getByLabel("Company website").clear();
+    await page.getByLabel("Company website").fill("https://example.com");
+
+    const logoPath = "frontend/images/flexile-logo.svg";
+    await page.getByLabel("Logo").setInputFiles(logoPath);
+
+    const testColor = "#4B5563";
+    await page.locator('input[type="color"]').evaluate((el: HTMLInputElement, color: string) => {
+      el.value = color;
+      el.dispatchEvent(new Event("input", { bubbles: true }));
+      el.dispatchEvent(new Event("change", { bubbles: true }));
+    }, testColor);
+
+    await page.waitForTimeout(1000);
+
+    await page.getByRole("button", { name: "Save changes" }).click();
+    await expect(page.getByText("Changes saved")).toBeVisible();
+
+    const updatedCompany = await db.query.companies.findFirst({
+      where: eq(companies.id, company.id),
+    });
+
+    expect(updatedCompany?.publicName).toBe("Updated Company Name");
+    expect(updatedCompany?.website).toBe("https://example.com");
+    expect(updatedCompany?.brandColor).toBe(testColor.toLowerCase());
+  });
+
+  test("displays initial company data in form fields", async ({ page }) => {
+    const companyNameInput = page.getByLabel("Company name");
+    const websiteInput = page.getByLabel("Company website");
+
+    await expect(companyNameInput).toHaveValue(company.name || "");
+
+    const companyData = await db.query.companies.findFirst({
+      where: eq(companies.id, company.id),
+    });
+
+    await expect(websiteInput).toHaveValue(companyData?.website || "");
+
+    const colorInput = page.locator('input[type="color"]');
+    await expect(colorInput).toHaveValue(companyData?.brandColor || "");
+
+    const logoImage = page.locator('img[alt="Company logo"]');
+    await expect(logoImage).toBeVisible();
+  });
+});

--- a/e2e/tests/company/administrator/settings/workspace.spec.ts
+++ b/e2e/tests/company/administrator/settings/workspace.spec.ts
@@ -54,16 +54,16 @@ test.describe.serial("Workspace settings", () => {
     const companyNameInput = page.getByLabel("Company name");
     const websiteInput = page.getByLabel("Company website");
 
-    await expect(companyNameInput).toHaveValue(company.name || "");
+    await expect(companyNameInput).toHaveValue(company.name as string);
 
     const companyData = await db.query.companies.findFirst({
       where: eq(companies.id, company.id),
     });
 
-    await expect(websiteInput).toHaveValue(companyData?.website || "");
+    await expect(websiteInput).toHaveValue(companyData?.website as string);
 
     const colorInput = page.locator('input[type="color"]');
-    await expect(colorInput).toHaveValue(companyData?.brandColor || "");
+    await expect(colorInput).toHaveValue(companyData?.brandColor || "#000000");
 
     const logoImage = page.locator('img[alt="Company logo"]');
     await expect(logoImage).toBeVisible();

--- a/frontend/app/administrator/settings/page.tsx
+++ b/frontend/app/administrator/settings/page.tsx
@@ -34,7 +34,8 @@ export default function SettingsPage() {
     resolver: zodResolver(formSchema),
     defaultValues: {
       publicName: company.name ?? "",
-      ...pick(settings),
+      website: settings.website ?? "",
+      brandColor: settings.brandColor ?? null,
     },
   });
 

--- a/frontend/middleware.ts
+++ b/frontend/middleware.ts
@@ -20,7 +20,7 @@ export default clerkMiddleware((_, req) => {
     };
     style-src 'self' 'unsafe-inline';
     connect-src 'self' ${clerkFapiUrl} https://docuseal.com ${s3Urls} ${helperHost};
-    img-src 'self' https://img.clerk.com https://docuseal.s3.amazonaws.com ${s3Urls};
+    img-src 'self' blob: https://img.clerk.com https://docuseal.s3.amazonaws.com ${s3Urls};
     worker-src 'self' blob:;
     font-src 'self';
     base-uri 'self';


### PR DESCRIPTION
This PR fixes two major issues in the Workspace Settings:

🖼️ Logo Upload Fix:

Fixed the issue where logo upload wasn’t working.

Root cause: Content Security Policy (CSP) was blocking image previews.

Fix: Updated the middilware image source to use blob: URLs, which are permitted under stricter CSP rules.

<img width="1455" height="834" alt="Screenshot 2025-07-11 at 12 44 43 AM" src="https://github.com/user-attachments/assets/be93d9ee-da06-48c9-8f73-0c07d80d6245" />


🎨 Brand Color & Website Retention Fix:

Previously, brandColor and website fields were not being retained after saving and refreshing.

Root cause: Initial form values were not being correctly populated from the persisted state.

Fix: Ensured the initial values are correctly loaded and reflected in the UI.


video: https://www.loom.com/share/3814b40cea8c416f82421e651990f9f9?sid=dfd51c7e-f907-45f4-afe0-d975af25427c

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved form behavior in the settings page by refining how default values are set for website and brand color fields.

* **Chores**
  * Updated security settings to allow images from blob URLs, enhancing compatibility for image sources.

* **Tests**
  * Added end-to-end tests for workspace settings, verifying form data display and update functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->