### PR TITLE
Fix: Preview button incorrectly opens publish modal

### DIFF
--- a/frontend/app/updates/company/Edit.tsx
+++ b/frontend/app/updates/company/Edit.tsx
@@ -75,10 +75,7 @@ const Edit = ({ update }: { update?: CompanyUpdate }) => {
     },
   });
 
-  const submit = form.handleSubmit(async (values, event) => {
-    if (event?.target instanceof HTMLElement && event.target.id === "preview") {
-      return saveMutation.mutateAsync({ preview: true, values });
-    }
+  const submit = form.handleSubmit(async () => {
     setModalOpen(true);
   });
 
@@ -96,11 +93,11 @@ const Edit = ({ update }: { update?: CompanyUpdate }) => {
             ) : (
               <>
                 <MutationStatusButton
-                  type="submit"
+                  type="button"
                   mutation={saveMutation}
-                  id="preview"
                   idleVariant="outline"
                   loadingText="Saving..."
+                  onClick={() => form.handleSubmit((values) => saveMutation.mutateAsync({ values, preview: true }))()}
                 >
                   <ArrowTopRightOnSquareIcon className="size-4" />
                   Preview


### PR DESCRIPTION
Closes #497

Before:

https://github.com/user-attachments/assets/03d02639-c1f9-4b7e-a704-390ca61591bc

After:

https://github.com/user-attachments/assets/4f13bea0-e9b2-4b82-adf6-ceb8a291fe06



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved the handling of the "Preview" button in the company edit form for a clearer and more intuitive user experience. The preview action is now separated from the main form submission flow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->