### PR TITLE
Fix Failing Tests

### DIFF
--- a/e2e/tests/company/invoices/list.spec.ts
+++ b/e2e/tests/company/invoices/list.spec.ts
@@ -341,7 +341,7 @@ test.describe("Invoices admin flow", () => {
 
     await login(page, adminUser);
     await page.getByRole("link", { name: "Invoices" }).click();
-    await page.locator("tbody tr").click();
+    await page.getByRole("row").getByText("Awaiting approval").first().click();
 
     await expect(page.getByText("This invoice includes rates above the default of $60/hour.")).toBeVisible();
 
@@ -350,7 +350,7 @@ test.describe("Invoices admin flow", () => {
       .set({ payRateInSubunits: null })
       .where(eq(companyContractors.id, companyContractor.id));
     await page.reload();
-    await page.locator("tbody tr").click();
+    await page.getByRole("row").getByText("Awaiting approval").first().click();
     await expect(page.getByRole("dialog")).toBeVisible();
     await expect(page.getByText("This invoice includes rates above the default of $60/hour.")).not.toBeVisible();
 
@@ -359,7 +359,7 @@ test.describe("Invoices admin flow", () => {
       .set({ payRateInSubunits: 60000 })
       .where(eq(companyContractors.id, companyContractor.id));
     await page.reload();
-    await page.locator("tbody tr").click();
+    await page.getByRole("row").getByText("Awaiting approval").first().click();
     await expect(page.getByRole("dialog")).toBeVisible();
     await expect(page.getByText("This invoice includes rates above the default of $60/hour.")).not.toBeVisible();
   });

--- a/frontend/app/people/page.tsx
+++ b/frontend/app/people/page.tsx
@@ -47,8 +47,10 @@ export default function PeoplePage() {
   const lastContractor = workers[0];
 
   const form = useForm({
-    defaultValues: {
-      ...(lastContractor ? { role: lastContractor.role } : {}),
+    values: {
+      email: "",
+      role: lastContractor?.role ?? "",
+      documentTemplateId: "",
       payRateType: lastContractor?.payRateType ?? PayRateType.Hourly,
       payRateInSubunits: lastContractor?.payRateInSubunits ?? null,
       startDate: today(getLocalTimeZone()),


### PR DESCRIPTION
Fixes failing test from #429

Spent some time investigating + fixing the CI errors, so this is my attemp to fix CI:

Took some time but finally figured it out a few things: 

Failing tests where: 

- e2e/tests/company/administrator/new-contract.spec.ts:179
- e2e/tests/company/administrator/role-autocomplete.spec.ts:63
- e2e/tests/company/invoices/list.spec.ts:333
- e2e/tests/company/onboarding/checklist.spec.ts:103

#429 The transition from useSuspenseQuery to useQuery makes all the components render immediately even before receiving data so defaultValues that depend on fetched data will not initialise properly. Turning the defaultValues to values which is reactive solves this problems and fixes the two first failing tests.

Adding the skeletons made another test fail in list.spec.ts which is fixed. 

The checklist test pass locally so don't know how to fix this :
![Screenshot 2025-07-11 at 01 46 19](https://github.com/user-attachments/assets/84de8982-1375-4a2d-817a-612f8fa74021)