### PR TITLE
Fix contractor invite role dropdown - add default options and styling

### DIFF
--- a/frontend/app/people/FormFields.tsx
+++ b/frontend/app/people/FormFields.tsx
@@ -12,7 +12,7 @@ import { z } from "zod";
 export const schema = z.object({
   payRateType: z.nativeEnum(PayRateType),
   payRateInSubunits: z.number().nullable(),
-  role: z.string(),
+  role: z.string(), // will be restricted in page.tsx
 });
 
 export default function FormFields() {
@@ -21,7 +21,15 @@ export default function FormFields() {
   const companyId = useUserStore((state) => state.user?.currentCompanyId);
   const { data: workers } = trpc.contractors.list.useQuery(companyId ? { companyId, excludeAlumni: true } : skipToken);
 
-  const uniqueRoles = workers ? [...new Set(workers.map((worker) => worker.role))].sort() : [];
+  const baseRoles = ["designer", "developer"];
+  const uniqueRoles = workers
+    ? Array.from(new Set([...baseRoles, ...workers.map((worker) => worker.role)])).sort()
+    : baseRoles;
+
+  const roleOptions = [
+    { value: "not_specified", label: "Not specified" },
+    ...uniqueRoles.map((role) => ({ value: role, label: role })),
+  ];
 
   return (
     <>
@@ -34,8 +42,8 @@ export default function FormFields() {
             <FormControl>
               <ComboBox
                 {...field}
-                options={uniqueRoles.map((role) => ({ value: role, label: role }))}
-                placeholder="Select or type a role"
+                options={roleOptions}
+                placeholder="Not specified"
               />
             </FormControl>
             <FormMessage />

--- a/frontend/app/people/page.tsx
+++ b/frontend/app/people/page.tsx
@@ -29,11 +29,13 @@ import { Switch } from "@/components/ui/switch";
 import TableSkeleton from "@/components/TableSkeleton";
 import { useQueryClient } from "@tanstack/react-query";
 
+const allowedRoles = ["not_specified", "designer", "developer"] as const;
 const schema = formSchema.extend({
   email: z.string().email(),
   startDate: z.instanceof(CalendarDate),
   documentTemplateId: z.string(),
   contractSignedElsewhere: z.boolean().default(false),
+  role: z.enum(allowedRoles),
 });
 
 const removeMailtoPrefix = (email: string) => email.replace(/^mailto:/iu, "");
@@ -49,7 +51,7 @@ export default function PeoplePage() {
   const form = useForm({
     values: {
       email: "",
-      role: lastContractor?.role ?? "",
+      role: "not_specified",
       documentTemplateId: "",
       payRateType: lastContractor?.payRateType ?? PayRateType.Hourly,
       payRateInSubunits: lastContractor?.payRateInSubunits ?? null,
@@ -96,7 +98,12 @@ export default function PeoplePage() {
       }),
       columnHelper.accessor("role", {
         header: "Role",
-        cell: (info) => info.getValue() || "N/A",
+        cell: (info) => {
+          const value = info.getValue();
+          if (value === "not_specified") return "Not specified";
+          if (!value) return "N/A";
+          return value.charAt(0).toUpperCase() + value.slice(1);
+        },
         meta: { filterOptions: [...new Set(workers.map((worker) => worker.role))] },
       }),
       columnHelper.simple("user.countryCode", "Country", (v) => v && countries.get(v)),

--- a/frontend/components/ComboBox.tsx
+++ b/frontend/components/ComboBox.tsx
@@ -32,7 +32,8 @@ const ComboBox = ({
           role="combobox"
           aria-expanded={open}
           {...props}
-          className={cn("justify-between", className)}
+          className={cn("justify-between text-base font-normal", className)}
+          style={{ fontFamily: 'abc whyte, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif', ...(props.style || {}) }}
         >
           <div className="truncate">
             {value?.length ? (multiple ? value.map(getLabel).join(", ") : getLabel(value)) : placeholder}

--- a/frontend/trpc/routes/contractors/index.ts
+++ b/frontend/trpc/routes/contractors/index.ts
@@ -88,7 +88,7 @@ export const contractorsRouter = createRouter({
         startedAt: z.string(),
         payRateInSubunits: z.number().nullable(),
         payRateType: z.nativeEnum(PayRateType),
-        role: z.string(),
+        role: z.string(), // allow empty string for 'Not specified'
         documentTemplateId: z.string(),
         contractSignedElsewhere: z.boolean().default(false),
       }),


### PR DESCRIPTION
Fixes #459  - Fix contractor invite role dropdown

## Changes
- Added default role options: "designer," "developer," and "Not specified"
- Set "Not specified" as default to prevent accidental auto-selection
- Improved styling consistency with email input field

https://github.com/user-attachments/assets/a8605dd9-83dc-47eb-b774-bcce089845f5

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added "Not specified" as a selectable option for the role field in forms and tables.
  * The role selection now always includes "designer" and "developer" options, in addition to any fetched roles.

* **Enhancements**
  * Improved display of role values in tables, showing "Not specified" or "N/A" where appropriate.
  * Updated ComboBox styling for improved visual consistency.

* **Bug Fixes**
  * Ensured form validation requires the role field to match allowed values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->