### PR TITLE
Refactor test auth flow to dynamically create Clerk users

### DIFF
--- a/e2e/factories/users.ts
+++ b/e2e/factories/users.ts
@@ -17,7 +17,7 @@ export const usersFactory = {
     const [user] = await db
       .insert(users)
       .values({
-        email: faker.internet.email().toLowerCase(),
+        email: `${faker.internet.email().split("@")[0]}+clerk_test@example.com`.toLowerCase(),
         legalName: faker.person.fullName(),
         preferredName: faker.person.firstName(),
         encryptedPassword: await bcrypt.hash("password", 10),
@@ -25,6 +25,8 @@ export const usersFactory = {
         invitationAcceptedAt: new Date(),
         currentSignInIp: faker.internet.ipv4(),
         lastSignInIp: faker.internet.ipv4(),
+        currentSignInAt: new Date(),
+        lastSignInAt: new Date(),
         streetAddress: "1st Street",
         city: "New York",
         state: "NY",

--- a/e2e/tests/login.spec.ts
+++ b/e2e/tests/login.spec.ts
@@ -1,3 +1,4 @@
+import { clerk } from "@clerk/testing/playwright";
 import { db } from "@test/db";
 import { usersFactory } from "@test/factories/users";
 import { setClerkUser } from "@test/helpers/auth";
@@ -7,13 +8,10 @@ import { users } from "@/db/schema";
 
 test("login", async ({ page }) => {
   const { user } = await usersFactory.create();
-  const { email } = await setClerkUser(user.id);
+  const { email } = await setClerkUser(user);
 
   await page.goto("/login");
-  await page.getByLabel("Email").fill(email);
-  await page.getByRole("button", { name: "Continue", exact: true }).click();
-  await page.getByLabel("Password", { exact: true }).fill("password");
-  await page.getByRole("button", { name: "Continue", exact: true }).click();
+  await clerk.signIn({ page, signInParams: { strategy: "email_code", identifier: email } });
 
   await expect(page.getByRole("heading", { name: "Invoices" })).toBeVisible();
 
@@ -27,16 +25,13 @@ test("login", async ({ page }) => {
 
 test("login with redirect_url", async ({ page }) => {
   const { user } = await usersFactory.create();
-  const { email } = await setClerkUser(user.id);
+  const { email } = await setClerkUser(user);
 
   await page.goto("/people");
 
   await page.waitForURL(/\/login\?.*redirect_url=%2Fpeople/u);
 
-  await page.getByLabel("Email").fill(email);
-  await page.getByRole("button", { name: "Continue", exact: true }).click();
-  await page.getByLabel("Password", { exact: true }).fill("password");
-  await page.getByRole("button", { name: "Continue", exact: true }).click();
+  await clerk.signIn({ page, signInParams: { strategy: "email_code", identifier: email } });
 
   await expect(page.getByRole("heading", { name: "People" })).toBeVisible();
 


### PR DESCRIPTION
- Removed hardcoded Clerk test users
- Dynamically creates Clerk users via API during test setup
- Updated `setClerkUser` and `login` helpers to support this flow
- Simplified email generation in user factory
- Ensured sign-in and sign-out flows work with the updated setup

<img width="904" height="322" alt="image" src="https://github.com/user-attachments/assets/ba023ea7-3ae5-4e34-a95c-d8dcad17e077" />
<img width="1670" height="863" alt="image" src="https://github.com/user-attachments/assets/4a2d8c18-8494-4ee6-a51f-14e6b8c46699" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Streamlined test user management by removing hardcoded test users and simplifying setup and cleanup logic.
  * Updated helper functions to work with full user objects instead of just user IDs.
  * Improved user creation for tests by adjusting email formatting and adding sign-in timestamp fields.

* **Tests**
  * Simplified login tests by using direct sign-in methods, reducing manual form interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->