### PR TITLE
feat: add skeleton loader for tables

### DIFF
--- a/frontend/app/equity/grants/page.tsx
+++ b/frontend/app/equity/grants/page.tsx
@@ -7,6 +7,7 @@ import DataTable, { createColumnHelper, useTable } from "@/components/DataTable"
 import { linkClasses } from "@/components/Link";
 import MutationButton from "@/components/MutationButton";
 import Placeholder from "@/components/Placeholder";
+import TableSkeleton from "@/components/TableSkeleton";
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import { Button } from "@/components/ui/button";
 import {
@@ -29,7 +30,7 @@ type EquityGrant = RouterOutput["equityGrants"]["list"][number];
 export default function GrantsPage() {
   const router = useRouter();
   const company = useCurrentCompany();
-  const [data, { refetch }] = trpc.equityGrants.list.useSuspenseQuery({ companyId: company.id });
+  const { data = [], isLoading, refetch } = trpc.equityGrants.list.useQuery({ companyId: company.id });
   const [cancellingGrantId, setCancellingGrantId] = useState<string | null>(null);
   const cancellingGrant = data.find((grant) => grant.id === cancellingGrantId);
   const cancelGrant = trpc.equityGrants.cancel.useMutation({
@@ -101,7 +102,9 @@ export default function GrantsPage() {
           </AlertDescription>
         </Alert>
       ) : null}
-      {data.length > 0 ? (
+      {isLoading ? (
+        <TableSkeleton columns={8} />
+      ) : data.length > 0 ? (
         <DataTable table={table} onRowClicked={(row) => router.push(`/people/${row.user.id}`)} />
       ) : (
         <Placeholder icon={CircleCheck}>There are no option grants right now.</Placeholder>

--- a/frontend/app/equity/option_pools/page.tsx
+++ b/frontend/app/equity/option_pools/page.tsx
@@ -3,6 +3,7 @@ import { CircleCheck } from "lucide-react";
 import React from "react";
 import DataTable, { createColumnHelper, useTable } from "@/components/DataTable";
 import Placeholder from "@/components/Placeholder";
+import TableSkeleton from "@/components/TableSkeleton";
 import { Progress } from "@/components/ui/progress";
 import { useCurrentCompany } from "@/global";
 import type { RouterOutput } from "@/trpc";
@@ -27,13 +28,15 @@ const columns = [
 
 export default function OptionPools() {
   const company = useCurrentCompany();
-  const [data] = trpc.optionPools.list.useSuspenseQuery({ companyId: company.id });
+  const { data = [], isLoading } = trpc.optionPools.list.useQuery({ companyId: company.id });
 
   const table = useTable({ columns, data });
 
   return (
     <EquityLayout>
-      {data.length > 0 ? (
+      {isLoading ? (
+        <TableSkeleton columns={5} />
+      ) : data.length > 0 ? (
         <DataTable table={table} />
       ) : (
         <Placeholder icon={CircleCheck}>The company does not have any option pools.</Placeholder>

--- a/frontend/app/equity/shares/page.tsx
+++ b/frontend/app/equity/shares/page.tsx
@@ -3,6 +3,7 @@ import { CheckCircleIcon } from "@heroicons/react/24/outline";
 import React from "react";
 import DataTable, { createColumnHelper, useTable } from "@/components/DataTable";
 import Placeholder from "@/components/Placeholder";
+import TableSkeleton from "@/components/TableSkeleton";
 import { useCurrentCompany, useCurrentUser } from "@/global";
 import type { RouterOutput } from "@/trpc";
 import { trpc } from "@/trpc/client";
@@ -22,7 +23,7 @@ const columns = [
 export default function Shares() {
   const company = useCurrentCompany();
   const user = useCurrentUser();
-  const [shareHoldings] = trpc.shareHoldings.list.useSuspenseQuery({
+  const { data: shareHoldings = [], isLoading } = trpc.shareHoldings.list.useQuery({
     companyId: company.id,
     investorId: user.roles.investor?.id ?? "",
   });
@@ -31,7 +32,9 @@ export default function Shares() {
 
   return (
     <EquityLayout>
-      {shareHoldings.length > 0 ? (
+      {isLoading ? (
+        <TableSkeleton columns={5} />
+      ) : shareHoldings.length > 0 ? (
         <DataTable table={table} />
       ) : (
         <Placeholder icon={CheckCircleIcon}>You do not hold any shares.</Placeholder>

--- a/frontend/app/equity/tender_offers/page.tsx
+++ b/frontend/app/equity/tender_offers/page.tsx
@@ -5,6 +5,7 @@ import { useRouter } from "next/navigation";
 import React from "react";
 import DataTable, { createColumnHelper, useTable } from "@/components/DataTable";
 import Placeholder from "@/components/Placeholder";
+import TableSkeleton from "@/components/TableSkeleton";
 import { Button } from "@/components/ui/button";
 import { useCurrentCompany, useCurrentUser } from "@/global";
 import type { RouterOutput } from "@/trpc";
@@ -17,7 +18,7 @@ export default function Buybacks() {
   const company = useCurrentCompany();
   const router = useRouter();
   const user = useCurrentUser();
-  const [data] = trpc.tenderOffers.list.useSuspenseQuery({ companyId: company.id });
+  const { data = [], isLoading } = trpc.tenderOffers.list.useQuery({ companyId: company.id });
 
   const columnHelper = createColumnHelper<RouterOutput["tenderOffers"]["list"][number]>();
   const columns = [
@@ -44,7 +45,9 @@ export default function Buybacks() {
         ) : null
       }
     >
-      {data.length ? (
+      {isLoading ? (
+        <TableSkeleton columns={3} />
+      ) : data.length ? (
         <DataTable table={table} onRowClicked={(row) => router.push(`/equity/tender_offers/${row.id}`)} />
       ) : (
         <Placeholder icon={CircleCheck}>There are no buybacks yet.</Placeholder>


### PR DESCRIPTION
PR for Issue : #411 

---

Tables covered:
- Option Pools
- Equity Grants
- Shares
- Buybacks

---

https://github.com/user-attachments/assets/d044e91a-0244-425d-a2cb-f0730c54afee


---

Test Status:

<img width="1289" height="234" alt="tests" src="https://github.com/user-attachments/assets/1a784ae5-6cdf-4449-92f0-e30574b01cb4" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added loading skeletons for equity grants, option pools, share holdings, and tender offers pages to improve user experience while data is loading.

* **Refactor**
  * Updated data loading approach across equity-related pages to provide explicit loading state handling and a more consistent interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->