### PR TITLE
fix: Update breadcrumb messages for equity buybacks in payout service

### DIFF
--- a/backend/app/services/pay_investor_equity_buybacks.rb
+++ b/backend/app/services/pay_investor_equity_buybacks.rb
@@ -43,7 +43,7 @@ class PayInvestorEquityBuybacks
       amount = net_amount_in_usd
     else
       exchange_rate = payout_service.get_exchange_rate(target_currency:).first["rate"]
-      Bugsnag.leave_breadcrumb("PayInvestorDividends - fetched exchange rate",
+      Bugsnag.leave_breadcrumb("PayInvestorEquityBuybacks - fetched exchange rate",
                                { response: exchange_rate }, Bugsnag::Breadcrumbs::LOG_BREADCRUMB_TYPE)
       amount = net_amount_in_usd * exchange_rate
     end
@@ -60,7 +60,7 @@ class PayInvestorEquityBuybacks
       raise WiseError, "Bank account is no longer active for equity buyback payment #{equity_buyback_payment.id}"
     end
     quote = payout_service.create_quote(target_currency:, amount:, recipient_id: bank_account.recipient_id)
-    Bugsnag.leave_breadcrumb("PayInvestorDividends - received quote",
+    Bugsnag.leave_breadcrumb("PayInvestorEquityBuybacks - received quote",
                              { response: quote }, Bugsnag::Breadcrumbs::LOG_BREADCRUMB_TYPE)
     quote_id = quote["id"]
     raise WiseError, "Creating quote failed for equity buyback payment #{equity_buyback_payment.id}" unless quote_id.present?
@@ -74,7 +74,7 @@ class PayInvestorEquityBuybacks
     transfer = payout_service.create_transfer(quote_id:, recipient_id: bank_account.recipient_id,
                                               unique_transaction_id: equity_buyback_payment.processor_uuid,
                                               reference: equity_buyback_payment.wise_transfer_reference)
-    Bugsnag.leave_breadcrumb("PayInvestorDividends - created transfer",
+    Bugsnag.leave_breadcrumb("PayInvestorEquityBuybacks - created transfer",
                              { response: transfer }, Bugsnag::Breadcrumbs::LOG_BREADCRUMB_TYPE)
     transfer_id = transfer["id"]
     raise WiseError, "Creating transfer failed for equity buyback payment #{equity_buyback_payment.id}" unless transfer_id.present?
@@ -84,7 +84,7 @@ class PayInvestorEquityBuybacks
                                    recipient_last4: bank_account.last_four_digits)
     response = payout_service.fund_transfer(transfer_id:)
 
-    Bugsnag.leave_breadcrumb("PayInvestorDividends - funded transfer",
+    Bugsnag.leave_breadcrumb("PayInvestorEquityBuybacks - funded transfer",
                              { response: }, Bugsnag::Breadcrumbs::LOG_BREADCRUMB_TYPE)
     unless response["status"] == "COMPLETED"
       raise WiseError, "Funding transfer failed for equity buyback payment #{equity_buyback_payment.id}"


### PR DESCRIPTION
This PR corrects several copy-paste errors in the Bugsnag logging within the `PayInvestorEquityBuybacks` service. The original breadcrumb messages incorrectly identified the service as `PayInvestorDividends`.

Change Details:
-   Updated the string literals in four `Bugsnag.leave_breadcrumb` calls to correctly reference `PayInvestorEquityBuybacks`.
-   This change is purely a bug fix for our internal logging and has no impact on the service's runtime 