### PR TITLE
fix: use GlobalConfig for Wise credentials and allow sandbox API in CSP

### DIFF
--- a/backend/config/initializers/wise.rb
+++ b/backend/config/initializers/wise.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
-WISE_API_KEY = ENV["WISE_API_KEY"]
-WISE_PROFILE_ID = ENV["WISE_PROFILE_ID"]
+WISE_API_KEY = GlobalConfig.get("WISE_API_KEY")
+WISE_PROFILE_ID = GlobalConfig.get("WISE_PROFILE_ID")
 WISE_API_URL = Rails.env.production? ? "https://api.transferwise.com" : "https://api.sandbox.transferwise.tech"

--- a/frontend/middleware.ts
+++ b/frontend/middleware.ts
@@ -12,6 +12,7 @@ export default clerkMiddleware((_, req) => {
     .map((bucket) => `https://${bucket}.s3.${env.AWS_REGION}.amazonaws.com https://${bucket}.s3.amazonaws.com`)
     .join(" ");
   const helperHost = env.HELPER_WIDGET_HOST ?? "";
+  const wiseUrl = NODE_ENV === "production" ? "" : "https://api.sandbox.transferwise.tech";
 
   const cspHeader = `
     default-src 'self';
@@ -19,7 +20,7 @@ export default clerkMiddleware((_, req) => {
       NODE_ENV === "production" ? "" : `'unsafe-eval'` // required by Clerk, as is style-src 'unsafe-inline' and worker-src blob:.
     };
     style-src 'self' 'unsafe-inline';
-    connect-src 'self' ${clerkFapiUrl} https://docuseal.com ${s3Urls} ${helperHost};
+    connect-src 'self' ${clerkFapiUrl} https://docuseal.com ${wiseUrl} ${s3Urls} ${helperHost};
     img-src 'self' blob: https://img.clerk.com https://docuseal.s3.amazonaws.com ${s3Urls};
     worker-src 'self' blob:;
     font-src 'self';


### PR DESCRIPTION
- Updated backend to load `WISE_API_KEY` and `WISE_PROFILE_ID` via `GlobalConfig` instead of direct ENV access.
- Fixed CSP issue in middleware where requests to `https://api.sandbox.transferwise.tech` were getting blocked during development.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated configuration handling for API keys to improve environment variable management.

* **Refactor**
  * Adjusted how environment-specific URLs are handled for external API connections.

* **Style**
  * Updated Content Security Policy settings to allow connections to the sandbox API in non-production environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->