### PR TITLE
fix(ui): improve responsiveness for Terms & Privacy pages and enable full-page print

### DIFF
--- a/frontend/app/(public)/layout.tsx
+++ b/frontend/app/(public)/layout.tsx
@@ -4,14 +4,14 @@ import logo from "@/images/flexile-logo.svg";
 
 export default function PublicLayout({ children }: { children: React.ReactNode }) {
   return (
-    <div className="flex h-full flex-col">
+    <div className="flex h-full flex-col print:block">
       <header className="flex w-full items-center justify-center bg-black p-6 text-white print:hidden">
         <a href="https://flexile.com/" className="invert" rel="noopener noreferrer">
           <Image src={logo} alt="Flexile" />
         </a>
       </header>
-      <main className="flex flex-1 flex-col items-center overflow-y-auto px-3 py-3">
-        <div className="my-auto grid w-full max-w-md gap-4 pt-7 print:my-0 print:max-w-full">{children}</div>
+      <main className="flex flex-1 flex-col items-center overflow-y-auto px-3 py-3 print:overflow-visible">
+        <div className="my-auto grid gap-4 pt-7">{children}</div>
       </main>
     </div>
   );


### PR DESCRIPTION
Solves Issue #566 

Description:
This PR improves the layout responsiveness and printing behavior of the Terms and Privacy Policy pages.

Before:

https://github.com/user-attachments/assets/be0b25de-3264-41f3-a957-77b96b9ced53


After:

https://github.com/user-attachments/assets/237d019c-b039-4952-a699-db54399ac29c



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved print layout by adjusting display, visibility, and overflow styles for better print rendering.
  * Header is now hidden when printing, and main content adapts for optimal print output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->