### PR TITLE
feat: add skeleton loader for tables

### DIFF
--- a/frontend/app/equity/cap_table/page.tsx
+++ b/frontend/app/equity/cap_table/page.tsx
@@ -6,6 +6,7 @@ import CopyButton from "@/components/CopyButton";
 import DataTable, { createColumnHelper, useTable } from "@/components/DataTable";
 import { linkClasses } from "@/components/Link";
 import Placeholder from "@/components/Placeholder";
+import TableSkeleton from "@/components/TableSkeleton";
 import { Alert, AlertDescription } from "@/components/ui/alert";
 import { useCurrentCompany, useCurrentUser } from "@/global";
 import {
@@ -26,7 +27,13 @@ export default function CapTable() {
   const company = useCurrentCompany();
   const searchParams = useSearchParams();
   const newSchema = searchParams.get("new_schema") !== null;
-  const [data] = trpc.capTable.show.useSuspenseQuery({ companyId: company.id, newSchema });
+  const {
+    data = { investors: [], shareClasses: [], optionPools: [], outstandingShares: "", fullyDilutedShares: "" },
+    isLoading,
+  } = trpc.capTable.show.useQuery({
+    companyId: company.id,
+    newSchema,
+  });
   const user = useCurrentUser();
   const canViewInvestor = !!user.roles.administrator || !!user.roles.lawyer;
 
@@ -171,7 +178,9 @@ export default function CapTable() {
         </Alert>
       )}
 
-      {data.investors.length > 0 ? (
+      {isLoading ? (
+        <TableSkeleton columns={6} />
+      ) : data.investors.length > 0 ? (
         <div className="overflow-x-auto">
           <DataTable table={investorsTable} caption="Investors" />
         </div>
@@ -179,10 +188,15 @@ export default function CapTable() {
         <Placeholder icon={CircleCheck}>There are no active investors right now.</Placeholder>
       )}
 
-      {data.investors.length > 0 && data.shareClasses.length > 0 && (
-        <div className="overflow-x-auto">
-          <DataTable table={shareClassesTable} caption="Share Classes" />
-        </div>
+      {isLoading ? (
+        <TableSkeleton columns={5} />
+      ) : (
+        data.investors.length > 0 &&
+        data.shareClasses.length > 0 && (
+          <div className="overflow-x-auto">
+            <DataTable table={shareClassesTable} caption="Share Classes" />
+          </div>
+        )
       )}
     </EquityLayout>
   );

--- a/frontend/app/equity/convertibles/page.tsx
+++ b/frontend/app/equity/convertibles/page.tsx
@@ -3,6 +3,7 @@ import { CircleCheck } from "lucide-react";
 import React from "react";
 import DataTable, { createColumnHelper, useTable } from "@/components/DataTable";
 import Placeholder from "@/components/Placeholder";
+import TableSkeleton from "@/components/TableSkeleton";
 import { useCurrentCompany, useCurrentUser } from "@/global";
 import type { RouterOutput } from "@/trpc";
 import { trpc } from "@/trpc/client";
@@ -22,7 +23,7 @@ const columns = [
 export default function Convertibles() {
   const company = useCurrentCompany();
   const user = useCurrentUser();
-  const [data] = trpc.convertibleSecurities.list.useSuspenseQuery({
+  const { data = { convertibleSecurities: [] }, isLoading } = trpc.convertibleSecurities.list.useQuery({
     companyId: company.id,
     investorId: user.roles.investor?.id ?? "",
   });
@@ -31,7 +32,9 @@ export default function Convertibles() {
 
   return (
     <EquityLayout>
-      {data.convertibleSecurities.length > 0 ? (
+      {isLoading ? (
+        <TableSkeleton columns={4} />
+      ) : data.convertibleSecurities.length > 0 ? (
         <DataTable table={table} />
       ) : (
         <Placeholder icon={CircleCheck}>You do not hold any convertible securities.</Placeholder>

--- a/frontend/app/equity/dividends/page.tsx
+++ b/frontend/app/equity/dividends/page.tsx
@@ -10,6 +10,7 @@ import { linkClasses } from "@/components/Link";
 import MutationButton from "@/components/MutationButton";
 import Placeholder from "@/components/Placeholder";
 import RichText from "@/components/RichText";
+import TableSkeleton from "@/components/TableSkeleton";
 import { Alert, AlertDescription } from "@/components/ui/alert";
 import { Avatar, AvatarImage } from "@/components/ui/avatar";
 import { Button } from "@/components/ui/button";
@@ -37,7 +38,11 @@ const columnHelper = createColumnHelper<Dividend>();
 export default function Dividends() {
   const company = useCurrentCompany();
   const user = useCurrentUser();
-  const [data, { refetch }] = trpc.dividends.list.useSuspenseQuery({
+  const {
+    data = [],
+    refetch,
+    isLoading,
+  } = trpc.dividends.list.useQuery({
     companyId: company.id,
     investorId: user.roles.investor?.id,
   });
@@ -141,7 +146,9 @@ export default function Dividends() {
           </AlertDescription>
         </Alert>
       ) : null}
-      {data.length > 0 ? (
+      {isLoading ? (
+        <TableSkeleton columns={7} />
+      ) : data.length > 0 ? (
         <DataTable table={table} />
       ) : (
         <Placeholder icon={CircleCheck}>You have not been issued any dividends yet.</Placeholder>

--- a/frontend/app/equity/options/page.tsx
+++ b/frontend/app/equity/options/page.tsx
@@ -11,6 +11,7 @@ import EquityLayout from "@/app/equity/Layout";
 import DataTable, { createColumnHelper, useTable } from "@/components/DataTable";
 import MutationButton from "@/components/MutationButton";
 import Placeholder from "@/components/Placeholder";
+import TableSkeleton from "@/components/TableSkeleton";
 import { Alert, AlertDescription } from "@/components/ui/alert";
 import { Button } from "@/components/ui/button";
 import { useCurrentCompany, useCurrentUser } from "@/global";
@@ -41,7 +42,7 @@ export default function OptionsPage() {
   const company = useCurrentCompany();
   const user = useCurrentUser();
   if (!user.roles.investor) forbidden();
-  const [data] = trpc.equityGrants.list.useSuspenseQuery({
+  const { data = [], isLoading } = trpc.equityGrants.list.useQuery({
     companyId: company.id,
     investorId: user.roles.investor.id,
     orderBy: "periodEndedAt" as const,
@@ -95,7 +96,9 @@ export default function OptionsPage() {
 
   return (
     <EquityLayout>
-      {data.length === 0 ? (
+      {isLoading ? (
+        <TableSkeleton columns={5} />
+      ) : data.length === 0 ? (
         <Placeholder icon={CircleCheck}>You don't have any option grants right now.</Placeholder>
       ) : (
         <>


### PR DESCRIPTION
PR for Issue : #411 

---

Tables covered:
- Convertibles
- Dividends
- Cap Table
- Options

---

https://github.com/user-attachments/assets/faf08342-9629-4331-9221-467bfb3cb642

https://github.com/user-attachments/assets/56e2e3a1-a423-4885-af9a-5d5131419423

---

Test suite:

<img width="1269" height="375" alt="tests-1" src="https://github.com/user-attachments/assets/b7120875-fcc9-41fb-8457-155668d827d4" />
