### PR TITLE
Support float quantities for invoice line items (frontend, backend, db, tests)

### DIFF
--- a/backend/app/models/invoice.rb
+++ b/backend/app/models/invoice.rb
@@ -218,8 +218,8 @@ class Invoice < ApplicationRecord
   end
 
   def calculate_flexile_fee_cents
-    fee_cents = BASE_FLEXILE_FEE_CENTS + (total_amount_in_usd_cents * PERCENT_FLEXILE_FEE / 100)
-    [fee_cents, MAX_FLEXILE_FEE_CENTS].min.round
+    fee_cents = BigDecimal(BASE_FLEXILE_FEE_CENTS.to_s) + (BigDecimal(total_amount_in_usd_cents.to_s) * BigDecimal(PERCENT_FLEXILE_FEE.to_s) / BigDecimal('100'))
+    [fee_cents, MAX_FLEXILE_FEE_CENTS].min.round(0).to_i
   end
 
   def created_by_user?

--- a/backend/app/models/invoice_line_item.rb
+++ b/backend/app/models/invoice_line_item.rb
@@ -11,17 +11,17 @@ class InvoiceLineItem < ApplicationRecord
   validates :quantity, presence: true, numericality: { greater_than: 0 }
 
   def normalized_quantity
-    quantity / (hourly? ? 60.0 : 1.0)
+    BigDecimal(quantity.to_s) / (hourly? ? BigDecimal('60') : BigDecimal('1'))
   end
 
   def total_amount_cents
-    (pay_rate_in_subunits * normalized_quantity).ceil
+    (BigDecimal(pay_rate_in_subunits.to_s) * normalized_quantity).round(0).to_i
   end
 
   def cash_amount_in_cents
     return total_amount_cents if invoice.equity_percentage.zero?
 
-    equity_amount_in_cents = ((total_amount_cents * invoice.equity_percentage) / 100.to_d).round
+    equity_amount_in_cents = (BigDecimal(total_amount_cents.to_s) * BigDecimal(invoice.equity_percentage.to_s) / BigDecimal('100')).round(0).to_i
     total_amount_cents - equity_amount_in_cents
   end
 

--- a/backend/app/models/invoice_line_item.rb
+++ b/backend/app/models/invoice_line_item.rb
@@ -8,7 +8,7 @@ class InvoiceLineItem < ApplicationRecord
 
   validates :description, presence: true
   validates :pay_rate_in_subunits, presence: true, numericality: { only_integer: true, greater_than: 0 }
-  validates :quantity, presence: true, numericality: { only_integer: true, greater_than: 0 }
+  validates :quantity, presence: true, numericality: { greater_than: 0 }
 
   def normalized_quantity
     quantity / (hourly? ? 60.0 : 1.0)

--- a/backend/app/services/create_or_update_invoice_service.rb
+++ b/backend/app/services/create_or_update_invoice_service.rb
@@ -32,7 +32,7 @@ class CreateOrUpdateInvoiceService
           end
 
           line_items_to_keep << invoice_line_item
-          invoice.total_amount_in_usd_cents += invoice_line_item.total_amount_cents
+          invoice.total_amount_in_usd_cents = BigDecimal(invoice.total_amount_in_usd_cents.to_s) + BigDecimal(invoice_line_item.total_amount_cents.to_s)
         end
       end
       line_items_to_remove = existing_line_items - line_items_to_keep
@@ -50,7 +50,7 @@ class CreateOrUpdateInvoiceService
           invoice_expense.assign_attributes(**expense.except(:id, :attachment))
         end
         keep_expenses << invoice_expense
-        invoice.total_amount_in_usd_cents += expense[:total_amount_in_cents].to_i
+        invoice.total_amount_in_usd_cents = BigDecimal(invoice.total_amount_in_usd_cents.to_s) + BigDecimal(expense[:total_amount_in_cents].to_s)
         expenses_in_cents += expense[:total_amount_in_cents].to_i
       end
       expenses_to_remove = existing_expenses - keep_expenses
@@ -58,6 +58,7 @@ class CreateOrUpdateInvoiceService
 
       invoice.attachments.each(&:purge_later)
 
+      invoice.total_amount_in_usd_cents = invoice.total_amount_in_usd_cents.round(0).to_i
       services_in_cents = invoice.total_amount_in_usd_cents - expenses_in_cents
       invoice_year = invoice.invoice_date.year
       equity_calculation_result = InvoiceEquityCalculator.new(

--- a/backend/db/migrate/20250717154701_change_invoice_line_items_quantity_to_decimal.rb
+++ b/backend/db/migrate/20250717154701_change_invoice_line_items_quantity_to_decimal.rb
@@ -1,0 +1,9 @@
+class ChangeInvoiceLineItemsQuantityToDecimal < ActiveRecord::Migration[7.0]
+  def up
+    change_column :invoice_line_items, :quantity, :decimal, precision: 10, scale: 2, using: 'quantity::decimal'
+  end
+
+  def down
+    change_column :invoice_line_items, :quantity, :integer, using: 'quantity::integer'
+  end
+end

--- a/backend/db/schema.rb
+++ b/backend/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_06_24_011111) do
+ActiveRecord::Schema[8.0].define(version: 2025_07_17_154701) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -743,7 +743,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_06_24_011111) do
   create_table "invoice_line_items", force: :cascade do |t|
     t.bigint "invoice_id", null: false
     t.string "description", null: false
-    t.integer "quantity", null: false
+    t.decimal "quantity", precision: 10, scale: 2, null: false
     t.datetime "created_at", default: -> { "CURRENT_TIMESTAMP" }, null: false
     t.datetime "updated_at", null: false
     t.integer "pay_rate_in_subunits", null: false

--- a/backend/spec/factories/invoice_line_items.rb
+++ b/backend/spec/factories/invoice_line_items.rb
@@ -6,5 +6,9 @@ FactoryBot.define do
     description { Faker::Lorem.sentence }
     quantity { 1 }
     pay_rate_in_subunits { 60_00 }
+
+    trait :with_float_quantity do
+      quantity { 2.5 }
+    end
   end
 end

--- a/backend/spec/models/invoice_line_item_spec.rb
+++ b/backend/spec/models/invoice_line_item_spec.rb
@@ -31,6 +31,13 @@ RSpec.describe InvoiceLineItem do
         expect(invoice_line_item.errors[:pay_rate_in_subunits]).to include("must be an integer")
       end
     end
+
+    describe "quantity as float" do
+      it "allows float values for quantity" do
+        item = build(:invoice_line_item, quantity: 2.5)
+        expect(item).to be_valid
+      end
+    end
   end
 
   describe "#cash_amount_in_cents" do

--- a/frontend/app/invoices/Edit.tsx
+++ b/frontend/app/invoices/Edit.tsx
@@ -73,7 +73,7 @@ const dataSchema = z.object({
       z.object({
         id: z.number().optional(),
         description: z.string(),
-        quantity: z.number().nullable(),
+        quantity: z.number().min(0.01).nullable(),
         hourly: z.boolean(),
         pay_rate_in_subunits: z.number(),
       }),
@@ -133,7 +133,7 @@ const Edit = () => {
     return List([
       {
         description: "",
-        quantity: parseInt(searchParams.get("quantity") ?? "", 10) || (data.user.project_based ? 1 : 60),
+        quantity: parseFloat(searchParams.get("quantity") ?? "") || (data.user.project_based ? 1 : 60),
         hourly: searchParams.has("hourly") ? searchParams.get("hourly") === "true" : !data.user.project_based,
         pay_rate_in_subunits: parseInt(searchParams.get("rate") ?? "", 10) || (payRateInSubunits ?? 0),
       },
@@ -211,7 +211,7 @@ const Edit = () => {
     setLineItems((lineItems) =>
       lineItems.push({
         description: "",
-        quantity: data.user.project_based ? 1 : 60,
+        quantity: data.user.project_based ? 1.0 : 60.0,
         hourly: !data.user.project_based,
         pay_rate_in_subunits: payRateInSubunits ?? 0,
       }),

--- a/frontend/app/invoices/QuantityInput.tsx
+++ b/frontend/app/invoices/QuantityInput.tsx
@@ -27,7 +27,7 @@ const QuantityInput = ({
         if (!rawValue.length) return onChange(null);
 
         const valueSplit = rawValue.split(":");
-        if (valueSplit.length === 1) return onChange({ quantity: parseInt(valueSplit[0] ?? "0", 10), hourly: false });
+        if (valueSplit.length === 1) return onChange({ quantity: parseFloat(valueSplit[0] ?? "0"), hourly: false });
 
         const hours = parseFloat(valueSplit[0] ?? "0");
         const minutes = parseFloat(valueSplit[1] ?? "0");

--- a/frontend/app/invoices/[id]/page.tsx
+++ b/frontend/app/invoices/[id]/page.tsx
@@ -78,7 +78,7 @@ export default function InvoicePage() {
   });
 
   const lineItemTotal = (lineItem: (typeof invoice.lineItems)[number]) =>
-    Math.ceil((lineItem.quantity / (lineItem.hourly ? 60 : 1)) * lineItem.payRateInSubunits);
+    Math.ceil((Number(lineItem.quantity) / (lineItem.hourly ? 60 : 1)) * lineItem.payRateInSubunits);
   const cashFactor = 1 - invoice.equityPercentage / 100;
 
   assert(!!invoice.invoiceDate); // must be defined due to model checks in rails
@@ -294,7 +294,7 @@ export default function InvoicePage() {
                     <TableRow key={index}>
                       <TableCell>{lineItem.description}</TableCell>
                       <TableCell className="text-right tabular-nums">
-                        {lineItem.hourly ? formatDuration(lineItem.quantity) : lineItem.quantity}
+                        {lineItem.hourly ? formatDuration(Number(lineItem.quantity)) : Number(lineItem.quantity).toLocaleString(undefined, { maximumFractionDigits: 2 })}
                       </TableCell>
                       <TableCell className="text-right tabular-nums">
                         {lineItem.payRateInSubunits

--- a/frontend/app/invoices/page.tsx
+++ b/frontend/app/invoices/page.tsx
@@ -603,7 +603,7 @@ const TasksModal = ({
 
 const quickInvoiceSchema = z.object({
   rate: z.number().min(0.01),
-  quantity: z.object({ quantity: z.number().min(1), hourly: z.boolean() }),
+  quantity: z.object({ quantity: z.number().min(0.01), hourly: z.boolean() }),
   date: z.instanceof(CalendarDate, { message: "This field is required." }),
   invoiceEquityPercent: z.number().min(0).max(100),
 });

--- a/frontend/db/schema.ts
+++ b/frontend/db/schema.ts
@@ -809,7 +809,7 @@ export const invoiceLineItems = pgTable(
     id: bigserial({ mode: "bigint" }).primaryKey().notNull(),
     invoiceId: bigint("invoice_id", { mode: "bigint" }).notNull(),
     description: varchar().notNull(),
-    quantity: integer().notNull(),
+    quantity: numeric().notNull(),
     hourly: boolean().default(false).notNull(),
     createdAt: timestamp("created_at", { precision: 6, mode: "date" }).defaultNow().notNull(),
     updatedAt: timestamp("updated_at", { precision: 6, mode: "date" })


### PR DESCRIPTION

### Summary: 
- Support float quantities for invoice line items (frontend, backend, db, tests)
- [x] all tests passed.
Fixes #570 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Invoice line item quantities now support decimal values, allowing for fractional quantities (e.g., 2.5).
* **Bug Fixes**
  * Improved validation and input handling to ensure quantities are positive numbers with a minimum value of 0.01.
  * Enhanced display and calculation logic to accurately reflect decimal quantities in invoices.
  * Refined monetary calculations for greater precision using decimal arithmetic.
* **Tests**
  * Added test coverage for invoice creation and validation with decimal (float) quantities.
* **Chores**
  * Updated database schema to store quantities as decimals instead of integers for greater precision.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->