### PR TITLE
feat: remove server.pid before start to avoid port conflicts

### DIFF
--- a/bin/dev
+++ b/bin/dev
@@ -22,6 +22,7 @@ echo "Starting application services"
 kill_process_listening_on_port 3000
 kill_process_listening_on_port 3001
 kill_process_listening_on_port 8288 # inngest
+rm -f backend/tmp/pids/server.pid
 
 export NODE_EXTRA_CA_CERTS="$(node docker/createCertificate.js)"
 make local


### PR DESCRIPTION
fix: #597 

### What:
This PR ensures that the Rails server starts cleanly by removing any existing `tmp/pids/server.pid` file before startup. This resolves the common issue of the server failing to start due to a stale PID file blocking the default port

### Why
Without this fix, developers may encounter port conflict errors

Issue image:
<img width="739" height="673" alt="Screenshot 2025-07-20 at 4 36 23 PM" src="https://github.com/user-attachments/assets/933e4a9f-6a80-4372-aa9e-76860d85c1d8" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved startup reliability by automatically removing stale server process files before launching application services.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->