### PR TITLE
fix(dev): auto-fix ESLint import/order via VS Code settings

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -13,5 +13,8 @@
   "[javascript]": {
     "editor.defaultFormatter": "esbenp.prettier-vscode"
   },
+  "editor.codeActionsOnSave": {
+    "source.fixAll.eslint": "explicit"
+  },
   "eslint.format.enable": true
 }


### PR DESCRIPTION
Before:-
It was really frustrating to fix the Eslint warning about `import/order` every time you are working on task.

After:-
import order automatically fixed when you click save(CMD+S) in VSCode/ Cursor. This is much better solution than completely removing the config https://github.com/antiwork/flexile/pull/196


https://github.com/user-attachments/assets/b9a33448-4fc5-4147-a89e-92a3ad97c830

