### PR TITLE
FIX: #605 Documents Navigation Missing Badge Count for Unsigned Documents 

### DIFF
--- a/frontend/app/(dashboard)/documents/index.tsx
+++ b/frontend/app/(dashboard)/documents/index.tsx
@@ -1,0 +1,42 @@
+import { useCurrentUser } from "@/global";
+import type { RouterOutput } from "@/trpc";
+
+type Document = RouterOutput["documents"]["list"][number];
+type SignableDocument = Document & { docusealSubmissionId: number };
+
+export function useIsDocumentSignable() {
+  const user = useCurrentUser();
+  const isCompanyRepresentative = user.roles.administrator || user.roles.lawyer;
+
+  return (document: Document): document is SignableDocument => {
+    // For badge purposes, we want to show documents that need signatures
+    // regardless of whether they have a DocuSeal submission ID yet
+    const hasUnsignedSignatories = document.signatories.some(
+      (signatory) =>
+        !signatory.signedAt &&
+        (signatory.id === user.id || (signatory.title === "Company Representative" && isCompanyRepresentative)),
+    );
+
+    // Keep the original logic that requires docusealSubmissionId for actual signing
+    const hasDocusealId = !!document.docusealSubmissionId;
+    const result = hasDocusealId && hasUnsignedSignatories;
+
+    return result;
+  };
+}
+
+// New function for badge counting that doesn't require docusealSubmissionId
+export function useIsDocumentSignatureRequired() {
+  const user = useCurrentUser();
+  const isCompanyRepresentative = user.roles.administrator || user.roles.lawyer;
+
+  return (document: Document): boolean => {
+    const hasUnsignedSignatories = document.signatories.some(
+      (signatory) =>
+        !signatory.signedAt &&
+        (signatory.id === user.id || (signatory.title === "Company Representative" && isCompanyRepresentative)),
+    );
+
+    return hasUnsignedSignatories;
+  };
+}

--- a/frontend/app/(dashboard)/documents/page.tsx
+++ b/frontend/app/(dashboard)/documents/page.tsx
@@ -19,6 +19,7 @@ import { useQueryState } from "nuqs";
 import React, { useEffect, useMemo, useState } from "react";
 import { useForm } from "react-hook-form";
 import { z } from "zod";
+import { useIsDocumentSignable } from "@/app/(dashboard)/documents";
 import DocusealForm, { customCss } from "@/app/(dashboard)/documents/DocusealForm";
 import { FinishOnboarding } from "@/app/(dashboard)/documents/FinishOnboarding";
 import { DashboardHeader } from "@/components/DashboardHeader";
@@ -236,13 +237,7 @@ export default function DocumentsPage() {
   );
   const [signDocumentParam] = useQueryState("sign");
   const [signDocumentId, setSignDocumentId] = useState<bigint | null>(null);
-  const isSignable = (document: Document): document is SignableDocument =>
-    !!document.docusealSubmissionId &&
-    document.signatories.some(
-      (signatory) =>
-        !signatory.signedAt &&
-        (signatory.id === user.id || (signatory.title === "Company Representative" && isCompanyRepresentative)),
-    );
+  const isSignable = useIsDocumentSignable();
   const signDocument = signDocumentId
     ? documents.find((document): document is SignableDocument => document.id === signDocumentId && isSignable(document))
     : null;

--- a/frontend/app/(dashboard)/layout.tsx
+++ b/frontend/app/(dashboard)/layout.tsx
@@ -21,6 +21,7 @@ import Image from "next/image";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 import React from "react";
+import { useIsDocumentSignatureRequired } from "@/app/(dashboard)/documents";
 import { navLinks as equityNavLinks } from "@/app/(dashboard)/equity";
 import { useIsActionable } from "@/app/(dashboard)/invoices";
 import { GettingStarted } from "@/components/GettingStarted";
@@ -191,12 +192,12 @@ const NavLinks = () => {
     { refetchInterval: 30_000 },
   );
   const isInvoiceActionable = useIsActionable();
+  const isDocumentSignatureRequired = useIsDocumentSignatureRequired();
   const { data: documentsData } = trpc.documents.list.useQuery(
-    user.currentCompanyId && user.id
-      ? { companyId: user.currentCompanyId, userId: user.id, signable: true }
-      : skipToken,
+    user.currentCompanyId && user.id ? { companyId: user.currentCompanyId, userId: user.id } : skipToken,
     { refetchInterval: 30_000 },
   );
+
   const updatesPath = company.routes.find((route) => route.label === "Updates")?.name;
   const equityLinks = equityNavLinks(user, company);
 
@@ -233,7 +234,7 @@ const NavLinks = () => {
           href="/documents"
           icon={Files}
           active={pathname.startsWith("/documents") || pathname.startsWith("/document_templates")}
-          badge={documentsData?.length}
+          badge={documentsData?.filter(isDocumentSignatureRequired).length}
         >
           Documents
         </NavLink>


### PR DESCRIPTION
### Summary

Fixed the Documents navigation badge to display the count of documents requiring signatures from the current user, instead of showing the total count of all documents. This aligns the behavior with the Invoices navigation which correctly shows only actionable items.

### Problem

The Documents navigation in the sidebar was showing a badge with the total count of ALL documents, not just those needing signatures from the current user. This was inconsistent with the Invoices navigation which correctly displays only actionable items (invoices needing approval/payment).

**Before:** ( manual debugging )

- Documents badge showed count of all documents
- Did not help users identify documents requiring their attention
<img width="1920" height="1080" alt="Screenshot from 2025-07-23 01-08-55" src="https://github.com/user-attachments/assets/b2699e0c-78a9-4bed-a7fa-bbff37aae035" />



**After:**

- Documents badge shows only documents requiring signatures from the current user
- Consistent with Invoices navigation behavior
- Badge updates dynamically when documents are signed
<img width="1920" height="1080" alt="Screenshot from 2025-07-23 01-25-02" src="https://github.com/user-attachments/assets/2b6af28c-8743-438f-9d57-9d5bec66789b" />



### Changes

#### 1. Created Document Filtering Logic (`frontend/app/(dashboard)/documents/index.tsx`)

- **`useIsDocumentSignable()`**: Maintains existing logic for documents that can actually be signed (requires DocuSeal submission ID)
- **`useIsDocumentSignatureRequired()`**: New function for badge counting that identifies documents needing signatures regardless of DocuSeal status

Both functions properly handle user roles:

- Direct signatories (document.signatories matching user.id)
- Company representatives (administrators/lawyers for "Company Representative" signatories)

#### 2. Updated Documents Page (`frontend/app/(dashboard)/documents/page.tsx`)

- Refactored to use the new `useIsDocumentSignable()` hook instead of inline logic
- Maintains existing functionality while improving code organization

#### 3. Fixed Navigation Badge (`frontend/app/(dashboard)/layout.tsx`)

- Imported and used `useIsDocumentSignatureRequired()` for badge filtering
- Changed from `documentsData?.length` to `documentsData?.filter(isDocumentSignatureRequired).length`
- Removed redundant `signable: true` parameter from documents query since filtering is now done client-side

### Testing

The existing e2e test in `e2e/tests/company/documents/badge.spec.ts` passes:

<img width="1920" height="1080" alt="document-badge-test" src="https://github.com/user-attachments/assets/9f444bb5-ee44-438b-a2fe-eec490aeab76" />


Closes #605


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added new logic to determine if a document is signable or requires a signature, improving accuracy based on user roles and document status.

* **Improvements**
  * Updated the documents navigation badge to reflect the count of documents requiring the user's signature.
  * Enhanced document filtering in the dashboard to use the new signable and signature-required logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->