### PR TITLE
Fix: test for company admin onboarding checklist completion

### DIFF
--- a/e2e/tests/company/onboarding/checklist.spec.ts
+++ b/e2e/tests/company/onboarding/checklist.spec.ts
@@ -74,7 +74,7 @@ test.describe.serial("Onboarding checklist", () => {
         await modal.getByRole("button", { name: "Send invite" }).click();
         await modal.waitFor({ state: "detached" });
       },
-      { page },
+      { page, title: "Who's joining?" },
     );
 
     await expect(page.getByText("75%")).toBeVisible();


### PR DESCRIPTION
Bug description:

Playwright test for onboarding checklist › completes admin onboarding... fails .
Details :  #617 

--

Steps to reproduce:

Run playwright test for :

- Onboarding checklist › completes admin onboarding checklist by adding company details, bank account, and inviting contractor 
   ( e2e/tests/company/onboarding/checklist.spec.ts )

--

Before:

<img width="1577" height="431" alt="onboarding-checklist-test-failure" src="https://github.com/user-attachments/assets/9a3034e9-e819-4ea8-b7be-1ff92cb51e44" />


After:

<img width="1288" height="195" alt="after-onboarding-checklist-test-failure" src="https://github.com/user-attachments/assets/7c1722a5-b36c-43b2-bd22-1168585e2359" />

--

Tests:

<img width="1288" height="195" alt="after-onboarding-checklist-test-failure" src="https://github.com/user-attachments/assets/7c1722a5-b36c-43b2-bd22-1168585e2359" />