### PR TITLE
fix: Date of birth on tax settings page

### DIFF
--- a/frontend/app/settings/tax/page.tsx
+++ b/frontend/app/settings/tax/page.tsx
@@ -150,7 +150,13 @@ export default function TaxPage() {
 
   const saveMutation = useMutation({
     mutationFn: async (signature: string) => {
-      const data = await updateTaxSettings.mutateAsync({ data: { ...form.getValues(), signature } });
+      const formValues = form.getValues();
+      const transformedData = {
+        ...formValues,
+        birth_date: formValues.birth_date ? formValues.birth_date.toString() : null,
+        signature,
+      };
+      const data = await updateTaxSettings.mutateAsync({ data: transformedData });
 
       setIsTaxInfoConfirmed(true);
       if (form.getFieldState("tax_id").isDirty) setTaxIdStatus(null);


### PR DESCRIPTION
Fixes: https://github.com/antiwork/flexile/issues/594

https://github.com/user-attachments/assets/e144f736-78f8-4abd-8905-5a621c2277d3


Added a new spec to verify my change.
You can see in the screenshot that test passed on the first time after i made the changes and on reverting the changes the birth date wasn't updated and we got an error.

![Screenshot 2025-07-23 at 8 04 37 PM](https://github.com/user-attachments/assets/87b48163-be8a-4168-b4d7-dfe17e4c557e)

How to test?

Go to settings/tax page 
Change your birth date and click save changes
Reload the page to confirm date of birth has been updated
