### PR TITLE
remove equityGrantsEnabled flag from company admin

### DIFF
--- a/backend/app/policies/equity_grant_policy.rb
+++ b/backend/app/policies/equity_grant_policy.rb
@@ -2,19 +2,15 @@
 
 class EquityGrantPolicy < ApplicationPolicy
   def index?
-    return false unless company.equity_grants_enabled?
-
     company_investor.present? || company_administrator.present? || company_lawyer.present?
   end
 
   def show?
-    return false unless company.equity_grants_enabled?
-
     return true if company_administrator.present? || company_lawyer.present?
     company_investor.present? && record.company_investor == company_investor
   end
 
   def create?
-    company.equity_grants_enabled? && company_administrator.present?
+    company_administrator.present?
   end
 end

--- a/backend/app/presenters/user_presenter.rb
+++ b/backend/app/presenters/user_presenter.rb
@@ -89,7 +89,7 @@ class UserPresenter
       companies: user.all_companies.compact.map do |company|
         flags = %w[company_updates].filter { Flipper.enabled?(_1, company) }
         flags.push("equity_compensation") if company.equity_compensation_enabled?
-        flags.push("equity_grants") if company.equity_grants_enabled?
+        flags.push("equity_grants")
         flags.push("dividends")
         flags.push("quickbooks") if company.quickbooks_enabled?
         flags.push("tender_offers") if company.tender_offers_enabled?
@@ -171,7 +171,7 @@ class UserPresenter
       if company_investor.present?
         result[:flags][:cap_table] ||= true if company.cap_table_enabled?
         result[:flags][:option_exercising] = company.json_flag?("option_exercising")
-        result[:flags][:equity_grants] = company.equity_grants_enabled?
+        result[:flags][:equity_grants] = true
 
         result[:flags][:tender_offers] ||= company.tender_offers_enabled?
       end
@@ -192,7 +192,7 @@ class UserPresenter
     def common_admin_props
       {
         flags: {
-          equity_grants: company.equity_grants_enabled?,
+          equity_grants: true,
           cap_table: company.cap_table_enabled?,
 
           tender_offers: company.tender_offers_enabled?,

--- a/backend/config/data/seed_templates/gumroad.json
+++ b/backend/config/data/seed_templates/gumroad.json
@@ -27,7 +27,6 @@
         "fmv_per_share_in_usd": 7.84,
         "is_trusted": true,
         "fully_diluted_shares": 200188,
-        "equity_grants_enabled": true,
         "is_gumroad": true,
         "tender_offers_enabled": true,
         "cap_table_enabled": true,
@@ -73,11 +72,26 @@
       "equity_exercise_bank_account": {
         "model_attributes": {
           "details": [
-            ["Beneficiary name", "Gumroad"],
-            ["Beneficiary address", "548 Market Street, San Francisco, CA 94104"],
-            ["Bank name", "Wise Business"],
-            ["Routing number", "987654321"],
-            ["SWIFT/BIC", "WZYOPW1L"]
+            [
+              "Beneficiary name",
+              "Gumroad"
+            ],
+            [
+              "Beneficiary address",
+              "548 Market Street, San Francisco, CA 94104"
+            ],
+            [
+              "Bank name",
+              "Wise Business"
+            ],
+            [
+              "Routing number",
+              "987654321"
+            ],
+            [
+              "SWIFT/BIC",
+              "WZYOPW1L"
+            ]
           ],
           "account_number": "123456789"
         }

--- a/backend/db/migrate/20250724120001_remove_equity_grants_enabled_from_companies.rb
+++ b/backend/db/migrate/20250724120001_remove_equity_grants_enabled_from_companies.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class RemoveEquityGrantsEnabledFromCompanies < ActiveRecord::Migration[7.0]
+  def change
+    remove_column :companies, :equity_grants_enabled, :boolean
+  end
+end

--- a/backend/db/schema.rb
+++ b/backend/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_07_17_153308) do
+ActiveRecord::Schema[8.0].define(version: 2025_07_24_120001) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -103,7 +103,6 @@ ActiveRecord::Schema[8.0].define(version: 2025_07_17_153308) do
     t.boolean "is_gumroad", default: false, null: false
     t.boolean "dividends_allowed", default: false, null: false
     t.boolean "is_trusted", default: false, null: false
-    t.boolean "equity_grants_enabled", default: false, null: false
     t.boolean "show_analytics_to_contractors", default: false, null: false
     t.boolean "company_updates_enabled", default: false, null: false
     t.string "default_currency", default: "usd", null: false

--- a/backend/spec/system/company/company_workers/stock_options_contract_spec.rb
+++ b/backend/spec/system/company/company_workers/stock_options_contract_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 RSpec.describe "Stock options contract" do
-  let(:company) { create(:company, name: "Gumroad", equity_grants_enabled: true) }
+  let(:company) { create(:company, name: "Gumroad") }
   let(:company_worker) { create(:company_worker, company:) }
   let(:user) { company_worker.user }
   let(:contract) do

--- a/backend/spec/system/company/convertible_securities/listing_page_spec.rb
+++ b/backend/spec/system/company/convertible_securities/listing_page_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe "Convertible securities page" do
                                   convertible_investment:, principal_value_in_cents: 1_000_000_00)
   end
 
-  let(:company) { create(:company, valuation_in_dollars: 150_000_000, fully_diluted_shares: 9_000_000, equity_grants_enabled: true) }
+  let(:company) { create(:company, valuation_in_dollars: 150_000_000, fully_diluted_shares: 9_000_000) }
   let(:company_investor) { create(:company_investor, company:) }
 
   before do

--- a/backend/spec/system/company/dividend_rounds/listing_page_spec.rb
+++ b/backend/spec/system/company/dividend_rounds/listing_page_spec.rb
@@ -53,7 +53,6 @@ RSpec.describe "Dividend Rounds listing page" do
     end
 
     it "shows the 'Grants' tab when the relevant feature is enabled" do
-      company.update!(equity_grants_enabled: true)
       sign_in user
 
       visit spa_company_dividend_rounds_path(company.external_id)

--- a/backend/spec/system/company/dividends/listing_page_spec.rb
+++ b/backend/spec/system/company/dividends/listing_page_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe "Dividends page" do
     create(:convertible_security, company_investor: investor)
     investor
   end
-  let(:company) { create(:company, equity_grants_enabled: true) }
+  let(:company) { create(:company) }
 
   before do
     sign_in company_investor.user

--- a/backend/spec/system/company/equity_grants/create_spec.rb
+++ b/backend/spec/system/company/equity_grants/create_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 RSpec.describe "Creating an equity grant" do
-  let!(:company) { create(:company, equity_grants_enabled: true) }
+  let!(:company) { create(:company) }
   let!(:option_pool) { create(:option_pool, company:, authorized_shares: 2_001, issued_shares: 1_000) }
   let!(:company_administrator) { create(:company_administrator, company:).user }
 

--- a/backend/spec/system/company/equity_grants/listing_page_spec.rb
+++ b/backend/spec/system/company/equity_grants/listing_page_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe "Equity Grants list page" do
   let(:company) { create(:company) }
 
   shared_examples "an administrator with access" do
-    before { company.update!(equity_grants_enabled: true) }
+    before { Flipper.enable(:option_exercising, company) }
 
     context "when records exist" do
       before do
@@ -160,7 +160,6 @@ RSpec.describe "Equity Grants list page" do
                             accepted_at: nil)
 
       sign_in user
-      company.update!(equity_grants_enabled: true)
       Flipper.enable(:option_exercising, company)
     end
 

--- a/backend/spec/system/company/equity_header_spec.rb
+++ b/backend/spec/system/company/equity_header_spec.rb
@@ -41,7 +41,6 @@ RSpec.describe "Equity section navigation" do
 
     it "shows the expected nav link and tabs if all features are enabled" do
       Flipper.enable(:cap_table, company)
-      company.update!(equity_grants_enabled: true)
 
       visit root_path
 
@@ -85,8 +84,6 @@ RSpec.describe "Equity section navigation" do
     before { sign_in company_worker.user }
 
     it "does not show the nav link irrespective of enabled features" do
-      company.update!(equity_grants_enabled: true)
-
       visit root_path
 
       expect(page).to_not have_link("Equity")
@@ -107,8 +104,8 @@ RSpec.describe "Equity section navigation" do
       expect(page).to have_current_path(spa_company_dividends_path(company.external_id))
     end
 
-    it "shows the expected nav link and tabs if the equity_grants and tender_offers features are enabled" do
-      company.update!(equity_grants_enabled: true, tender_offers_enabled: true)
+    it "shows the expected nav link and tabs if the tender_offers feature is enabled" do
+      company.update!(tender_offers_enabled: true)
 
       visit root_path
 

--- a/backend/spec/system/company/option_pools/listing_page_spec.rb
+++ b/backend/spec/system/company/option_pools/listing_page_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 RSpec.describe "Option pools" do
-  let(:company) { create(:company, equity_grants_enabled: true) }
+  let(:company) { create(:company) }
 
   shared_examples "a user with access" do
     before do

--- a/backend/spec/system/company/share_holdings/listing_page_spec.rb
+++ b/backend/spec/system/company/share_holdings/listing_page_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe "Share holdings page" do
                            share_price_usd: 2.41, share_class:)
   end
 
-  let(:company) { create(:company, valuation_in_dollars: 100_000_000, fully_diluted_shares: 2_000_000, equity_grants_enabled: true) }
+  let(:company) { create(:company, valuation_in_dollars: 100_000_000, fully_diluted_shares: 2_000_000) }
   let(:company_investor) { create(:company_investor, company:) }
 
   before do

--- a/e2e/tests/company/equity/grants.spec.ts
+++ b/e2e/tests/company/equity/grants.spec.ts
@@ -19,7 +19,6 @@ import { assertDefined } from "@/utils/assert";
 test.describe("New Contractor", () => {
   test("allows issuing equity grants", async ({ page, next }) => {
     const { company, adminUser } = await companiesFactory.createCompletedOnboarding({
-      equityGrantsEnabled: true,
       equityCompensationEnabled: true,
       conversionSharePriceUsd: "1",
     });
@@ -140,7 +139,6 @@ test.describe("New Contractor", () => {
 
   test("allows cancelling a grant", async ({ page }) => {
     const { company, adminUser } = await companiesFactory.createCompletedOnboarding({
-      equityGrantsEnabled: true,
       conversionSharePriceUsd: "1",
     });
     const { companyInvestor } = await companyInvestorsFactory.create({ companyId: company.id });
@@ -171,7 +169,6 @@ test.describe("New Contractor", () => {
 
   test("allows exercising options", async ({ page, next }) => {
     const { company } = await companiesFactory.createCompletedOnboarding({
-      equityGrantsEnabled: true,
       conversionSharePriceUsd: "1",
       jsonData: { flags: ["option_exercising"] },
     });

--- a/e2e/tests/company/people/header-navigation.spec.ts
+++ b/e2e/tests/company/people/header-navigation.spec.ts
@@ -26,7 +26,6 @@ test.describe("People header navigation", () => {
     const { company, adminUser } = await companiesFactory.createCompletedOnboarding({
       tenderOffersEnabled: true,
       capTableEnabled: true,
-      equityGrantsEnabled: true,
     });
 
     await companyContractorsFactory.create({

--- a/frontend/db/schema.ts
+++ b/frontend/db/schema.ts
@@ -1846,7 +1846,6 @@ export const companies = pgTable(
     countryCode: varchar("country_code"),
     isGumroad: boolean("is_gumroad").notNull().default(false),
     isTrusted: boolean("is_trusted").notNull().default(false),
-    equityGrantsEnabled: boolean("equity_grants_enabled").notNull().default(false),
     showAnalyticsToContractors: boolean("show_analytics_to_contractors").notNull().default(false),
     companyUpdatesEnabled: boolean("company_updates_enabled").notNull().default(false),
     defaultCurrency: varchar("default_currency").default("usd").notNull(),

--- a/frontend/trpc/routes/equityGrants.ts
+++ b/frontend/trpc/routes/equityGrants.ts
@@ -79,7 +79,6 @@ export const equityGrantsRouter = createRouter({
       }),
     )
     .query(async ({ input, ctx }) => {
-      if (!ctx.company.equityGrantsEnabled) throw new TRPCError({ code: "FORBIDDEN" });
       if (
         !ctx.companyAdministrator &&
         !ctx.companyLawyer &&

--- a/frontend/trpc/routes/optionPools.ts
+++ b/frontend/trpc/routes/optionPools.ts
@@ -6,7 +6,6 @@ import { companyProcedure, createRouter } from "@/trpc";
 
 export const optionPoolsRouter = createRouter({
   list: companyProcedure.query(async ({ ctx }) => {
-    if (!ctx.company.equityGrantsEnabled) throw new TRPCError({ code: "FORBIDDEN" });
     if (!(ctx.companyAdministrator || ctx.companyLawyer)) throw new TRPCError({ code: "FORBIDDEN" });
 
     return await db.query.optionPools.findMany({


### PR DESCRIPTION

https://github.com/user-attachments/assets/eb105a36-ca81-4cfb-a75b-2e50a65ae3ff



<img width="1250" height="359" alt="image" src="https://github.com/user-attachments/assets/e8fe1462-906b-49ee-86a0-01c724a8d17d" />
<img width="1250" height="359" alt="image" src="https://github.com/user-attachments/assets/feffe7fb-8e18-41fa-a27c-3b9578e69849" />

<img width="1260" height="120" alt="image" src="https://github.com/user-attachments/assets/f12effaa-a539-40f7-b8f7-7d52a6f5870f" />
<img width="1265" height="86" alt="image" src="https://github.com/user-attachments/assets/97b46954-4f0d-4ec7-88d2-bdef7e648c35" />


Reference issue: #578 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Equity grants functionality is now always available for companies; it no longer depends on a separate enablement flag.

* **Bug Fixes**
  * Users and administrators will consistently see equity grants-related features without requiring additional company configuration.

* **Chores**
  * Removed the equity grants enablement flag from company settings, database schema, and related test setups.
  * Updated tests and permissions to reflect the removal of the equity grants enablement requirement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->