### PR TITLE
remove lawyersEnabled flag from company admin

### DIFF
--- a/backend/app/policies/company_lawyer_policy.rb
+++ b/backend/app/policies/company_lawyer_policy.rb
@@ -2,8 +2,6 @@
 
 class CompanyLawyerPolicy < ApplicationPolicy
   def create?
-    return false unless company.lawyers_enabled?
-
     company_administrator.present?
   end
 end

--- a/backend/app/presenters/user_presenter.rb
+++ b/backend/app/presenters/user_presenter.rb
@@ -94,7 +94,7 @@ class UserPresenter
         flags.push("quickbooks") if company.quickbooks_enabled?
         flags.push("tender_offers") if company.tender_offers_enabled?
         flags.push("cap_table") if company.cap_table_enabled?
-        flags.push("lawyers") if company.lawyers_enabled?
+        flags.push("lawyers")
         flags.push("expenses") if company.expenses_enabled?
         flags.push("equity_compensation") if company.equity_compensation_enabled?
         flags.push("option_exercising") if company.json_flag?("option_exercising")

--- a/backend/db/migrate/20250724120003_remove_lawyers_enabled_from_companies.rb
+++ b/backend/db/migrate/20250724120003_remove_lawyers_enabled_from_companies.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class RemoveLawyersEnabledFromCompanies < ActiveRecord::Migration[7.0]
+  def change
+    remove_column :companies, :lawyers_enabled, :boolean
+  end
+end

--- a/backend/db/schema.rb
+++ b/backend/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_07_17_153308) do
+ActiveRecord::Schema[8.0].define(version: 2025_07_24_120003) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -109,7 +109,6 @@ ActiveRecord::Schema[8.0].define(version: 2025_07_17_153308) do
     t.string "default_currency", default: "usd", null: false
     t.boolean "cap_table_enabled", default: false, null: false
     t.boolean "tender_offers_enabled", default: false, null: false
-    t.boolean "lawyers_enabled", default: false, null: false
     t.decimal "conversion_share_price_usd"
     t.boolean "equity_compensation_enabled", default: false, null: false
     t.jsonb "json_data", default: {"flags" => []}, null: false

--- a/backend/spec/system/company/documents_spec.rb
+++ b/backend/spec/system/company/documents_spec.rb
@@ -253,52 +253,34 @@ RSpec.describe "Documents page" do
       expect(page).to_not have_selector("h2", text: "Upcoming filing dates for 1099-NEC, 1099-DIV, and 1042-S")
     end
 
-    context "when lawyers are enabled" do
-      before do
-        company.update!(lawyers_enabled: true)
-      end
+    it "allows inviting a lawyer" do
+      visit spa_company_documents_path(company.external_id)
 
-      it "allows inviting a lawyer" do
-        visit spa_company_documents_path(company.external_id)
+      expect(page).to have_button("Invite lawyer")
 
-        expect(page).to have_button("Invite lawyer")
+      click_button "Invite lawyer"
+      expect(page).to have_content("Who's joining?")
 
-        click_button "Invite lawyer"
-        expect(page).to have_content("Who's joining?")
+      fill_in "Email", with: "new_lawyer@example.com"
+      click_button "Invite"
 
-        fill_in "Email", with: "new_lawyer@example.com"
-        click_button "Invite"
+      wait_for_ajax
 
-        wait_for_ajax
-
-        expect(CompanyLawyer.count).to eq(1)
-        expect(CompanyLawyer.last.user.email).to eq("new_lawyer@example.com")
-      end
-
-      it "shows an error when inviting an existing user" do
-        visit spa_company_documents_path(company.external_id)
-
-        existing_user = create(:user, email: "existing_lawyer@example.com")
-
-        click_button "Invite lawyer"
-        fill_in "Email", with: existing_user.email
-        click_button "Invite"
-
-        expect(page).to have_content("Email has already been taken")
-        expect(CompanyLawyer.count).to eq(0)
-      end
+      expect(CompanyLawyer.count).to eq(1)
+      expect(CompanyLawyer.last.user.email).to eq("new_lawyer@example.com")
     end
 
-    context "when lawyers are disabled" do
-      before do
-        company.update!(lawyers_enabled: false)
-      end
+    it "shows an error when inviting an existing user" do
+      visit spa_company_documents_path(company.external_id)
 
-      it "does not show the invite lawyer button" do
-        visit spa_company_documents_path(company.external_id)
+      existing_user = create(:user, email: "existing_lawyer@example.com")
 
-        expect(page).to_not have_button("Invite lawyer")
-      end
+      click_button "Invite lawyer"
+      fill_in "Email", with: existing_user.email
+      click_button "Invite"
+
+      expect(page).to have_content("Email has already been taken")
+      expect(CompanyLawyer.count).to eq(0)
     end
   end
 
@@ -372,7 +354,6 @@ RSpec.describe "Documents page" do
         expect(page).to have_link("Download", href: rails_blob_path(document_1.attachment, disposition: "attachment"))
       end
 
-      # Pagination
       expect(page).to_not have_selector("[aria-label='Pagination']")
 
       stub_const("DocumentsPresenter::RECORDS_PER_PAGE", 1)

--- a/e2e/tests/company/documents/documents.spec.ts
+++ b/e2e/tests/company/documents/documents.spec.ts
@@ -90,3 +90,25 @@ test.describe("Documents search functionality", () => {
     await expect(page.getByRole("row").filter({ hasText: document2.name })).not.toBeVisible();
   });
 });
+
+test.describe("Invite lawyer functionality", () => {
+  test("allows inviting a lawyer", async ({ page }) => {
+    const { adminUser } = await companiesFactory.createCompletedOnboarding();
+
+    await login(page, adminUser);
+    await page.goto("/documents");
+    await expect(page.getByRole("heading", { name: "Documents" })).toBeVisible();
+
+    await expect(page.getByRole("button", { name: "Invite lawyer" })).toBeVisible();
+    await page.getByRole("button", { name: "Invite lawyer" }).click();
+    await expect(page.getByText("Who's joining?")).toBeVisible();
+
+    const emailInput = page.getByLabel("Email");
+    await expect(emailInput).toBeVisible();
+    await emailInput.fill("new_lawyer@example.com");
+    await page.getByRole("button", { name: "Invite" }).click();
+
+    await expect(page.getByRole("heading", { name: "Documents" })).toBeVisible();
+    // TODO (techdebt): Add assertion for successful invite (e.g., toast, row, or API check)
+  });
+});

--- a/frontend/app/(dashboard)/documents/page.tsx
+++ b/frontend/app/(dashboard)/documents/page.tsx
@@ -352,7 +352,7 @@ export default function DocumentsPage() {
         headerActions={
           <>
             {isCompanyRepresentative && documents.length === 0 ? <EditTemplates /> : null}
-            {user.roles.administrator && company.flags.includes("lawyers") ? (
+            {user.roles.administrator ? (
               <Button onClick={() => setShowInviteModal(true)}>
                 <BriefcaseBusiness className="size-4" />
                 Invite lawyer

--- a/frontend/db/schema.ts
+++ b/frontend/db/schema.ts
@@ -1853,7 +1853,6 @@ export const companies = pgTable(
 
     tenderOffersEnabled: boolean("tender_offers_enabled").notNull().default(false),
     capTableEnabled: boolean("cap_table_enabled").default(false).notNull(),
-    lawyersEnabled: boolean("lawyers_enabled").notNull().default(false),
     conversionSharePriceUsd: numeric("conversion_share_price_usd"),
     equityCompensationEnabled: boolean("equity_compensation_enabled").notNull().default(false),
     jsonData: jsonb("json_data").notNull().$type<{ flags: string[] }>().default({ flags: [] }),


### PR DESCRIPTION


https://github.com/user-attachments/assets/b7668605-e77f-4445-889e-b14a6b6a3443


<img width="1268" height="301" alt="image" src="https://github.com/user-attachments/assets/e78959ea-cc61-4c2b-946a-637bc64c3305" />
<img width="1268" height="301" alt="image" src="https://github.com/user-attachments/assets/1435d2a8-8611-4ce0-8e7f-6a83cca616c2" />

<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/780ced73-def8-4efe-ab85-bb40e4cf169d" />

Reference issue: #578 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * The "lawyers" feature is now always available for companies without requiring a specific setting.
  * Users with administrator roles can invite lawyers directly from the documents page.

* **Bug Fixes**
  * Resolved inconsistencies in inviting lawyers by standardizing the feature's availability.

* **Chores**
  * Removed the "lawyers_enabled" setting from company records and all related logic in the system.
  * Updated database schema to reflect the removal of the "lawyers_enabled" column.
  * Simplified the user interface by always displaying the "Invite lawyer" button for administrators.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->