### PR TITLE
Bug: fix failing rspecs by removing remaining references

### DIFF
--- a/backend/app/services/purge_seed_data.rb
+++ b/backend/app/services/purge_seed_data.rb
@@ -180,7 +180,6 @@ class PurgeSeedData
 
     def purge_user!(user)
       user.user_compliance_infos.each do |user_compliance_info|
-        user_compliance_info.tax_documents.each(&:destroy!)
         user_compliance_info.destroy!
       end
       WiseRecipient.where(user:).find_each do |wise_recipient|

--- a/backend/spec/models/company_spec.rb
+++ b/backend/spec/models/company_spec.rb
@@ -37,7 +37,6 @@ RSpec.describe Company do
     it { is_expected.to have_many(:share_classes) }
     it { is_expected.to have_many(:share_holdings).through(:company_investors) }
     it { is_expected.to have_many(:option_pools) }
-    it { is_expected.to have_many(:tax_documents) }
     it { is_expected.to have_many(:tender_offers) }
     it { is_expected.to have_one(:quickbooks_integration).conditions(deleted_at: nil) }
     it { is_expected.to have_one_attached(:logo) }

--- a/backend/spec/models/user_compliance_info_spec.rb
+++ b/backend/spec/models/user_compliance_info_spec.rb
@@ -3,7 +3,6 @@
 RSpec.describe UserComplianceInfo do
   describe "associations" do
     it { is_expected.to belong_to(:user) }
-    it { is_expected.to have_many(:tax_documents) }
     it { is_expected.to have_many(:documents) }
     it { is_expected.to have_many(:dividends) }
   end
@@ -517,20 +516,6 @@ RSpec.describe UserComplianceInfo do
         expect(submitted_1099_nec).to_not be_deleted
       end
 
-      context "when there are already deleted records for the same tax year" do
-        let!(:deleted_1099_nec) do
-          create(:tax_document, :deleted, :form_1099nec, user_compliance_info:, tax_year: 2023)
-        end
-
-        it "marks the user compliance info and corresponding records as deleted" do
-          user_compliance_info.mark_deleted!
-          expect(user_compliance_info.reload).to be_deleted
-          expect(form_1099_nec.reload).to be_deleted
-          expect(tax_document.reload).to_not be_deleted
-          expect(submitted_1099_nec).to_not be_deleted
-          expect(deleted_1099_nec).to be_deleted
-        end
-      end
 
       context "when there are paid dividends attached to the user compliance info" do
         let!(:form_1099_div) { create(:tax_doc, :form_1099div, user_compliance_info:) }

--- a/backend/spec/models/user_spec.rb
+++ b/backend/spec/models/user_spec.rb
@@ -28,7 +28,6 @@ RSpec.describe User do
     it { is_expected.to have_one(:bank_account_for_dividends).class_name("WiseRecipient") }
 
     it { is_expected.to have_many(:user_compliance_infos).autosave(true) }
-    it { is_expected.to have_many(:tax_documents).through(:user_compliance_infos) }
 
     describe "#compliance_info" do
       it "returns the most recent, live compliance info record" do


### PR DESCRIPTION
Removing remaining references to `tax_documents` to ensure passing backend tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated user data purging to improve handling of compliance information and associated documents.

* **Tests**
  * Removed tests related to company, user, and user compliance information associations with tax documents.
  * Simplified test coverage for deletion scenarios involving compliance information and tax documents.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->