### PR TITLE
fix: turbopack not compatibile with experimental.typedRoutes

### DIFF
--- a/Procfile.dev
+++ b/Procfile.dev
@@ -1,5 +1,5 @@
 web: cd backend && ./bin/rails s -p 3000
 sidekiq: cd backend && bundle exec sidekiq -q default -q mailers
 tsc: pnpm run typecheck:watch
-next: TZ=UTC pnpm next dev frontend --turbopack -H flexile.dev -p 3001
+next: TZ=UTC pnpm next dev frontend -H flexile.dev -p 3001
 inngest: pnpm inngest-cli dev --no-discovery -u http://localhost:3001/api/inngest

--- a/Procfile.test
+++ b/Procfile.test
@@ -1,4 +1,4 @@
 web: cd backend && ./bin/rails s -p 3100
 sidekiq: cd backend && bundle exec sidekiq -q default -q mailers
-next: TZ=UTC [ -n "$CI" ] && node e2e/next.js || pnpm next dev frontend --turbopack -H test.flexile.dev --experimental-https -p 3101
+next: TZ=UTC [ -n "$CI" ] && node e2e/next.js || pnpm next dev frontend -H test.flexile.dev --experimental-https -p 3101
 inngest: pnpm inngest-cli dev --no-discovery -p 8298 -u https://test.flexile.dev:3101/api/inngest


### PR DESCRIPTION
Before:- 

:35:55 next.1    | 
02:35:55 next.1    |  ⨯ You are using configuration and/or tools that are not yet
02:35:55 next.1    | supported by Next.js with Turbopack:
02:35:55 next.1    | 
02:35:55 next.1    | 
02:35:55 next.1    | - Unsupported Next.js configuration option(s) (next.config.js)
02:35:55 next.1    |   To use Turbopack, remove the following configuration options:
02:35:55 next.1    |     - experimental.typedRoutes
02:35:55 next.1    | 
02:35:55 next.1    | 
02:35:55 next.1    | If you cannot make the changes above, but still want to try out
02:35:55 next.1    | Next.js with Turbopack, create the Next.js playground app
02:35:55 next.1    | by running the following commands:
02:35:55 next.1    | 
02:35:55 next.1    |   pnpm create next-app --example with-turbopack with-turbopack-app
02:35:55 next.1    |   cd with-turbopack-app
02:35:55 next.1    |   pnpm run dev
02:35:55 next.1    |         
02:35:55 next.1    |  ⚠ Learn more about Next.js and Turbopack: https://nextjs.org/docs/architecture/turbopack
02:35:55 next.1    | 
02:35:55 next.1    | 
02:35:56 next.1    | exited with code 0
02:35:56 system    | sending SIGTERM to all processes
02:35:56 tsc.1     |  ELIFECYCLE  Command failed.
02:35:56 tsc.1     |  ELIFECYCLE  Command failed.
02:35:56 inngest.1 | terminated by SIGTERM
02:35:56 tsc.1     | terminated by SIGTERM
02:35:56 sidekiq.1 | terminated by SIGTERM
02:35:56 web.1     | terminated by SIGTERM

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated development and test server startup commands by removing a specific flag for the server bundler. No changes to user-facing features or functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->