### PR TITLE
Added Mobile Navigation for sidebar

### DIFF
--- a/frontend/app/(dashboard)/layout.tsx
+++ b/frontend/app/(dashboard)/layout.tsx
@@ -2,7 +2,6 @@
 
 import { SignOutButton } from "@clerk/nextjs";
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "@radix-ui/react-collapsible";
-import { useQueryClient } from "@tanstack/react-query";
 import {
   BookUser,
   ChartPie,
@@ -45,29 +44,16 @@ import {
   SidebarProvider,
   useSidebar,
 } from "@/components/ui/sidebar";
-import { useCurrentCompany, useCurrentUser, useUserStore } from "@/global";
+import { useCurrentCompany, useCurrentUser } from "@/global";
 import defaultCompanyLogo from "@/images/default-company-logo.svg";
 import { storageKeys } from "@/models/constants";
-import { request } from "@/utils/request";
-import { company_switch_path } from "@/utils/routes";
 import { useIsMobile } from "@/utils/use-mobile";
 import { useNavData } from "@/utils/use-navdata";
 
 export default function DashboardLayout({ children }: { children: React.ReactNode }) {
   const user = useCurrentUser();
   const isMobile = useIsMobile();
-
-  const queryClient = useQueryClient();
-  const switchCompany = async (companyId: string) => {
-    useUserStore.setState((state) => ({ ...state, pending: true }));
-    await request({
-      method: "POST",
-      url: company_switch_path(companyId),
-      accept: "json",
-    });
-    await queryClient.resetQueries({ queryKey: ["currentUser"] });
-    useUserStore.setState((state) => ({ ...state, pending: false }));
-  };
+  const { switchCompany } = useNavData();
 
   return (
     <SidebarProvider>

--- a/frontend/components/BottomNavbar.tsx
+++ b/frontend/components/BottomNavbar.tsx
@@ -17,6 +17,12 @@ import Image from "next/image";
 import Link from "next/link";
 import * as React from "react";
 import { Dialog, DialogClose, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
 import { useSidebar } from "@/components/ui/sidebar";
 import defaultCompanyLogo from "@/images/default-company-logo.svg";
 import { cn } from "@/utils";
@@ -38,105 +44,10 @@ type MoreSection =
       action: () => void;
     };
 
-type NavTab = {
-  label: string;
-  href: string;
-  icon: React.ReactNode;
-  active: boolean;
-  showDot?: boolean;
-  onClick?: (e: React.MouseEvent) => void;
-  modal?: boolean;
-};
-
 export default function BottomNavbar() {
-  const [equitySheet, setEquitySheet] = React.useState(false);
+  const [openModal, setOpenModal] = React.useState<"equity" | "more" | null>(null);
   const sidebar = useSidebar();
-  const {
-    user,
-    company,
-    pathname,
-    routes,
-    invoicesData,
-    isInvoiceActionable,
-    updatesPath,
-    equityLinks,
-    isOpen,
-    setIsOpen,
-  } = useNavData();
-
-  const showInvoicesDot = (invoicesData?.filter(isInvoiceActionable).length ?? 0) > 0;
-
-  const navTabs: (NavTab | false)[] = [
-    routes.has("Invoices") && {
-      label: "Invoices",
-      href: "/invoices",
-      icon: (
-        <ReceiptIcon className={cn("mb-1 size-6", pathname.startsWith("/invoices") ? "text-black" : "text-gray-400")} />
-      ),
-      active: pathname.startsWith("/invoices"),
-      showDot: showInvoicesDot,
-    },
-    routes.has("Documents") && {
-      label: "Documents",
-      href: "/documents",
-      icon: (
-        <Files
-          className={cn(
-            "mb-1 size-6",
-            pathname.startsWith("/documents") ? "stroke-[2.5] text-black" : "stroke-[1.25] text-gray-400",
-          )}
-        />
-      ),
-      active: pathname.startsWith("/documents"),
-    },
-    routes.has("People") && {
-      label: "People",
-      href: "/people",
-      icon: <Users className={cn("mb-1 size-6", pathname.startsWith("/people") ? "text-black" : "text-gray-400")} />,
-      active: pathname.startsWith("/people"),
-    },
-    routes.has("Equity") &&
-      equityLinks.length > 0 && {
-        label: "Equity",
-        href: "#",
-        icon: (
-          <ChartPie
-            className={cn(
-              "mb-1 size-6",
-              pathname.startsWith("/equity") || equitySheet ? "text-black" : "text-gray-400",
-            )}
-          />
-        ),
-        active: pathname.startsWith("/equity") || equitySheet,
-        onClick: (e: React.MouseEvent) => {
-          e.preventDefault();
-          setEquitySheet(true);
-        },
-      },
-    {
-      label: "More",
-      href: "#",
-      icon: <MoreHorizontal className={cn("mb-1 size-6", isOpen ? "text-black" : "text-gray-400")} />,
-      active: isOpen,
-      modal: true,
-    },
-  ];
-
-  function isNavTab(tab: unknown): tab is NavTab {
-    return !!tab;
-  }
-  const filteredNavTabs = navTabs.filter(isNavTab);
-
-  const companySection = {
-    label: company.name,
-    icon: (
-      <span className="relative mr-3 size-6">
-        <Image src={company.logo_url || defaultCompanyLogo} fill className="rounded-sm object-contain" alt="" />
-      </span>
-    ),
-    hasChevron: (user?.companies?.length ?? 0) > 1,
-    onClick: undefined,
-  };
+  const { user, updatesPath, equityLinks, switchCompany } = useNavData();
 
   const moreSections: MoreSection[] = [
     ...(updatesPath
@@ -173,148 +84,303 @@ export default function BottomNavbar() {
 
   return (
     <>
-      <Dialog open={equitySheet} onOpenChange={setEquitySheet}>
+      <Dialog
+        open={openModal !== null}
+        onOpenChange={(open) => {
+          if (!open) setOpenModal(null);
+        }}
+      >
         <DialogContent
           className={cn(
             "fixed !top-auto left-1/2 mx-auto !mt-0 w-full max-w-md -translate-x-1/2 !translate-y-0 !transform-none rounded-t-2xl rounded-b-none bg-white p-0",
             "border-none shadow-[0px_-2px_24px_rgba(0,0,0,0.11)]",
           )}
-          style={{
-            bottom: "64px",
-            zIndex: 100,
-          }}
+          style={{ bottom: "64px", zIndex: 100 }}
         >
           <DialogHeader className="px-6 pt-6 pb-2">
-            <DialogTitle className="text-lg font-semibold">Equity</DialogTitle>
+            <DialogTitle className="text-lg font-semibold">
+              {openModal === "equity" ? "Equity" : openModal === "more" ? "More" : ""}
+            </DialogTitle>
           </DialogHeader>
-          <ul className="flex flex-col px-2 pb-3">
-            {equityModalSections.map((link) => (
-              <li key={link.label}>
-                <Link
-                  href={link.href}
-                  className="flex w-full items-center rounded-t-lg px-4 py-3 text-base transition-colors hover:bg-gray-100"
-                  onClick={() => setEquitySheet(false)}
-                >
-                  <span>{link.label}</span>
-                  <ChevronRight className="ml-auto size-4" />
-                </Link>
-              </li>
-            ))}
-          </ul>
+          {openModal === "equity" && (
+            <ul className="flex flex-col px-2 pb-3">
+              {equityModalSections.map((link) => (
+                <li key={link.label}>
+                  <Link
+                    href={link.href}
+                    className="flex w-full items-center rounded-t-lg px-4 py-3 text-base transition-colors hover:bg-gray-100"
+                    onClick={() => setOpenModal(null)}
+                  >
+                    <span>{link.label}</span>
+                    <ChevronRight className="ml-auto size-4" />
+                  </Link>
+                </li>
+              ))}
+            </ul>
+          )}
+          {openModal === "more" && (
+            <ul className="flex flex-col px-2 pb-3">
+              {user.companies.length > 1 ? (
+                <li className="px-2 pt-2 pb-1">
+                  <DropdownMenu>
+                    <DropdownMenuTrigger asChild>
+                      <button
+                        className="flex w-full items-center rounded-lg px-2 py-2 text-base font-semibold transition-colors hover:bg-gray-100 focus:outline-none"
+                        aria-label="Switch company"
+                      >
+                        <CompanyName />
+                        <ChevronsUpDown className="ml-auto h-4 w-4" />
+                      </button>
+                    </DropdownMenuTrigger>
+                    <DropdownMenuContent className="w-[--radix-dropdown-menu-trigger-width]" align="start">
+                      {user.companies.map((company) => (
+                        <DropdownMenuItem
+                          key={company.id}
+                          onSelect={() => {
+                            if (user.currentCompanyId !== company.id) void switchCompany(company.id);
+                            setOpenModal(null);
+                          }}
+                          className="flex items-center gap-2"
+                        >
+                          <Image
+                            src={company.logo_url || defaultCompanyLogo}
+                            width={20}
+                            height={20}
+                            className="rounded-xs"
+                            alt=""
+                          />
+                          <span className="line-clamp-1">{company.name}</span>
+                          {company.id === user.currentCompanyId && (
+                            <div className="ml-auto size-2 rounded-full bg-blue-500"></div>
+                          )}
+                        </DropdownMenuItem>
+                      ))}
+                    </DropdownMenuContent>
+                  </DropdownMenu>
+                </li>
+              ) : (
+                <li className="px-2 pt-2 pb-1">
+                  <div className="flex items-center gap-2">
+                    <CompanyName />
+                  </div>
+                </li>
+              )}
+              {moreSections.map((item) => {
+                if (item.type === "logout") {
+                  return (
+                    <li key={item.label}>
+                      <SignOutButton>
+                        <button
+                          className="flex w-full items-center rounded-t-lg px-4 py-3 text-base transition-colors hover:bg-gray-100"
+                          onClick={() => setOpenModal(null)}
+                          type="button"
+                          style={{ background: "none", border: 0 }}
+                        >
+                          {item.icon}
+                          <span>{item.label}</span>
+                        </button>
+                      </SignOutButton>
+                    </li>
+                  );
+                }
+                return (
+                  <li key={item.label}>
+                    <Link
+                      href={{ pathname: item.href }}
+                      className="flex w-full items-center rounded-t-lg px-4 py-3 text-base transition-colors hover:bg-gray-100"
+                      onClick={() => {
+                        setOpenModal(null);
+                        sidebar.setOpenMobile(false);
+                      }}
+                    >
+                      {item.icon}
+                      <span>{item.label}</span>
+                      {item.hasChevron ? <ChevronRight className="ml-auto size-4" /> : null}
+                    </Link>
+                  </li>
+                );
+              })}
+            </ul>
+          )}
           <DialogClose asChild className="absolute top-2 right-4 rounded-full p-2 hover:bg-gray-200"></DialogClose>
         </DialogContent>
       </Dialog>
 
-      <Dialog open={isOpen} onOpenChange={setIsOpen}>
-        <DialogContent
-          className={cn(
-            "fixed !top-auto left-1/2 mx-auto !mt-0 w-full max-w-md -translate-x-1/2 !translate-y-0 !transform-none rounded-t-2xl rounded-b-none bg-white p-0",
-            "border-none shadow-[0px_-2px_24px_rgba(0,0,0,0.11)]",
-          )}
-          style={{
-            bottom: "64px",
-            zIndex: 100,
-          }}
-        >
-          <DialogHeader className="px-6 pt-6 pb-2">
-            <DialogTitle className="text-lg font-semibold">More</DialogTitle>
-          </DialogHeader>
-          <ul className="flex flex-col px-2 pb-3">
-            <li>
-              <button
-                className="flex w-full items-center rounded-t-lg px-4 py-3 text-base font-semibold transition-colors hover:bg-gray-100"
-                onClick={companySection.onClick}
-                style={{ background: "none", border: 0 }}
-                tabIndex={0}
-              >
-                {companySection.icon}
-                <span>{companySection.label}</span>
-                {companySection.hasChevron ? <ChevronsUpDown className="ml-auto size-4" /> : null}
-              </button>
-            </li>
-            {moreSections.map((item) => {
-              if (item.type === "logout") {
-                return (
-                  <li key={item.label}>
-                    <SignOutButton>
-                      <button
-                        className="flex w-full items-center rounded-t-lg px-4 py-3 text-base transition-colors hover:bg-gray-100"
-                        onClick={() => setIsOpen(false)}
-                        type="button"
-                        style={{ background: "none", border: 0 }}
-                      >
-                        {item.icon}
-                        <span>{item.label}</span>
-                      </button>
-                    </SignOutButton>
-                  </li>
-                );
-              }
-              return (
-                <li key={item.label}>
-                  <Link
-                    href={{ pathname: item.href }}
-                    className="flex w-full items-center rounded-t-lg px-4 py-3 text-base transition-colors hover:bg-gray-100"
-                    onClick={() => {
-                      setIsOpen(false);
-                      sidebar.setOpenMobile(false);
-                    }}
-                  >
-                    {item.icon}
-                    <span>{item.label}</span>
-                    {item.hasChevron ? <ChevronRight className="ml-auto size-4" /> : null}
-                  </Link>
-                </li>
-              );
-            })}
-          </ul>
-        </DialogContent>
-      </Dialog>
-
       <nav className="fixed right-0 bottom-0 left-0 z-100 border-t border-gray-200 bg-white shadow-lg md:hidden">
-        <ul className="flex h-16 items-center justify-between px-2">
-          {filteredNavTabs.map((tab) => (
-            <li key={tab.label} className="mx-1 flex flex-1 justify-center">
-              {tab.label === "Equity" ? (
-                <button
-                  className="flex flex-col items-center pt-1 text-xs text-gray-500 hover:text-black focus:outline-none"
-                  aria-label="Open equity menu"
-                  onClick={tab.onClick}
-                  type="button"
-                >
-                  <ChartPie className={cn("mb-1 size-6", tab.active ? "text-black" : "text-gray-400")} />
-                  <span className={tab.active ? "font-semibold text-black" : "text-gray-400"}>Equity</span>
-                </button>
-              ) : tab.modal ? (
-                <button
-                  className="flex flex-col items-center pt-1 text-xs text-gray-500 hover:text-black"
-                  aria-label="Open more menu"
-                  onClick={() => setIsOpen(true)}
-                  type="button"
-                >
-                  {tab.icon}
-                  <span className="text-xs">More</span>
-                </button>
-              ) : (
-                <Link
-                  href={{ pathname: tab.href }}
-                  className="flex flex-col items-center pt-1 text-xs"
-                  aria-current={tab.active ? "page" : undefined}
-                  onClick={() => sidebar.setOpenMobile(false)}
-                >
-                  <div className="relative flex flex-col items-center">
-                    {tab.icon}
-                    {tab.showDot ? (
-                      <span className="absolute -top-2 left-4 h-3 w-3 rounded-full border-2 border-white bg-blue-500" />
-                    ) : null}
-                  </div>
-                  <span className={tab.active ? "font-semibold text-black" : "text-gray-400"}>{tab.label}</span>
-                </Link>
-              )}
-            </li>
-          ))}
-        </ul>
+        <MobileNavLinks
+          onEquityClick={() => setOpenModal("equity")}
+          onMoreClick={() => setOpenModal("more")}
+          openModal={openModal}
+        />
       </nav>
     </>
   );
 }
+
+const CompanyName = () => {
+  const { company } = useNavData();
+  return (
+    <>
+      {company.name ? (
+        <Link href="/settings" className="relative size-6">
+          <Image src={company.logo_url || defaultCompanyLogo} fill className="rounded-sm" alt="" />
+        </Link>
+      ) : null}
+      <div>
+        <span className="line-clamp-1 text-sm font-bold" title={company.name ?? ""}>
+          {company.name}
+        </span>
+      </div>
+    </>
+  );
+};
+
+export const MobileNavLinks = ({
+  onEquityClick,
+  onMoreClick,
+  openModal,
+}: {
+  onEquityClick: () => void;
+  onMoreClick: () => void;
+  openModal: "equity" | "more" | null;
+}) => {
+  const { pathname, routes, invoicesData, isInvoiceActionable, equityLinks } = useNavData();
+  const sidebar = useSidebar();
+  const showInvoicesDot = (invoicesData?.filter(isInvoiceActionable).length ?? 0) > 0;
+
+  return (
+    <ul className="flex h-16 items-center justify-between px-2">
+      {routes.has("Invoices") && (
+        <MobileNavItem
+          href="/invoices"
+          icon={
+            <ReceiptIcon
+              className={cn(
+                "mb-1 size-6",
+                openModal === null && pathname.startsWith("/invoices") ? "text-black" : "text-gray-400",
+              )}
+            />
+          }
+          label="Invoices"
+          active={openModal === null && pathname.startsWith("/invoices")}
+          showDot={showInvoicesDot}
+          onClick={() => sidebar.setOpenMobile(false)}
+        />
+      )}
+      {routes.has("Documents") && (
+        <MobileNavItem
+          href="/documents"
+          icon={
+            <Files
+              className={cn(
+                "mb-1 size-6",
+                openModal === null && pathname.startsWith("/documents") ? "text-black" : "text-gray-400",
+              )}
+            />
+          }
+          label="Documents"
+          active={openModal === null && pathname.startsWith("/documents")}
+          onClick={() => sidebar.setOpenMobile(false)}
+        />
+      )}
+      {routes.has("People") && (
+        <MobileNavItem
+          href="/people"
+          icon={
+            <Users
+              className={cn(
+                "mb-1 size-6",
+                openModal === null && pathname.startsWith("/people") ? "text-black" : "text-gray-400",
+              )}
+            />
+          }
+          label="People"
+          active={openModal === null && pathname.startsWith("/people")}
+          onClick={() => sidebar.setOpenMobile(false)}
+        />
+      )}
+
+      {routes.has("Equity") && equityLinks.length > 0 && (
+        <MobileNavItem
+          icon={
+            <ChartPie
+              className={cn("mb-1 size-6", openModal === "equity" ? "font-bold text-black" : "text-gray-400")}
+            />
+          }
+          label="Equity"
+          active={openModal === "equity"}
+          onClick={onEquityClick}
+          asButton
+        />
+      )}
+      <MobileNavItem
+        icon={
+          <MoreHorizontal
+            className={cn("mb-1 size-6", openModal === "more" ? "font-bold text-black" : "text-gray-400")}
+          />
+        }
+        label="More"
+        active={openModal === "more"}
+        onClick={onMoreClick}
+        asButton
+      />
+    </ul>
+  );
+};
+
+const MobileNavItem = ({
+  href,
+  icon,
+  label,
+  active,
+  showDot,
+  onClick,
+  asButton = false,
+}: {
+  href?: string;
+  icon: React.ReactNode;
+  label: string;
+  active: boolean;
+  showDot?: boolean;
+  onClick: () => void;
+  asButton?: boolean;
+}) => {
+  const content = (
+    <>
+      <div className="relative flex flex-col items-center">
+        {icon}
+        {showDot ? (
+          <span className="absolute -top-2 left-4 h-3 w-3 rounded-full border-2 border-white bg-blue-500" />
+        ) : null}
+      </div>
+      <span className={active ? "font-semibold text-black" : "text-gray-400"}>{label}</span>
+    </>
+  );
+
+  if (asButton) {
+    return (
+      <li className="mx-1 flex flex-1 justify-center">
+        <button
+          className="flex flex-col items-center pt-1 text-xs text-gray-500 hover:text-black focus:outline-none"
+          aria-label={label}
+          onClick={onClick}
+          type="button"
+        >
+          {content}
+        </button>
+      </li>
+    );
+  }
+  return (
+    <li className="mx-1 flex flex-1 justify-center">
+      <Link
+        href={{ pathname: href || "#" }}
+        className="flex flex-col items-center pt-1 text-xs"
+        aria-current={active ? "page" : undefined}
+        onClick={onClick}
+      >
+        {content}
+      </Link>
+    </li>
+  );
+};

--- a/frontend/components/BottomNavbar.tsx
+++ b/frontend/components/BottomNavbar.tsx
@@ -1,0 +1,320 @@
+"use client";
+
+import { SignOutButton } from "@clerk/nextjs";
+import {
+  ChartPie,
+  ChevronRight,
+  ChevronsUpDown,
+  Files,
+  LogOut,
+  MoreHorizontal,
+  ReceiptIcon,
+  Rss,
+  Settings,
+  Users,
+} from "lucide-react";
+import Image from "next/image";
+import Link from "next/link";
+import * as React from "react";
+import { Dialog, DialogClose, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog";
+import { useSidebar } from "@/components/ui/sidebar";
+import defaultCompanyLogo from "@/images/default-company-logo.svg";
+import { cn } from "@/utils";
+import { useNavData } from "@/utils/use-navdata";
+
+type MoreSection =
+  | {
+      type: "link";
+      label: string;
+      href: string;
+      icon: React.ReactNode;
+      hasChevron: boolean;
+    }
+  | {
+      type: "logout";
+      label: string;
+      icon: React.ReactNode;
+      hasChevron: boolean;
+      action: () => void;
+    };
+
+type NavTab = {
+  label: string;
+  href: string;
+  icon: React.ReactNode;
+  active: boolean;
+  showDot?: boolean;
+  onClick?: (e: React.MouseEvent) => void;
+  modal?: boolean;
+};
+
+export default function BottomNavbar() {
+  const [equitySheet, setEquitySheet] = React.useState(false);
+  const sidebar = useSidebar();
+  const {
+    user,
+    company,
+    pathname,
+    routes,
+    invoicesData,
+    isInvoiceActionable,
+    updatesPath,
+    equityLinks,
+    isOpen,
+    setIsOpen,
+  } = useNavData();
+
+  const showInvoicesDot = (invoicesData?.filter(isInvoiceActionable).length ?? 0) > 0;
+
+  const navTabs: (NavTab | false)[] = [
+    routes.has("Invoices") && {
+      label: "Invoices",
+      href: "/invoices",
+      icon: (
+        <ReceiptIcon className={cn("mb-1 size-6", pathname.startsWith("/invoices") ? "text-black" : "text-gray-400")} />
+      ),
+      active: pathname.startsWith("/invoices"),
+      showDot: showInvoicesDot,
+    },
+    routes.has("Documents") && {
+      label: "Documents",
+      href: "/documents",
+      icon: (
+        <Files
+          className={cn(
+            "mb-1 size-6",
+            pathname.startsWith("/documents") ? "stroke-[2.5] text-black" : "stroke-[1.25] text-gray-400",
+          )}
+        />
+      ),
+      active: pathname.startsWith("/documents"),
+    },
+    routes.has("People") && {
+      label: "People",
+      href: "/people",
+      icon: <Users className={cn("mb-1 size-6", pathname.startsWith("/people") ? "text-black" : "text-gray-400")} />,
+      active: pathname.startsWith("/people"),
+    },
+    routes.has("Equity") &&
+      equityLinks.length > 0 && {
+        label: "Equity",
+        href: "#",
+        icon: (
+          <ChartPie
+            className={cn(
+              "mb-1 size-6",
+              pathname.startsWith("/equity") || equitySheet ? "text-black" : "text-gray-400",
+            )}
+          />
+        ),
+        active: pathname.startsWith("/equity") || equitySheet,
+        onClick: (e: React.MouseEvent) => {
+          e.preventDefault();
+          setEquitySheet(true);
+        },
+      },
+    {
+      label: "More",
+      href: "#",
+      icon: <MoreHorizontal className={cn("mb-1 size-6", isOpen ? "text-black" : "text-gray-400")} />,
+      active: isOpen,
+      modal: true,
+    },
+  ];
+
+  function isNavTab(tab: unknown): tab is NavTab {
+    return !!tab;
+  }
+  const filteredNavTabs = navTabs.filter(isNavTab);
+
+  const companySection = {
+    label: company.name,
+    icon: (
+      <span className="relative mr-3 size-6">
+        <Image src={company.logo_url || defaultCompanyLogo} fill className="rounded-sm object-contain" alt="" />
+      </span>
+    ),
+    hasChevron: (user?.companies?.length ?? 0) > 1,
+    onClick: undefined,
+  };
+
+  const moreSections: MoreSection[] = [
+    ...(updatesPath
+      ? [
+          {
+            type: "link" as const,
+            label: "Updates",
+            href: "/updates/company",
+            icon: <Rss className="mr-3 size-5" />,
+            hasChevron: true,
+          },
+        ]
+      : []),
+    {
+      type: "link",
+      label: "Settings",
+      href: "/settings",
+      icon: <Settings className="mr-3 size-5" />,
+      hasChevron: true,
+    },
+    {
+      type: "logout",
+      label: "Log out",
+      icon: <LogOut className="mr-3 size-5" />,
+      hasChevron: false,
+      action: () => (window.location.href = "/sign-out"),
+    },
+  ];
+
+  const equityModalSections = equityLinks.map((link) => ({
+    label: link.label,
+    href: link.route,
+  }));
+
+  return (
+    <>
+      <Dialog open={equitySheet} onOpenChange={setEquitySheet}>
+        <DialogContent
+          className={cn(
+            "fixed !top-auto left-1/2 mx-auto !mt-0 w-full max-w-md -translate-x-1/2 !translate-y-0 !transform-none rounded-t-2xl rounded-b-none bg-white p-0",
+            "border-none shadow-[0px_-2px_24px_rgba(0,0,0,0.11)]",
+          )}
+          style={{
+            bottom: "64px",
+            zIndex: 100,
+          }}
+        >
+          <DialogHeader className="px-6 pt-6 pb-2">
+            <DialogTitle className="text-lg font-semibold">Equity</DialogTitle>
+          </DialogHeader>
+          <ul className="flex flex-col px-2 pb-3">
+            {equityModalSections.map((link) => (
+              <li key={link.label}>
+                <Link
+                  href={link.href}
+                  className="flex w-full items-center rounded-t-lg px-4 py-3 text-base transition-colors hover:bg-gray-100"
+                  onClick={() => setEquitySheet(false)}
+                >
+                  <span>{link.label}</span>
+                  <ChevronRight className="ml-auto size-4" />
+                </Link>
+              </li>
+            ))}
+          </ul>
+          <DialogClose asChild className="absolute top-2 right-4 rounded-full p-2 hover:bg-gray-200"></DialogClose>
+        </DialogContent>
+      </Dialog>
+
+      <Dialog open={isOpen} onOpenChange={setIsOpen}>
+        <DialogContent
+          className={cn(
+            "fixed !top-auto left-1/2 mx-auto !mt-0 w-full max-w-md -translate-x-1/2 !translate-y-0 !transform-none rounded-t-2xl rounded-b-none bg-white p-0",
+            "border-none shadow-[0px_-2px_24px_rgba(0,0,0,0.11)]",
+          )}
+          style={{
+            bottom: "64px",
+            zIndex: 100,
+          }}
+        >
+          <DialogHeader className="px-6 pt-6 pb-2">
+            <DialogTitle className="text-lg font-semibold">More</DialogTitle>
+          </DialogHeader>
+          <ul className="flex flex-col px-2 pb-3">
+            <li>
+              <button
+                className="flex w-full items-center rounded-t-lg px-4 py-3 text-base font-semibold transition-colors hover:bg-gray-100"
+                onClick={companySection.onClick}
+                style={{ background: "none", border: 0 }}
+                tabIndex={0}
+              >
+                {companySection.icon}
+                <span>{companySection.label}</span>
+                {companySection.hasChevron ? <ChevronsUpDown className="ml-auto size-4" /> : null}
+              </button>
+            </li>
+            {moreSections.map((item) => {
+              if (item.type === "logout") {
+                return (
+                  <li key={item.label}>
+                    <SignOutButton>
+                      <button
+                        className="flex w-full items-center rounded-t-lg px-4 py-3 text-base transition-colors hover:bg-gray-100"
+                        onClick={() => setIsOpen(false)}
+                        type="button"
+                        style={{ background: "none", border: 0 }}
+                      >
+                        {item.icon}
+                        <span>{item.label}</span>
+                      </button>
+                    </SignOutButton>
+                  </li>
+                );
+              }
+              return (
+                <li key={item.label}>
+                  <Link
+                    href={{ pathname: item.href }}
+                    className="flex w-full items-center rounded-t-lg px-4 py-3 text-base transition-colors hover:bg-gray-100"
+                    onClick={() => {
+                      setIsOpen(false);
+                      sidebar.setOpenMobile(false);
+                    }}
+                  >
+                    {item.icon}
+                    <span>{item.label}</span>
+                    {item.hasChevron ? <ChevronRight className="ml-auto size-4" /> : null}
+                  </Link>
+                </li>
+              );
+            })}
+          </ul>
+        </DialogContent>
+      </Dialog>
+
+      <nav className="fixed right-0 bottom-0 left-0 z-100 border-t border-gray-200 bg-white shadow-lg md:hidden">
+        <ul className="flex h-16 items-center justify-between px-2">
+          {filteredNavTabs.map((tab) => (
+            <li key={tab.label} className="mx-1 flex flex-1 justify-center">
+              {tab.label === "Equity" ? (
+                <button
+                  className="flex flex-col items-center pt-1 text-xs text-gray-500 hover:text-black focus:outline-none"
+                  aria-label="Open equity menu"
+                  onClick={tab.onClick}
+                  type="button"
+                >
+                  <ChartPie className={cn("mb-1 size-6", tab.active ? "text-black" : "text-gray-400")} />
+                  <span className={tab.active ? "font-semibold text-black" : "text-gray-400"}>Equity</span>
+                </button>
+              ) : tab.modal ? (
+                <button
+                  className="flex flex-col items-center pt-1 text-xs text-gray-500 hover:text-black"
+                  aria-label="Open more menu"
+                  onClick={() => setIsOpen(true)}
+                  type="button"
+                >
+                  {tab.icon}
+                  <span className="text-xs">More</span>
+                </button>
+              ) : (
+                <Link
+                  href={{ pathname: tab.href }}
+                  className="flex flex-col items-center pt-1 text-xs"
+                  aria-current={tab.active ? "page" : undefined}
+                  onClick={() => sidebar.setOpenMobile(false)}
+                >
+                  <div className="relative flex flex-col items-center">
+                    {tab.icon}
+                    {tab.showDot ? (
+                      <span className="absolute -top-2 left-4 h-3 w-3 rounded-full border-2 border-white bg-blue-500" />
+                    ) : null}
+                  </div>
+                  <span className={tab.active ? "font-semibold text-black" : "text-gray-400"}>{tab.label}</span>
+                </Link>
+              )}
+            </li>
+          ))}
+        </ul>
+      </nav>
+    </>
+  );
+}

--- a/frontend/components/BottomNavbar.tsx
+++ b/frontend/components/BottomNavbar.tsx
@@ -48,6 +48,7 @@ export default function BottomNavbar() {
   const [openModal, setOpenModal] = React.useState<"equity" | "more" | null>(null);
   const sidebar = useSidebar();
   const { user, updatesPath, equityLinks, switchCompany } = useNavData();
+  const dialogContentRef = React.useRef<HTMLDivElement>(null);
 
   const moreSections: MoreSection[] = [
     ...(updatesPath
@@ -91,6 +92,7 @@ export default function BottomNavbar() {
         }}
       >
         <DialogContent
+          ref={dialogContentRef}
           className={cn(
             "fixed !top-auto left-1/2 mx-auto !mt-0 w-full max-w-md -translate-x-1/2 !translate-y-0 !transform-none rounded-t-2xl rounded-b-none bg-white p-0",
             "border-none shadow-[0px_-2px_24px_rgba(0,0,0,0.11)]",
@@ -132,7 +134,11 @@ export default function BottomNavbar() {
                         <ChevronsUpDown className="ml-auto h-4 w-4" />
                       </button>
                     </DropdownMenuTrigger>
-                    <DropdownMenuContent className="w-[--radix-dropdown-menu-trigger-width]" align="start">
+                    <DropdownMenuContent
+                      className="w-[--radix-dropdown-menu-trigger-width]"
+                      align="start"
+                      container={dialogContentRef.current}
+                    >
                       {user.companies.map((company) => (
                         <DropdownMenuItem
                           key={company.id}

--- a/frontend/components/DashboardHeader.tsx
+++ b/frontend/components/DashboardHeader.tsx
@@ -1,15 +1,18 @@
 import React from "react";
 import { SidebarTrigger } from "@/components/ui/sidebar";
+import { useIsMobile } from "@/utils/use-mobile";
 
 export function DashboardHeader({ title, headerActions }: { title: React.ReactNode; headerActions?: React.ReactNode }) {
+  const isMobile = useIsMobile();
+
   return (
-    <header className="pt-2 md:pt-4">
+    <header className="pt-4">
       <div className="grid gap-y-8">
         <div className="grid items-center justify-between gap-3 md:flex">
           <div>
             <div className="flex items-center justify-between gap-2">
-              <SidebarTrigger className="md:hidden" />
-              <h1 className="text-sm font-bold">{title}</h1>
+              {!isMobile && <SidebarTrigger className="md:hidden" />}
+              <h1 className="text-xl font-bold md:text-sm">{title}</h1>
             </div>
           </div>
 

--- a/frontend/components/ui/dropdown-menu.tsx
+++ b/frontend/components/ui/dropdown-menu.tsx
@@ -19,10 +19,13 @@ function DropdownMenuContent({
   className,
   sideOffset = 4,
   align = "start",
+  container,
   ...props
-}: React.ComponentProps<typeof DropdownMenuPrimitive.Content>) {
+}: React.ComponentProps<typeof DropdownMenuPrimitive.Content> & {
+  container?: HTMLElement | null;
+}) {
   return (
-    <DropdownMenuPrimitive.Portal>
+    <DropdownMenuPrimitive.Portal container={container}>
       <DropdownMenuPrimitive.Content
         data-slot="dropdown-menu-content"
         sideOffset={sideOffset}

--- a/frontend/utils/use-navdata.ts
+++ b/frontend/utils/use-navdata.ts
@@ -1,0 +1,51 @@
+import { skipToken } from "@tanstack/react-query";
+import { usePathname } from "next/navigation";
+import React from "react";
+import { navLinks as equityNavLinks } from "../app/(dashboard)/equity";
+import { useIsActionable } from "../app/(dashboard)/invoices";
+import { useCurrentCompany, useCurrentUser } from "../global";
+import { storageKeys } from "../models/constants";
+import { trpc } from "../trpc/client";
+
+export function useNavData() {
+  const user = useCurrentUser();
+  const company = useCurrentCompany();
+  const pathname = usePathname();
+  const routes = new Set(
+    company.routes.flatMap((route) => [route.label, ...(route.subLinks?.map((subLink) => subLink.label) || [])]),
+  );
+  const { data: invoicesData } = trpc.invoices.list.useQuery(
+    user.currentCompanyId && user.roles.administrator
+      ? { companyId: user.currentCompanyId, status: ["received", "approved", "failed"] }
+      : skipToken,
+    { refetchInterval: 30_000 },
+  );
+  const isInvoiceActionable = useIsActionable();
+  const { data: documentsData } = trpc.documents.list.useQuery(
+    user.currentCompanyId && user.id
+      ? {
+          companyId: user.currentCompanyId,
+          userId: user.roles.administrator || user.roles.lawyer ? null : user.id,
+          signable: true,
+        }
+      : skipToken,
+    { refetchInterval: 30_000 },
+  );
+  const updatesPath = company.routes.find((route) => route.label === "Updates")?.name;
+  const equityLinks = equityNavLinks(user, company);
+  const [isOpen, setIsOpen] = React.useState(() => localStorage.getItem(storageKeys.EQUITY_MENU_STATE) === "open");
+
+  return {
+    user,
+    company,
+    pathname,
+    routes,
+    invoicesData,
+    isInvoiceActionable,
+    documentsData,
+    updatesPath,
+    equityLinks,
+    isOpen,
+    setIsOpen,
+  };
+}


### PR DESCRIPTION
Resolves #449 

- PR changes the sidebar to a bottom navbar on mobile screens.
- Refactored nav-related data fetching into a shared `useNavData` hook for reuse in sidebar and navbar

## Demo
### Admin view
https://github.com/user-attachments/assets/281ce18e-ddb6-4bf6-9680-50711933aadf

<img width="394" height="776" alt="Screenshot 2025-07-30 151908" src="https://github.com/user-attachments/assets/a416c737-c102-4db9-a1d2-ceb0c976228e" />

Note: I’ve already developed the Documents page and will push it after a few more iterations.

### Contractor view
<img width="381" height="785" alt="Screenshot 2025-07-29 161439" src="https://github.com/user-attachments/assets/86dab0c7-95e3-4181-b8fe-bdf8c327457d" />
<img width="395" height="793" alt="Screenshot 2025-07-29 181114" src="https://github.com/user-attachments/assets/f7184e41-a222-4fa0-82c8-7c80850a6f46" />
<img width="383" height="786" alt="Screenshot 2025-07-29 203647- 2" src="https://github.com/user-attachments/assets/6aa46243-4864-4c11-9ea9-8f88a9cd207c" />
<img width="393" height="792" alt="Screenshot 2025-07-29 203611" src="https://github.com/user-attachments/assets/19451131-f655-42fa-b527-b05ca76bc9df" />