### PR TITLE
fix: failing mobile navigation test

### DIFF
--- a/e2e/tests/mobile-navigation.spec.ts
+++ b/e2e/tests/mobile-navigation.spec.ts
@@ -70,9 +70,7 @@ test.describe("Mobile navigation", () => {
     await page.getByRole("button", { name: "Toggle Sidebar" }).click();
     await page.getByRole("button", { name: "Equity" }).click();
     await page.getByRole("link", { name: "Dividends" }).click();
-    const breadcrumb = page.getByRole("navigation", { name: "breadcrumb" });
-    await expect(breadcrumb.getByText("Equity")).toBeVisible();
-    await expect(breadcrumb.getByText("Dividends")).toBeVisible();
+    await expect(page.getByRole("heading", { name: "Dividends" })).toBeVisible();
 
     await expect(page.getByRole("link", { name: "Invoices" })).not.toBeVisible();
     await expect(page.getByRole("link", { name: "Documents" })).not.toBeVisible();


### PR DESCRIPTION
Description:

Test for mobile navigation is failing. This is happening due to recent removal of breadcrumb in #699 .

Steps to reproduce:

- Run test for e2e/tests/mobile-navigation.spec.ts

--

Before:

<img width="1060" height="296" alt="Screenshot 2025-08-01 at 7 33 05 PM" src="https://github.com/user-attachments/assets/463320ad-6ebe-4d1a-b48c-0cdeaaf1e154" />


After:

<img width="1119" height="108" alt="Screenshot 2025-08-01 at 7 28 38 PM" src="https://github.com/user-attachments/assets/127ca0d5-31cf-4e83-81e3-5a1c9d9b3441" />

--

Tests:

<img width="1119" height="108" alt="Screenshot 2025-08-01 at 7 28 38 PM" src="https://github.com/user-attachments/assets/127ca0d5-31cf-4e83-81e3-5a1c9d9b3441" />
