### PR TITLE
fix header padding on invoices page

### DIFF
--- a/frontend/app/(dashboard)/invoices/page.tsx
+++ b/frontend/app/(dashboard)/invoices/page.tsx
@@ -404,7 +404,7 @@ export default function InvoicesPage() {
         <TableSkeleton columns={6} />
       ) : data.length > 0 ? (
         <>
-          <div className="flex justify-between md:hidden">
+          <div className="mx-4 flex justify-between md:hidden">
             <h2 className="text-xl font-bold">
               {data.length} {pluralize("invoice", data.length)}
             </h2>


### PR DESCRIPTION
**Before:**
<img width="362" height="533" alt="Screenshot 2025-08-02 at 03 13 38" src="https://github.com/user-attachments/assets/ff3f9f3d-38c8-43c8-8407-71599425b5b3" />

**After:**
<img width="444" height="666" alt="Screenshot 2025-08-02 at 03 13 20" src="https://github.com/user-attachments/assets/b4e4b208-f08c-47af-add2-e1c8b0d1598c" />