### PR TITLE
Implements company funding for dividend payments

### DIFF
--- a/backend/app/models/consolidated_invoice.rb
+++ b/backend/app/models/consolidated_invoice.rb
@@ -10,6 +10,8 @@ class ConsolidatedInvoice < ApplicationRecord
   has_many :invoices, through: :consolidated_invoices_invoices
   has_many :consolidated_payments
   has_many :integration_records, as: :integratable
+  has_many :dividend_rounds
+
   has_one_attached :receipt
   has_one :successful_payment, -> { successful.order(succeeded_at: :desc) }, class_name: "ConsolidatedPayment"
   has_one :quickbooks_journal_entry, -> do

--- a/backend/app/models/dividend_round.rb
+++ b/backend/app/models/dividend_round.rb
@@ -4,6 +4,8 @@ class DividendRound < ApplicationRecord
   include ExternalId
 
   belongs_to :company
+  belongs_to :consolidated_invoice, optional: true
+
   has_many :dividends
   has_many :investor_dividend_rounds
 
@@ -15,6 +17,13 @@ class DividendRound < ApplicationRecord
   validates :ready_for_payment, inclusion: { in: [true, false] }
 
   scope :ready_for_payment, -> { where(ready_for_payment: true) }
+
+  def flexile_fees_in_cents
+    dividends.map do |dividend|
+      calculated_fee = ((dividend.total_amount_in_cents.to_d * 2.9.to_d / 100.to_d) + 30.to_d).round.to_i
+      [30_00, calculated_fee].min
+    end.sum
+  end
 
   def send_dividend_emails
     company.company_investors.joins(:dividends)

--- a/backend/app/services/dividend_consolidated_invoice_creation.rb
+++ b/backend/app/services/dividend_consolidated_invoice_creation.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+class DividendConsolidatedInvoiceCreation
+  attr_reader :dividend_round
+
+  def initialize(dividend_round)
+    @dividend_round = dividend_round
+  end
+
+  def process
+    raise "Should not generate consolidated invoice for company #{company.id}" unless company.active? && company.bank_account_ready?
+
+    dividend_amount_cents = dividend_round.total_amount_in_cents
+    fee_cents = dividend_round.flexile_fees_in_cents
+
+    consolidated_invoice = company.consolidated_invoices.create!(
+      invoice_date: Date.current,
+      invoice_number: "FX-DIV-#{company.consolidated_invoices.count + 1}",
+      status: ConsolidatedInvoice::SENT,
+      period_start_date: dividend_round.issued_at.to_date,
+      period_end_date: dividend_round.issued_at.to_date,
+      invoice_amount_cents: dividend_amount_cents,
+      flexile_fee_cents: fee_cents,
+      transfer_fee_cents: 0,
+      total_cents: dividend_amount_cents + fee_cents,
+    )
+
+    dividend_round.update!(consolidated_invoice: consolidated_invoice)
+    consolidated_invoice
+  end
+
+  private
+    def company
+      dividend_round.company
+    end
+end

--- a/backend/app/services/dividend_report_csv.rb
+++ b/backend/app/services/dividend_report_csv.rb
@@ -27,10 +27,7 @@ class DividendReportCsv
                                        .where(dividend_payments: { status: Payments::Status::SUCCEEDED })
                                        .sum("dividend_payments.transfer_fee_in_cents") / 100.0
 
-        flexile_fees = dividends.map do |dividend|
-          calculated_fee = ((dividend.total_amount_in_cents.to_d * 2.9.to_d / 100.to_d) + 30.to_d).round.to_i
-          [30_00, calculated_fee].min
-        end.sum / 100.0
+        flexile_fees = dividend_round.flexile_fees_in_cents / 100.0
 
         total_ach_pull = total_dividends + flexile_fees
 

--- a/backend/app/services/pay_investor_dividends.rb
+++ b/backend/app/services/pay_investor_dividends.rb
@@ -16,12 +16,10 @@ class PayInvestorDividends
   end
 
   def process
-    return if dividends.any? { !_1.status.in?([Dividend::ISSUED, Dividend::RETAINED]) } ||
-              user.tax_information_confirmed_at.nil? ||
-              user.bank_account_for_dividends.nil?
+    return if dividends.any? { !_1.immediately_payable? }
     return unless user.has_verified_tax_id?
     raise "Feature unsupported for company #{company.id}" unless company.equity_enabled?
-    raise "Flexile balance insufficient to pay for dividends to investor #{company_investor.id}" unless Wise::AccountBalance.has_sufficient_flexile_balance?(net_amount_in_usd)
+    raise "Not enough account balance to pay out for company #{company.id}" unless company.has_sufficient_balance?(net_amount_in_usd)
     raise "Unknown country for user #{user.id}" if user.country_code.blank?
 
     if user.sanctioned_country_resident?

--- a/backend/db/migrate/20250802054705_add_consolidated_invoice_id_to_dividend_rounds.rb
+++ b/backend/db/migrate/20250802054705_add_consolidated_invoice_id_to_dividend_rounds.rb
@@ -1,0 +1,5 @@
+class AddConsolidatedInvoiceIdToDividendRounds < ActiveRecord::Migration[8.0]
+  def change
+    add_column :dividend_rounds, :consolidated_invoice_id, :bigint
+  end
+end

--- a/backend/db/schema.rb
+++ b/backend/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_07_31_200856) do
+ActiveRecord::Schema[8.0].define(version: 2025_08_02_054705) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -382,6 +382,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_07_31_200856) do
     t.boolean "return_of_capital", null: false
     t.boolean "ready_for_payment", default: false, null: false
     t.text "release_document"
+    t.bigint "consolidated_invoice_id"
     t.index ["company_id"], name: "index_dividend_rounds_on_company_id"
     t.index ["external_id"], name: "index_dividend_rounds_on_external_id", unique: true
   end

--- a/backend/spec/models/consolidated_invoice_spec.rb
+++ b/backend/spec/models/consolidated_invoice_spec.rb
@@ -7,6 +7,7 @@ RSpec.describe ConsolidatedInvoice do
     it { is_expected.to have_many(:invoices).through(:consolidated_invoices_invoices) }
     it { is_expected.to have_many(:consolidated_payments) }
     it { is_expected.to have_many(:integration_records) }
+    it { is_expected.to have_many(:dividend_rounds) }
     it { is_expected.to have_one(:quickbooks_journal_entry) }
   end
 

--- a/backend/spec/models/dividend_round_spec.rb
+++ b/backend/spec/models/dividend_round_spec.rb
@@ -3,6 +3,7 @@
 RSpec.describe DividendRound do
   describe "associations" do
     it { is_expected.to belong_to(:company) }
+    it { is_expected.to belong_to(:consolidated_invoice).optional }
     it { is_expected.to have_many(:dividends) }
     it { is_expected.to have_many(:investor_dividend_rounds) }
   end

--- a/backend/spec/models/dividend_spec.rb
+++ b/backend/spec/models/dividend_spec.rb
@@ -113,4 +113,64 @@ RSpec.describe Dividend do
       expect(dividend.retained_reason).to eq(reason)
     end
   end
+
+  describe "#company_charged?" do
+    context "when dividend round has no consolidated invoice" do
+      let(:dividend) { create(:dividend) }
+
+      it "returns false" do
+        expect(dividend.company_charged?).to eq(false)
+      end
+    end
+
+    context "when dividend round has a consolidated invoice that is paid or pending payment" do
+      let(:consolidated_invoice) { create(:consolidated_invoice, status: ConsolidatedInvoice::SENT) }
+      let(:dividend_round) { create(:dividend_round, consolidated_invoice:) }
+      let(:dividend) { create(:dividend, dividend_round:) }
+
+      it "returns true" do
+        expect(dividend.company_charged?).to eq(true)
+      end
+    end
+
+    context "when dividend round has a consolidated invoice that is not paid or pending payment" do
+      let(:consolidated_invoice) { create(:consolidated_invoice, status: ConsolidatedInvoice::FAILED) }
+      let(:dividend_round) { create(:dividend_round, consolidated_invoice:) }
+      let(:dividend) { create(:dividend, dividend_round:) }
+
+      it "returns false" do
+        expect(dividend.company_charged?).to eq(false)
+      end
+    end
+  end
+
+  describe "#company_paid?" do
+    context "when dividend round has no consolidated invoice" do
+      let(:dividend) { create(:dividend) }
+
+      it "returns false" do
+        expect(dividend.company_paid?).to eq(false)
+      end
+    end
+
+    context "when dividend round has a paid consolidated invoice" do
+      let(:consolidated_invoice) { create(:consolidated_invoice, :paid) }
+      let(:dividend_round) { create(:dividend_round, consolidated_invoice:) }
+      let(:dividend) { create(:dividend, dividend_round:) }
+
+      it "returns true" do
+        expect(dividend.company_paid?).to eq(true)
+      end
+    end
+
+    context "when dividend round has an unpaid consolidated invoice" do
+      let(:consolidated_invoice) { create(:consolidated_invoice, status: ConsolidatedInvoice::SENT) }
+      let(:dividend_round) { create(:dividend_round, consolidated_invoice:) }
+      let(:dividend) { create(:dividend, dividend_round:) }
+
+      it "returns false" do
+        expect(dividend.company_paid?).to eq(false)
+      end
+    end
+  end
 end

--- a/backend/spec/services/dividend_consolidated_invoice_creation_spec.rb
+++ b/backend/spec/services/dividend_consolidated_invoice_creation_spec.rb
@@ -1,0 +1,65 @@
+# frozen_string_literal: true
+
+RSpec.describe DividendConsolidatedInvoiceCreation do
+  describe "#process" do
+    let(:company) { create(:company, :active, :with_bank_account) }
+    let(:dividend_round) { create(:dividend_round, company:, total_amount_in_cents: 50_000) }
+    let(:service) { described_class.new(dividend_round) }
+
+    context "when company is active and has bank account" do
+      before do
+        allow(dividend_round).to receive(:flexile_fees_in_cents).and_return(2_000)
+      end
+
+      it "creates a consolidated invoice with correct attributes" do
+        consolidated_invoice = service.process
+
+        expect(consolidated_invoice).to be_persisted
+        expect(consolidated_invoice.company).to eq(company)
+        expect(consolidated_invoice.invoice_date).to eq(Date.current)
+        expect(consolidated_invoice.invoice_number).to start_with("FX-DIV-")
+        expect(consolidated_invoice.status).to eq(ConsolidatedInvoice::SENT)
+        expect(consolidated_invoice.period_start_date).to eq(dividend_round.issued_at.to_date)
+        expect(consolidated_invoice.period_end_date).to eq(dividend_round.issued_at.to_date)
+        expect(consolidated_invoice.invoice_amount_cents).to eq(50_000)
+        expect(consolidated_invoice.flexile_fee_cents).to eq(2_000)
+        expect(consolidated_invoice.transfer_fee_cents).to eq(0)
+        expect(consolidated_invoice.total_cents).to eq(52_000)
+      end
+
+      it "associates the consolidated invoice with the dividend round" do
+        consolidated_invoice = service.process
+        dividend_round.reload
+
+        expect(dividend_round.consolidated_invoice).to eq(consolidated_invoice)
+      end
+
+      it "generates correct invoice number based on existing count" do
+        create(:consolidated_invoice, company:)
+        consolidated_invoice = service.process
+
+        expect(consolidated_invoice.invoice_number).to eq("FX-DIV-2")
+      end
+    end
+
+    context "when company is not active" do
+      let(:company) { create(:company, :with_bank_account, status: "inactive") }
+
+      it "raises an error" do
+        expect { service.process }.to raise_error("Should not generate consolidated invoice for company #{company.id}")
+      end
+    end
+
+    context "when company does not have bank account ready" do
+      let(:company) { create(:company, :active) }
+
+      before do
+        allow(company).to receive(:bank_account_ready?).and_return(false)
+      end
+
+      it "raises an error" do
+        expect { service.process }.to raise_error("Should not generate consolidated invoice for company #{company.id}")
+      end
+    end
+  end
+end


### PR DESCRIPTION
This PR implements the functionality to fund company balances, by pulling money from the customer via Stripe, and sending to Wise, which would be needed to process dividend payout, this is needed to complete implementation for #10 on #648