### PR TITLE
Add flexile logo to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <p align="center">
   <picture>
-    <img src="https://github.com/antiwork/flexile/blob/main/frontend/public/icon-192.png" height="128" alt="Flexile Logo">
+    <img src="https://raw.githubusercontent.com/antiwork/flexile/main/frontend/public/icon-192.png" height="128" alt="Flexile Logo">
   </picture>
 </p>
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,9 @@
+<p align="center">
+  <picture>
+    <img src="https://github.com/antiwork/flexile/blob/main/frontend/public/icon-192.png" alt="Flexile Logo">
+  </picture>
+</p>
+
 # Flexile
 
 Contractor payments as easy as 1-2-3.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <p align="center">
   <picture>
-    <img src="https://github.com/antiwork/flexile/blob/main/frontend/public/icon-192.png" height="100" alt="Flexile Logo">
+    <img src="https://github.com/antiwork/flexile/blob/main/frontend/public/icon-192.png" height="128" alt="Flexile Logo">
   </picture>
 </p>
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <p align="center">
   <picture>
-    <img src="https://github.com/antiwork/flexile/blob/main/frontend/public/icon-192.png" alt="Flexile Logo">
+    <img src="https://github.com/antiwork/flexile/blob/main/frontend/public/icon-192.png" height="100" alt="Flexile Logo">
   </picture>
 </p>
 


### PR DESCRIPTION
Related to #506 

<img width="908" height="453" alt="image" src="https://github.com/user-attachments/assets/ae4ca125-1daf-4c5c-b24d-9ee21196b0c4" />

## Why

This change aligns the look of README.md to other Antiwork repositories (for example [Shortest](https://github.com/antiwork/shortest)) and gives a better first impression of the repository README.md.

## Additional Notes

The logo is an image sourced internally from https://github.com/wiksien/flexile/blob/feat/add-logo-readme/frontend/public/icon-192.png and it has a black background with a white logo so it works both in light mode and dark mode.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated the README to include a centered Flexile logo at the top for improved visual branding.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->