### PR TITLE
Add warning about using windows and wsl for setup in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Contractor payments as easy as 1-2-3.
 ## Setup
 
 > **⚠️ Warning:**  
-> We highly recommend using either a MacOS system or a Linux distribution for setting up Flexile on your machine. Using Windows and WSL is known to cause a lot of issues that are hard to debug. If you are using Windows, consider setting up an instance of Linux distro via tools like [VirtualBox](https://Virtualbox.org).
+> We recommend using macOS or a Linux distribution for setting up Flexile locally. Windows and WSL often introduce hard-to-debug issues. If you use Windows, consider running a Linux distribution in a virtual machine (e.g. with [VirtualBox](https://virtualbox.org)).
 
 You'll need:
 

--- a/README.md
+++ b/README.md
@@ -4,6 +4,9 @@ Contractor payments as easy as 1-2-3.
 
 ## Setup
 
+> **⚠️ Warning:**  
+> We highly recommend using either a MacOS system or a Linux distribution for setting up Flexile on your machine. Using Windows and WSL is known to cause a lot of issues that are hard to debugg. If you are using Windows, consider setting up an instance of Linux distro via tools like [VirtualBox](https://Virtualbox.org).
+
 You'll need:
 
 - [Docker](https://docs.docker.com/engine/install/)

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Contractor payments as easy as 1-2-3.
 ## Setup
 
 > **⚠️ Warning:**  
-> We highly recommend using either a MacOS system or a Linux distribution for setting up Flexile on your machine. Using Windows and WSL is known to cause a lot of issues that are hard to debugg. If you are using Windows, consider setting up an instance of Linux distro via tools like [VirtualBox](https://Virtualbox.org).
+> We highly recommend using either a MacOS system or a Linux distribution for setting up Flexile on your machine. Using Windows and WSL is known to cause a lot of issues that are hard to debug. If you are using Windows, consider setting up an instance of Linux distro via tools like [VirtualBox](https://Virtualbox.org).
 
 You'll need:
 


### PR DESCRIPTION
Related to #506 

<img width="935" height="361" alt="image" src="https://github.com/user-attachments/assets/d897a990-b77d-4231-a310-fdfa20c9c20e" />

## Why

Windows and WSL had been prone to problems when it comes to DX experience, like complicated mkcert configuration in WSL and other issues. Since we don't plan to support Windows based DX, it is best that we explicitly recommend users to use either Linux or MacOS in order to avoid frustration by new contributors when setting up their local, that can lead to giving up on contributing.

## Additional Notes

The PR aims to not exclude Windows based contributors by giving the option of making a VM instance of Linux.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a warning in the Setup section recommending MacOS or Linux for setup and advising Windows users to use virtualization tools due to known issues.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->