### PR TITLE
fix: complete flow test race condition

### DIFF
--- a/e2e/helpers/auth.ts
+++ b/e2e/helpers/auth.ts
@@ -24,18 +24,15 @@ export const login = async (page: Page, user: typeof users.$inferSelect) => {
 };
 
 export const logout = async (page: Page) => {
-  const gettingStartedInnerTrigger = page.getByTestId("getting-started-inner-trigger");
+  // Look for the Getting Started inner panel by its text and aria-expanded attribute
+  const gettingStartedInnerTrigger = page.locator('div[aria-expanded="true"]:has-text("Getting started")').first();
 
   // Make sure Getting Started inner panel is closed
   if (await gettingStartedInnerTrigger.isVisible().catch(() => false)) {
-    const isExpanded = await gettingStartedInnerTrigger.getAttribute("aria-expanded").catch(() => null);
-
-    if (isExpanded === "true") {
-      // Click the trigger to collapse it
-      await gettingStartedInnerTrigger.click();
-      // Wait a moment for the animation to complete
-      await page.waitForTimeout(300);
-    }
+    // Click the trigger to collapse it
+    await gettingStartedInnerTrigger.click();
+    // Wait a moment for the animation to complete
+    await page.waitForTimeout(300);
   }
 
   await page.getByRole("button", { name: "Log out" }).first().click();

--- a/e2e/helpers/auth.ts
+++ b/e2e/helpers/auth.ts
@@ -23,6 +23,7 @@ export const login = async (page: Page, user: typeof users.$inferSelect) => {
   await page.waitForURL(/^(?!.*\/login$).*/u);
 };
 
+// TODO: This is a hack to close the Getting Started inner panel. We need to make sure Logout button is visible later
 export const logout = async (page: Page) => {
   // Look for the Getting Started inner panel by its text and aria-expanded attribute
   const gettingStartedInnerTrigger = page.locator('div[aria-expanded="true"]:has-text("Getting started")').first();

--- a/e2e/helpers/auth.ts
+++ b/e2e/helpers/auth.ts
@@ -24,14 +24,21 @@ export const login = async (page: Page, user: typeof users.$inferSelect) => {
 };
 
 export const logout = async (page: Page) => {
-  // Navigate to a page with logout functionality
-  await page.goto("/dashboard");
+  const gettingStartedInnerTrigger = page.getByTestId("getting-started-inner-trigger");
 
-  // Look for logout button (this may vary based on your UI)
-  const logoutButton = page.getByRole("button", { name: "Logout" }).first();
-  if (await logoutButton.isVisible()) {
-    await logoutButton.click();
+  // Make sure Getting Started inner panel is closed
+  if (await gettingStartedInnerTrigger.isVisible().catch(() => false)) {
+    const isExpanded = await gettingStartedInnerTrigger.getAttribute("aria-expanded").catch(() => null);
+
+    if (isExpanded === "true") {
+      // Click the trigger to collapse it
+      await gettingStartedInnerTrigger.click();
+      // Wait a moment for the animation to complete
+      await page.waitForTimeout(300);
+    }
   }
+
+  await page.getByRole("button", { name: "Log out" }).first().click();
 
   // Wait for redirect to login
   await page.waitForURL(/.*\/login.*/u);

--- a/e2e/helpers/auth.ts
+++ b/e2e/helpers/auth.ts
@@ -31,6 +31,7 @@ export const logout = async (page: Page) => {
 
   // Wait for redirect to login
   await page.waitForURL(/.*\/login.*/u);
+  await page.waitForLoadState("networkidle");
 };
 
 /**

--- a/e2e/helpers/auth.ts
+++ b/e2e/helpers/auth.ts
@@ -23,18 +23,9 @@ export const login = async (page: Page, user: typeof users.$inferSelect) => {
   await page.waitForURL(/^(?!.*\/login$).*/u);
 };
 
-// TODO: This is a hack to close the Getting Started inner panel. We need to make sure Logout button is visible later
 export const logout = async (page: Page) => {
-  // Look for the Getting Started inner panel by its text and aria-expanded attribute
-  const gettingStartedInnerTrigger = page.locator('div[aria-expanded="true"]:has-text("Getting started")').first();
-
-  // Make sure Getting Started inner panel is closed
-  if (await gettingStartedInnerTrigger.isVisible().catch(() => false)) {
-    // Click the trigger to collapse it
-    await gettingStartedInnerTrigger.click();
-    // Wait a moment for the animation to complete
-    await page.waitForTimeout(300);
-  }
+  // Navigate to invoices page to ensure we're on a dashboard page with sidebar
+  await page.goto("/invoices");
 
   await page.getByRole("button", { name: "Log out" }).first().click();
 

--- a/frontend/app/(dashboard)/layout.tsx
+++ b/frontend/app/(dashboard)/layout.tsx
@@ -56,8 +56,14 @@ import { trpc } from "@/trpc/client";
 import { request } from "@/utils/request";
 import { company_switch_path } from "@/utils/routes";
 
-// Custom logout component that handles OTP logout
-const LogoutButton = ({ children }: { children: React.ReactNode }) => {
+export default function DashboardLayout({ children }: { children: React.ReactNode }) {
+  const user = useCurrentUser();
+  const company = useCurrentCompany();
+  const router = useRouter();
+  const queryClient = useQueryClient();
+  const [showTryEquity, setShowTryEquity] = React.useState(true);
+  const [hovered, setHovered] = React.useState(false);
+  const canShowTryEquity = user.roles.administrator && !company.equityEnabled;
   const { data: session } = useSession();
   const { logout } = useUserStore();
 
@@ -70,27 +76,6 @@ const LogoutButton = ({ children }: { children: React.ReactNode }) => {
     // Redirect to login
     window.location.href = "/login";
   };
-
-  return (
-    <button
-      onClick={() => {
-        void handleLogout();
-      }}
-      className="w-full"
-    >
-      {children}
-    </button>
-  );
-};
-
-export default function DashboardLayout({ children }: { children: React.ReactNode }) {
-  const user = useCurrentUser();
-  const company = useCurrentCompany();
-  const router = useRouter();
-  const queryClient = useQueryClient();
-  const [showTryEquity, setShowTryEquity] = React.useState(true);
-  const [hovered, setHovered] = React.useState(false);
-  const canShowTryEquity = user.roles.administrator && !company.equityEnabled;
 
   const switchCompany = async (companyId: string) => {
     useUserStore.setState((state) => ({ ...state, pending: true }));
@@ -210,12 +195,10 @@ export default function DashboardLayout({ children }: { children: React.ReactNod
                 </SidebarMenuItem>
               ) : null}
               <SidebarMenuItem>
-                <LogoutButton>
-                  <SidebarMenuButton className="cursor-pointer">
-                    <LogOut className="size-6" />
-                    <span>Log out</span>
-                  </SidebarMenuButton>
-                </LogoutButton>
+                <SidebarMenuButton onClick={() => void handleLogout()} className="cursor-pointer">
+                  <LogOut className="size-6" />
+                  <span>Log out</span>
+                </SidebarMenuButton>
               </SidebarMenuItem>
             </SidebarMenu>
           </SidebarGroupContent>

--- a/frontend/app/(dashboard)/layout.tsx
+++ b/frontend/app/(dashboard)/layout.tsx
@@ -161,55 +161,8 @@ export default function DashboardLayout({ children }: { children: React.ReactNod
               </SidebarGroupContent>
             </SidebarGroup>
           ) : null}
-
-          <SidebarGroup className="mt-auto">
-            <SidebarGroupContent>
-              <SidebarMenu>
-                {canShowTryEquity && showTryEquity ? (
-                  <SidebarMenuItem>
-                    <SidebarMenuButton asChild>
-                      <div
-                        className="group relative flex cursor-pointer items-center justify-between"
-                        onClick={() => router.push("/settings/administrator/equity")}
-                        onMouseEnter={() => setHovered(true)}
-                        onMouseLeave={() => setHovered(false)}
-                        role="button"
-                        tabIndex={0}
-                      >
-                        <span className="flex items-center gap-2">
-                          <Sparkles className="size-6" />
-                          <span>Try equity</span>
-                        </span>
-                        {hovered ? (
-                          <button
-                            type="button"
-                            aria-label="Dismiss try equity"
-                            className="hover:bg-muted absolute top-1/2 right-2 -translate-y-1/2 rounded p-1 transition-colors"
-                            onClick={(e) => {
-                              e.stopPropagation();
-                              setShowTryEquity(false);
-                            }}
-                            tabIndex={0}
-                          >
-                            <X className="text-muted-foreground hover:text-foreground size-4 transition-colors" />
-                          </button>
-                        ) : null}
-                      </div>
-                    </SidebarMenuButton>
-                  </SidebarMenuItem>
-                ) : null}
-                <SidebarMenuItem>
-                  <LogoutButton>
-                    <SidebarMenuButton className="cursor-pointer">
-                      <LogOut className="size-6" />
-                      <span>Log out</span>
-                    </SidebarMenuButton>
-                  </LogoutButton>
-                </SidebarMenuItem>
-              </SidebarMenu>
-            </SidebarGroupContent>
-          </SidebarGroup>
         </SidebarContent>
+
         {company.checklistItems.length > 0 ? (
           <SidebarGroup className="mt-auto px-0 py-0">
             <SidebarGroupContent>
@@ -219,6 +172,54 @@ export default function DashboardLayout({ children }: { children: React.ReactNod
             </SidebarGroupContent>
           </SidebarGroup>
         ) : null}
+
+        <SidebarGroup className="px-0 py-0">
+          <SidebarGroupContent>
+            <SidebarMenu>
+              {canShowTryEquity && showTryEquity ? (
+                <SidebarMenuItem>
+                  <SidebarMenuButton asChild>
+                    <div
+                      className="group relative flex cursor-pointer items-center justify-between"
+                      onClick={() => router.push("/settings/administrator/equity")}
+                      onMouseEnter={() => setHovered(true)}
+                      onMouseLeave={() => setHovered(false)}
+                      role="button"
+                      tabIndex={0}
+                    >
+                      <span className="flex items-center gap-2">
+                        <Sparkles className="size-6" />
+                        <span>Try equity</span>
+                      </span>
+                      {hovered ? (
+                        <button
+                          type="button"
+                          aria-label="Dismiss try equity"
+                          className="hover:bg-muted absolute top-1/2 right-2 -translate-y-1/2 rounded p-1 transition-colors"
+                          onClick={(e) => {
+                            e.stopPropagation();
+                            setShowTryEquity(false);
+                          }}
+                          tabIndex={0}
+                        >
+                          <X className="text-muted-foreground hover:text-foreground size-4 transition-colors" />
+                        </button>
+                      ) : null}
+                    </div>
+                  </SidebarMenuButton>
+                </SidebarMenuItem>
+              ) : null}
+              <SidebarMenuItem>
+                <LogoutButton>
+                  <SidebarMenuButton size="lg" className="cursor-pointer">
+                    <LogOut className="size-6" />
+                    <span>Log out</span>
+                  </SidebarMenuButton>
+                </LogoutButton>
+              </SidebarMenuItem>
+            </SidebarMenu>
+          </SidebarGroupContent>
+        </SidebarGroup>
       </Sidebar>
 
       <SidebarInset>

--- a/frontend/app/(dashboard)/layout.tsx
+++ b/frontend/app/(dashboard)/layout.tsx
@@ -173,7 +173,7 @@ export default function DashboardLayout({ children }: { children: React.ReactNod
           </SidebarGroup>
         ) : null}
 
-        <SidebarGroup className="px-0 py-0">
+        <SidebarGroup className="mt-auto">
           <SidebarGroupContent>
             <SidebarMenu>
               {canShowTryEquity && showTryEquity ? (
@@ -211,7 +211,7 @@ export default function DashboardLayout({ children }: { children: React.ReactNod
               ) : null}
               <SidebarMenuItem>
                 <LogoutButton>
-                  <SidebarMenuButton size="lg" className="cursor-pointer">
+                  <SidebarMenuButton className="cursor-pointer">
                     <LogOut className="size-6" />
                     <span>Log out</span>
                   </SidebarMenuButton>

--- a/frontend/components/GettingStarted.tsx
+++ b/frontend/components/GettingStarted.tsx
@@ -87,7 +87,10 @@ export const GettingStarted = () => {
         className="flex h-full flex-col-reverse"
       >
         <CollapsibleTrigger asChild>
-          <SidebarMenuButton className="h-full items-center justify-between rounded-none px-5">
+          <SidebarMenuButton
+            className="h-full items-center justify-between rounded-none px-5"
+            data-testid="getting-started-trigger"
+          >
             {status === "completed" ? (
               <div className="flex h-4 w-4 items-center justify-center rounded-full border-2 border-blue-500 bg-blue-500">
                 <CheckIcon />
@@ -123,7 +126,10 @@ export const GettingStarted = () => {
           ) : (
             <div className="mt-2 rounded-lg border border-gray-200 bg-white px-1 pb-4 shadow-sm">
               <CollapsibleTrigger asChild>
-                <div className="mx-3 flex h-11 cursor-pointer items-center justify-between">
+                <div
+                  className="mx-3 flex h-11 cursor-pointer items-center justify-between"
+                  data-testid="getting-started-inner-trigger"
+                >
                   <span className="font-medium">Getting started</span>
                   <ChevronDown className={cn("h-4 w-4")} />
                 </div>

--- a/frontend/components/GettingStarted.tsx
+++ b/frontend/components/GettingStarted.tsx
@@ -87,10 +87,7 @@ export const GettingStarted = () => {
         className="flex h-full flex-col-reverse"
       >
         <CollapsibleTrigger asChild>
-          <SidebarMenuButton
-            className="h-full items-center justify-between rounded-none px-5"
-            data-testid="getting-started-trigger"
-          >
+          <SidebarMenuButton className="h-full items-center justify-between rounded-none px-5">
             {status === "completed" ? (
               <div className="flex h-4 w-4 items-center justify-center rounded-full border-2 border-blue-500 bg-blue-500">
                 <CheckIcon />
@@ -126,10 +123,7 @@ export const GettingStarted = () => {
           ) : (
             <div className="mt-2 rounded-lg border border-gray-200 bg-white px-1 pb-4 shadow-sm">
               <CollapsibleTrigger asChild>
-                <div
-                  className="mx-3 flex h-11 cursor-pointer items-center justify-between"
-                  data-testid="getting-started-inner-trigger"
-                >
+                <div className="mx-3 flex h-11 cursor-pointer items-center justify-between">
                   <span className="font-medium">Getting started</span>
                   <ChevronDown className={cn("h-4 w-4")} />
                 </div>


### PR DESCRIPTION

Due to consecutive logout and login many times in the test "allows contractor to submit/delete invoices and admin to approve/reject them" in e2e/tests/company/invoices/complete-flow.spec.ts. It was sometimes reaching a race condition where  Error: page.goto: Navigation to "https://test.flexile.dev:3101/login" is interrupted by another navigation to "https://test.flexile.dev:3101/login"

Before:
![Screenshot 2025-08-03 at 12 00 11 AM](https://github.com/user-attachments/assets/ff8d1f58-9e21-4eb0-867b-c464c3c9703a)


After:
![Screenshot 2025-08-03 at 12 03 48 AM](https://github.com/user-attachments/assets/542ed6ce-2371-4de3-88e0-a58b2472cb70)
