### PR TITLE
fix broken invite flow

### DIFF
--- a/backend/app/controllers/concerns/set_current.rb
+++ b/backend/app/controllers/concerns/set_current.rb
@@ -35,7 +35,7 @@ module SetCurrent
       if cookies["invitation_token"].present?
         invite_link = CompanyInviteLink.find_by(token: cookies["invitation_token"])
         invited_company = invite_link&.company
-        user.update!(signup_invite_link: invite_link) if invite_link
+        AcceptCompanyInviteLink.new(user:, token: invite_link.token).perform if invite_link
         cookies.delete("invitation_token")
       end
     end


### PR DESCRIPTION
The removal of the pre-onboarding state has broken the invite link flow. Previously, the AcceptInviteService was triggered while the user was in the onboarding state, which ensured that a CompanyWorker was created. Now that the onboarding state has been removed, the CompanyWorker is no longer being created when the invite is accepted.

REF : https://github.com/antiwork/flexile/pull/646/files#diff-48e07e012c5e026a033affd66353fc033b09533159ce6a3de733235b681024dc