### PR TITLE
Add support for inviting company administrators

### DIFF
--- a/backend/app/controllers/internal/companies/administrators_controller.rb
+++ b/backend/app/controllers/internal/companies/administrators_controller.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+class Internal::Companies::AdministratorsController < Internal::Companies::BaseController
+  def create
+    authorize CompanyAdministrator
+
+    result = InviteAdmin.new(company: Current.company, email: params[:email], current_user: Current.user).perform
+
+    if result[:success]
+      render json: { success: true }
+    else
+      render json: { success: false, field: result[:field], error_message: result[:error_message] }, status: :unprocessable_entity
+    end
+  end
+end

--- a/backend/app/mailers/company_administrator_mailer.rb
+++ b/backend/app/mailers/company_administrator_mailer.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+class CompanyAdministratorMailer < ApplicationMailer
+  def invitation_instructions(administrator_id:, url:)
+    company_administrator = CompanyAdministrator.find(administrator_id)
+    user = company_administrator.user
+    @company = company_administrator.company
+    @url = url
+
+    mail(
+      to: user.email,
+      subject: "You've been invited to join #{@company.name} as an administrator",
+      reply_to: @company.email
+    )
+  end
+end

--- a/backend/app/policies/company_administrator_policy.rb
+++ b/backend/app/policies/company_administrator_policy.rb
@@ -8,4 +8,8 @@ class CompanyAdministratorPolicy < ApplicationPolicy
   def reset?
     show?
   end
+
+  def create?
+    user.company_administrator_for?(company)
+  end
 end

--- a/backend/app/services/invite_admin.rb
+++ b/backend/app/services/invite_admin.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+class InviteAdmin
+  def initialize(company:, email:, current_user:)
+    @company = company
+    @email = email
+    @current_user = current_user
+  end
+
+  def perform
+    user = User.find_or_initialize_by(email:)
+    is_existing_user = user.persisted?
+
+    if is_existing_user
+      existing_company_administrator = user.company_administrators.find_by(company:)
+      if existing_company_administrator.present?
+        return { success: false, field: "email", error_message: "User is already an administrator for this company." }
+      end
+    end
+
+    company_administrator = user.company_administrators.find_or_initialize_by(company: company)
+
+    if is_existing_user
+      user.invited_by = current_user
+      user.save && company_administrator.save
+    else
+      user.invite!(current_user) { |u| u.skip_invitation = true }
+    end
+
+    if user.errors.blank? && company_administrator.errors.blank?
+      company_administrator.save! unless company_administrator.persisted?
+      CompanyAdministratorMailer.invitation_instructions(administrator_id: company_administrator.id, url: user.create_clerk_invitation).deliver_later
+      { success: true }
+    else
+      error_object = if company_administrator.errors.any?
+        company_administrator
+      else
+        user
+      end
+      { success: false, field: error_object.errors.first.attribute, error_message: error_object.errors.first.full_message }
+    end
+  end
+
+  private
+    attr_reader :company, :email, :current_user
+end

--- a/backend/app/services/invite_lawyer.rb
+++ b/backend/app/services/invite_lawyer.rb
@@ -15,6 +15,7 @@ class InviteLawyer
     user.invite!(current_user) { |u| u.skip_invitation = true }
 
     if user.errors.blank?
+      company_lawyer.save! unless company_lawyer.persisted?
       CompanyLawyerMailer.invitation_instructions(lawyer_id: company_lawyer.id, url: user.create_clerk_invitation).deliver_later
       { success: true }
     else

--- a/backend/app/views/company_administrator_mailer/invitation_instructions.html.erb
+++ b/backend/app/views/company_administrator_mailer/invitation_instructions.html.erb
@@ -1,0 +1,5 @@
+<h1>You've been invited to join <%= @company.name %> as an administrator</h1>
+
+<p><%= @company.name %> has invited you to join their administrative team on Flexile.</p>
+
+<%= link_to "Accept invitation and set up account", @url, class: "button" %>

--- a/backend/config/routes/internal.rb
+++ b/backend/config/routes/internal.rb
@@ -44,6 +44,7 @@ scope path: :internal, module: :internal do
     end
     resources :workers, only: [:create]
     resources :lawyers, only: [:create]
+    resources :administrators, only: [:create]
     resources :equity_grant_exercises, only: :create do
       member do
         post :resend

--- a/backend/spec/fixtures/vcr_cassettes/InviteAdmin/when_inviting_a_new_user/creates_a_new_user_and_company_administrator_with_correct_attributes.yml
+++ b/backend/spec/fixtures/vcr_cassettes/InviteAdmin/when_inviting_a_new_user/creates_a_new_user_and_company_administrator_with_correct_attributes.yml
@@ -1,0 +1,57 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.clerk.com/v1/invitations
+    body:
+      encoding: UTF-8
+      string: '{"email_address":"admin@example.com","expires_in_days":365,"ignore_existing":true}'
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/2.0.0/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Bearer sk_test_IcXt4Bzlq8rkPYCp3tBSNQnfZtrnyoh9VdGDJvzRKr
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 04 Aug 2025 16:02:09 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Cf-Ray:
+      - 969f47062f5b3cf4-BOM
+      Cf-Cache-Status:
+      - DYNAMIC
+      Clerk-Api-Version:
+      - '2025-04-10'
+      X-Cfworker:
+      - '1'
+      X-Clerk-Trace-Id:
+      - cd468264c22313ca442212239b30fc3d
+      X-Cloud-Trace-Context:
+      - cd468264c22313ca442212239b30fc3d
+      Set-Cookie:
+      - __cf_bm=5bZ64T1lHDHtT2yKKL1pi7RZ52ozWwLq2RlgFTFLpz8-1754323329-1.0.1.1-haR5rUwNWvVPmsYQdIRYY0jXJlOMnz2Q4_nJUTWg_TcTKpiNWcikJWjgtwuDcoDnVjskwqln.DAEmwS4tVXCZc8N13HJa8MwOExFI.LW1cU;
+        path=/; expires=Mon, 04-Aug-25 16:32:09 GMT; domain=.api.clerk.com; HttpOnly;
+        Secure; SameSite=None
+      Vary:
+      - Accept-Encoding
+      Server:
+      - cloudflare
+    body:
+      encoding: ASCII-8BIT
+      string: '{"object":"invitation","id":"inv_30pT5Hm3noCHGZefEVuscwugXib","email_address":"admin@example.com","public_metadata":{},"status":"pending","url":"https://neutral-whippet-64.clerk.accounts.dev/v1/tickets/accept?ticket=eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJlaXMiOjMxNTM2MDAwLCJleHAiOjE3ODU4NTkzMjksImlpZCI6Imluc18zMDh2ODFzMHlielNYOU5uUWNCT2k0b21TSzgiLCJzaWQiOiJpbnZfMzBwVDVIbTNub0NIR1plZkVWdXNjd3VnWGliIiwic3QiOiJpbnZpdGF0aW9uIn0.fTdMm1DyL3quG3JIvGSJxmDIaRJRzlt9xENCnA0fPr1o6gaGB41_NpqU7r3fDD7qKoiZA7TwFu85gjy_6BH6WtWFxRNqU1FSJxwU2Gim3fN_uhidl8yN7SVRVRxQa-cW1rr4UNkgzlj3PewKYRgkXm1M9Oot6mPKV4P6BnErC0neR16jUGeKvqAgAhCFe0eDx--OSFjfXlBP-tWWukZYuO037b89p-PBk5yySKDmtSlwAGBy74-B0vsDj_O3UmnmrWzXSkLxYpIBKTyGWY7WGYZxKj8BuhAsfubN_wkShVPHYTKLFArjUmC7aSlVsRV-uYw2IjpFDmrgB9R2J9EizA","expires_at":1785859329550,"created_at":1754323329550,"updated_at":1754323329550}'
+  recorded_at: Mon, 04 Aug 2025 16:02:09 GMT
+recorded_with: VCR 6.3.1

--- a/backend/spec/fixtures/vcr_cassettes/InviteAdmin/when_inviting_an_existing_user_who_is_not_an_admin_for_this_company/allows_the_invitation_and_creates_a_new_company_administrator.yml
+++ b/backend/spec/fixtures/vcr_cassettes/InviteAdmin/when_inviting_an_existing_user_who_is_not_an_admin_for_this_company/allows_the_invitation_and_creates_a_new_company_administrator.yml
@@ -1,0 +1,57 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.clerk.com/v1/invitations
+    body:
+      encoding: UTF-8
+      string: '{"email_address":"admin@example.com","expires_in_days":365,"ignore_existing":true}'
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/2.0.0/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Bearer sk_test_IcXt4Bzlq8rkPYCp3tBSNQnfZtrnyoh9VdGDJvzRKr
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 04 Aug 2025 16:17:27 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Cf-Ray:
+      - 969f5d6c5e16470e-BOM
+      Cf-Cache-Status:
+      - DYNAMIC
+      Clerk-Api-Version:
+      - '2025-04-10'
+      X-Cfworker:
+      - '1'
+      X-Clerk-Trace-Id:
+      - db35bc7be742bfcb811562237cce2aae
+      X-Cloud-Trace-Context:
+      - db35bc7be742bfcb811562237cce2aae
+      Set-Cookie:
+      - __cf_bm=MALhao9bnPAwIOOB_RF3OPzxboEeGfrsvE1I_KEXi2g-1754324247-1.0.1.1-el7o4K7gAFGNbunCttyOYW0Z3WwgabLDYm475FF0fVlDUYxgRPesp9H7FRHQElcg8tlUJyelcTjxc72qs9GiBFceUpQapmJvK9YklH8c_i8;
+        path=/; expires=Mon, 04-Aug-25 16:47:27 GMT; domain=.api.clerk.com; HttpOnly;
+        Secure; SameSite=None
+      Vary:
+      - Accept-Encoding
+      Server:
+      - cloudflare
+    body:
+      encoding: ASCII-8BIT
+      string: '{"object":"invitation","id":"inv_30pUwW7XByKy1mrpQiqi9kgMIiu","email_address":"admin@example.com","public_metadata":{},"status":"pending","url":"https://neutral-whippet-64.clerk.accounts.dev/v1/tickets/accept?ticket=eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJlaXMiOjMxNTM2MDAwLCJleHAiOjE3ODU4NjAyNDYsImlpZCI6Imluc18zMDh2ODFzMHlielNYOU5uUWNCT2k0b21TSzgiLCJzaWQiOiJpbnZfMzBwVXdXN1hCeUt5MW1ycFFpcWk5a2dNSWl1Iiwic3QiOiJpbnZpdGF0aW9uIn0.OY8AhzQn1xAWEhtZWhYaKe0F67s3Ad_tHdTehlS-pf39w8VYnSkVTjRD9OW2pfv4mu50-VBGxH3RZMAZNRnC1ZygW14CFx_zGkbbKNOcS4RmQX8cw5_vtLsCLtcHE3ilcHS41MUET1ns7Lei4CPg2EYBHJ6i8hWbB9P9AjMC67ZTdGo2IgE7BW3sxBmoh4J08O9Gn-qr3MP9VeWPypEbttBB8mLSTkH3Hpf5v-j0LJiAe8_LNoEru47JiA8LSzUxtEyWpAZYO7U3n8g3_pYd4EuZEHeIOibl2kYSYUnbzzy8ct1SAkJkFauhf389_8bOOvF7QIcR6j9ZsGclIRqhxA","expires_at":1785860246997,"created_at":1754324246997,"updated_at":1754324246997}'
+  recorded_at: Mon, 04 Aug 2025 16:17:27 GMT
+recorded_with: VCR 6.3.1

--- a/backend/spec/services/invite_admin_spec.rb
+++ b/backend/spec/services/invite_admin_spec.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+RSpec.describe InviteAdmin do
+  let!(:company) { create(:company, :completed_onboarding) }
+  let(:email) { "admin@example.com" }
+  let!(:current_user) { create(:user) }
+
+  subject(:invite_admin) { described_class.new(company:, email:, current_user:).perform }
+
+  context "when inviting a new user" do
+    it "creates a new user and company_administrator with correct attributes", :vcr do
+      result = nil
+      expect do
+        result = invite_admin
+      end.to change(User, :count).by(1)
+         .and change(CompanyAdministrator, :count).by(1)
+         .and have_enqueued_mail(CompanyAdministratorMailer, :invitation_instructions)
+
+      expect(result[:success]).to be true
+
+      user = User.last
+      company_administrator = CompanyAdministrator.last
+
+      expect(user.email).to eq(email)
+      expect(company_administrator.company).to eq(company)
+      expect(company_administrator.user).to eq(user)
+      expect(user.invited_by).to eq(current_user)
+    end
+  end
+
+  context "when inviting an existing user who is not an admin for this company" do
+    let!(:existing_user) { create(:user, email:) }
+    let!(:other_company) { create(:company) }
+    let!(:other_company_administrator) { create(:company_administrator, company: other_company, user: existing_user) }
+
+    it "allows the invitation and creates a new company_administrator", :vcr do
+      result = nil
+      expect do
+        result = invite_admin
+      end.to change(CompanyAdministrator, :count).by(1)
+         .and have_enqueued_mail(CompanyAdministratorMailer, :invitation_instructions)
+
+      expect(result[:success]).to be true
+
+      company_administrator = CompanyAdministrator.last
+      expect(company_administrator.company).to eq(company)
+      expect(company_administrator.user).to eq(existing_user)
+    end
+  end
+
+  context "when inviting an existing user who is already an admin for this company" do
+    let!(:existing_user) { create(:user, email:) }
+    let!(:existing_company_administrator) { create(:company_administrator, company:, user: existing_user) }
+
+    it "returns an error and does not create new records or send emails" do
+      result = nil
+      expect do
+        result = invite_admin
+      end.not_to have_enqueued_mail(CompanyAdministratorMailer, :invitation_instructions)
+
+      expect(result[:success]).to be false
+      expect(result[:error_message]).to eq("User is already an administrator for this company.")
+      expect(result[:field]).to eq("email")
+    end
+  end
+end

--- a/frontend/trpc/routes/administrators.ts
+++ b/frontend/trpc/routes/administrators.ts
@@ -1,0 +1,21 @@
+import { TRPCError } from "@trpc/server";
+import { z } from "zod";
+import { companyProcedure, createRouter } from "@/trpc";
+import { company_administrators_url } from "@/utils/routes";
+
+export const administratorsRouter = createRouter({
+  invite: companyProcedure.input(z.object({ email: z.string() })).mutation(async ({ ctx, input }) => {
+    if (!ctx.companyAdministrator) throw new TRPCError({ code: "FORBIDDEN" });
+
+    const response = await fetch(company_administrators_url(ctx.company.externalId, { host: ctx.host }), {
+      method: "POST",
+      body: JSON.stringify(input),
+      headers: { "Content-Type": "application/json", ...ctx.headers },
+    });
+
+    if (!response.ok) {
+      const { error_message } = z.object({ error_message: z.string() }).parse(await response.json());
+      throw new TRPCError({ code: "BAD_REQUEST", message: error_message });
+    }
+  }),
+});

--- a/frontend/trpc/server.ts
+++ b/frontend/trpc/server.ts
@@ -5,6 +5,7 @@ import { companiesRouter } from "@/trpc/routes/companies";
 import { equityCalculationsRouter } from "@/trpc/routes/equityCalculations";
 import { filesRouter } from "@/trpc/routes/files";
 import { investorEntitiesRouter } from "@/trpc/routes/investorEntities";
+import { administratorsRouter } from "./routes/administrators";
 import { companyInviteLinksRouter } from "./routes/companyInviteLinks";
 import { companyUpdatesRouter } from "./routes/companyUpdates";
 import { consolidatedInvoicesRouter } from "./routes/consolidatedInvoices";
@@ -54,6 +55,7 @@ export const appRouter = createRouter({
   investorEntities: investorEntitiesRouter,
   equityCalculations: equityCalculationsRouter,
   lawyers: lawyersRouter,
+  administrators: administratorsRouter,
   companyInviteLinks: companyInviteLinksRouter,
   support: supportRouter,
 });

--- a/frontend/utils/routes.d.ts
+++ b/frontend/utils/routes.d.ts
@@ -688,6 +688,30 @@ export const company_administrator_stripe_microdeposit_verifications_path: ((
 
 /**
  * Generates rails route to
+ * /internal/companies/:company_id/administrators(.:format)
+ * @param {any} company_id
+ * @param {object | undefined} options
+ * @returns {string} route path
+ */
+export const company_administrators_url: ((
+  company_id: RequiredRouteParameter,
+  options?: {format?: OptionalRouteParameter} & RouteOptions
+) => string) & RouteHelperExtras;
+
+/**
+ * Generates rails route to
+ * /internal/companies/:company_id/administrators(.:format)
+ * @param {any} company_id
+ * @param {object | undefined} options
+ * @returns {string} route path
+ */
+export const company_administrators_path: ((
+  company_id: RequiredRouteParameter,
+  options?: {format?: OptionalRouteParameter} & RouteOptions
+) => string) & RouteHelperExtras;
+
+/**
+ * Generates rails route to
  * /company/billing(.:format)
  * @param {object | undefined} options
  * @returns {string} route path

--- a/frontend/utils/routes.js
+++ b/frontend/utils/routes.js
@@ -1009,6 +1009,24 @@ export const company_administrator_stripe_microdeposit_verifications_path = /*#_
 
 /**
  * Generates rails route to
+ * /internal/companies/:company_id/administrators(.:format)
+ * @param {any} company_id
+ * @param {object | undefined} options
+ * @returns {string} route path
+ */
+export const company_administrators_url = /*#__PURE__*/ __jsr.r({"company_id":{"r":true},"format":{}}, [2,[7,"/"],[2,[6,"internal"],[2,[7,"/"],[2,[6,"companies"],[2,[7,"/"],[2,[3,"company_id"],[2,[7,"/"],[2,[6,"administrators"],[1,[2,[8,"."],[3,"format"]]]]]]]]]]], true);
+
+/**
+ * Generates rails route to
+ * /internal/companies/:company_id/administrators(.:format)
+ * @param {any} company_id
+ * @param {object | undefined} options
+ * @returns {string} route path
+ */
+export const company_administrators_path = /*#__PURE__*/ __jsr.r({"company_id":{"r":true},"format":{}}, [2,[7,"/"],[2,[6,"internal"],[2,[7,"/"],[2,[6,"companies"],[2,[7,"/"],[2,[3,"company_id"],[2,[7,"/"],[2,[6,"administrators"],[1,[2,[8,"."],[3,"format"]]]]]]]]]]]);
+
+/**
+ * Generates rails route to
  * /company/billing(.:format)
  * @param {object | undefined} options
  * @returns {string} route path


### PR DESCRIPTION
<img width="1551" height="597" alt="image" src="https://github.com/user-attachments/assets/e4754c06-f15a-40f2-a6f1-d4e4310572cd" />

Introduced an API endpoint and service to invite new company admins.  
Added mailer and HTML template for sending invitation emails.  
Frontend integrated via TRPC mutation and route helpers. 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added the ability to invite users as company administrators via the internal API.
  * Introduced email invitations for new company administrators with a dedicated email template.
  * Added new route helpers for generating administrator invitation URLs and paths.
  * Extended the frontend with support for inviting company administrators.

* **Bug Fixes**
  * Ensured new administrator records are saved before sending invitation emails.

* **Tests**
  * Added tests for the administrator invitation process, including scenarios for new and existing users.

* **Documentation**
  * Updated route helper documentation to include new administrator-related helpers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->