### PR TITLE
Vest equity on invoice date

### DIFF
--- a/backend/app/sidekiq/vest_stock_options_job.rb
+++ b/backend/app/sidekiq/vest_stock_options_job.rb
@@ -31,7 +31,7 @@ class VestStockOptionsJob
         equity_grant:,
         invoice:,
         post_invoice_payment_vesting_event: equity_grant.vesting_events.create!(
-          vesting_date: DateTime.current,
+          vesting_date: invoice.invoice_date,
           vested_shares: invoice.equity_amount_in_options
         )
       ).process


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Vesting events now use the invoice date instead of the current date as the vesting date. This ensures more accurate tracking of vesting timelines.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->