### PR TITLE
feat: implement new company update modal with parallel & intercepting…

### DIFF
--- a/e2e/tests/company/updates/company/create.spec.ts
+++ b/e2e/tests/company/updates/company/create.spec.ts
@@ -36,7 +36,7 @@ test.describe("company update creation", () => {
     await fillForm(page, title, content);
     await page.getByRole("button", { name: "Publish" }).click();
 
-    await expect(page.getByRole("alertdialog", { name: "Publish update?" })).toBeVisible();
+    await expect(page.getByRole("dialog", { name: "Publish update?" })).toBeVisible();
     await page.getByRole("button", { name: "Yes, publish" }).click();
 
     await page.waitForURL("/updates/company");
@@ -83,11 +83,11 @@ test.describe("company update creation", () => {
 
     await page.getByRole("button", { name: "Preview" }).click();
     await expect(page.locator('[data-slot="form-message"]').first()).toBeVisible();
-    await expect(page.getByRole("alertdialog")).not.toBeVisible();
+    await expect(page.getByRole("dialog")).not.toBeVisible();
 
     await page.getByRole("button", { name: "Publish" }).click();
     await expect(page.locator('[data-slot="form-message"]').first()).toBeVisible();
-    await expect(page.getByRole("alertdialog")).not.toBeVisible();
+    await expect(page.getByRole("dialog")).not.toBeVisible();
 
     const updates = await db.query.companyUpdates.findMany({
       where: eq(companyUpdates.companyId, company.id),
@@ -109,7 +109,7 @@ test.describe("company update creation", () => {
     await page.getByLabel("Title").fill("Updated Title");
 
     await page.getByRole("button", { name: "Update" }).click();
-    await expect(page.getByRole("alertdialog", { name: "Publish update?" })).toBeVisible();
+    await expect(page.getByRole("dialog", { name: "Publish update?" })).toBeVisible();
     await page.getByRole("button", { name: "Yes, update" }).click();
 
     await page.waitForURL("/updates/company");
@@ -119,6 +119,135 @@ test.describe("company update creation", () => {
       where: eq(companyUpdates.id, companyUpdate.id),
     });
     expect(updatedRecord?.title).toBe("Updated Title");
+    expect(updatedRecord?.sentAt).not.toBeNull();
+  });
+
+  test("allows publishing company update in modal", async ({ page }) => {
+    const title = "Published Update (Modal)";
+    const content = "This will be published via modal";
+
+    await login(page, adminUser);
+    await page.goto("/updates/company");
+
+    await expect(page.getByRole("link", { name: "New update" })).toBeVisible();
+    await page.getByRole("link", { name: "New update" }).click();
+    await expect(page).toHaveURL("/updates/company/new");
+    await expect(page.getByRole("dialog", { name: "New company update" })).toBeVisible();
+
+    await withinModal(
+      async (modal) => {
+        await modal.getByLabel("Title").fill(title);
+        await modal.locator('[contenteditable="true"]').fill(content);
+        await modal.getByRole("button", { name: "Publish" }).click();
+        await expect(page.getByRole("dialog", { name: "Publish update?" })).toBeVisible();
+        await page.getByRole("button", { name: "Yes, publish" }).click();
+      },
+      { page, title: "New company update" },
+    );
+
+    await expect(page.getByRole("dialog")).not.toBeVisible();
+    await expect(page.getByRole("row").filter({ hasText: title }).filter({ hasText: "Sent" })).toBeVisible();
+
+    const updates = await db.query.companyUpdates.findMany({
+      where: eq(companyUpdates.companyId, company.id),
+    });
+    expect(updates).toHaveLength(1);
+    expect(updates[0]?.sentAt).not.toBeNull();
+  });
+
+  test("allows previewing content in modal", async ({ page }) => {
+    const title = "Test Update (Modal)";
+    const content = "Test content";
+
+    await login(page, adminUser);
+    await page.goto("/updates/company");
+
+    await expect(page.getByRole("link", { name: "New update" })).toBeVisible();
+    await page.getByRole("link", { name: "New update" }).click();
+
+    await withinModal(
+      async (modal) => {
+        await modal.getByLabel("Title").fill(title);
+        await modal.locator('[contenteditable="true"]').fill(content);
+
+        await modal.getByRole("button", { name: "Preview" }).click();
+
+        await withinModal(
+          async (previewModal) => {
+            await expect(previewModal.getByText(title)).toBeVisible();
+            await expect(previewModal.getByText(content)).toBeVisible();
+          },
+          { page, title },
+        );
+      },
+      { page, title: "New company update" },
+    );
+
+    const updates = await db.query.companyUpdates.findMany({
+      where: eq(companyUpdates.companyId, company.id),
+    });
+    expect(updates).toHaveLength(1);
+    expect(updates[0]?.sentAt).toBeNull();
+  });
+
+  test("prevents submission with validation errors in modal", async ({ page }) => {
+    await login(page, adminUser);
+    await page.goto("/updates/company");
+
+    await page.getByRole("link", { name: "New Update" }).click();
+
+    await withinModal(
+      async (modal) => {
+        await modal.getByRole("button", { name: "Preview" }).click();
+        await expect(modal.locator('[data-slot="form-message"]').first()).toBeVisible();
+        await expect(modal.getByRole("dialog")).not.toBeVisible();
+
+        await modal.getByRole("button", { name: "Publish" }).click();
+        await expect(modal.locator('[data-slot="form-message"]').first()).toBeVisible();
+        await expect(modal.getByRole("dialog")).not.toBeVisible();
+      },
+      { page, title: "New company update" },
+    );
+
+    const updates = await db.query.companyUpdates.findMany({
+      where: eq(companyUpdates.companyId, company.id),
+    });
+    expect(updates).toHaveLength(0);
+  });
+
+  test("allows editing published update in modal", async ({ page }) => {
+    const { companyUpdate } = await companyUpdatesFactory.createPublished({
+      companyId: company.id,
+      title: "Original Title",
+      body: "<p>Original content</p>",
+    });
+
+    await login(page, adminUser);
+    await page.goto("/updates/company");
+
+    await page.getByRole("row").filter({ hasText: "Original Title" }).click();
+    await expect(page.getByRole("dialog", { name: "Edit company update" })).toBeVisible();
+
+    await withinModal(
+      async (modal) => {
+        await expect(modal.getByLabel("Title")).toHaveValue("Original Title");
+        await modal.getByLabel("Title").clear();
+        await modal.getByLabel("Title").fill("Updated Title (Modal)");
+        await modal.getByRole("button", { name: "Update" }).click();
+        await expect(page.getByRole("dialog", { name: "Publish update?" })).toBeVisible();
+        await page.getByRole("button", { name: "Yes, update" }).click();
+      },
+      { page, title: "Edit company update" },
+    );
+
+    await expect(
+      page.getByRole("row").filter({ hasText: "Updated Title (Modal)" }).filter({ hasText: "Sent" }),
+    ).toBeVisible();
+
+    const updatedRecord = await db.query.companyUpdates.findFirst({
+      where: eq(companyUpdates.id, companyUpdate.id),
+    });
+    expect(updatedRecord?.title).toBe("Updated Title (Modal)");
     expect(updatedRecord?.sentAt).not.toBeNull();
   });
 });

--- a/frontend/app/(dashboard)/@modal/(.)updates/company/[id]/edit/page.tsx
+++ b/frontend/app/(dashboard)/@modal/(.)updates/company/[id]/edit/page.tsx
@@ -1,0 +1,19 @@
+"use client";
+import { useParams } from "next/navigation";
+import React from "react";
+import EditPage from "@/app/(dashboard)/updates/company/Edit";
+import { Modal } from "@/components/Modal";
+import { useCurrentCompany } from "@/global";
+import { trpc } from "@/trpc/client";
+
+export default function EditModal() {
+  const company = useCurrentCompany();
+  const { id } = useParams<{ id: string }>();
+  const [update] = trpc.companyUpdates.get.useSuspenseQuery({ companyId: company.id, id });
+
+  return (
+    <Modal title="Edit company update">
+      <EditPage update={update} isModal />
+    </Modal>
+  );
+}

--- a/frontend/app/(dashboard)/@modal/(.)updates/company/new/page.tsx
+++ b/frontend/app/(dashboard)/@modal/(.)updates/company/new/page.tsx
@@ -1,0 +1,11 @@
+"use client";
+import EditPage from "@/app/(dashboard)/updates/company/Edit";
+import { Modal } from "@/components/Modal";
+
+export default function NewModal() {
+  return (
+    <Modal title="New company update">
+      <EditPage isModal />
+    </Modal>
+  );
+}

--- a/frontend/app/(dashboard)/@modal/default.tsx
+++ b/frontend/app/(dashboard)/@modal/default.tsx
@@ -1,0 +1,3 @@
+export default function Default() {
+  return null;
+}

--- a/frontend/app/(dashboard)/layout.tsx
+++ b/frontend/app/(dashboard)/layout.tsx
@@ -59,7 +59,7 @@ import { trpc } from "@/trpc/client";
 import { request } from "@/utils/request";
 import { company_switch_path } from "@/utils/routes";
 
-export default function DashboardLayout({ children }: { children: React.ReactNode }) {
+export default function DashboardLayout({ children, modal }: { children: React.ReactNode; modal: React.ReactNode }) {
   const user = useCurrentUser();
   const company = useCurrentCompany();
   const pathname = usePathname();
@@ -211,8 +211,11 @@ export default function DashboardLayout({ children }: { children: React.ReactNod
       </Sidebar>
       <SidebarInset>
         <div className="flex flex-col not-print:h-screen not-print:overflow-hidden">
-          <main className="flex flex-1 flex-col not-print:overflow-y-auto">
-            <div className="flex flex-col gap-4">{children}</div>
+          <main className="flex flex-1 flex-col pb-4 not-print:overflow-y-auto">
+            <div className="mx-3 flex flex-col gap-6">
+              {children}
+              {modal}
+            </div>
           </main>
         </div>
       </SidebarInset>

--- a/frontend/components/Modal.tsx
+++ b/frontend/components/Modal.tsx
@@ -1,0 +1,20 @@
+"use client";
+import { useRouter } from "next/navigation";
+import { Dialog, DialogContent, DialogTitle } from "@/components/ui/dialog";
+
+export function Modal({ children, title }: { children: React.ReactNode; title: string }) {
+  const router = useRouter();
+
+  const handleOpenChange = () => {
+    router.back();
+  };
+
+  return (
+    <Dialog defaultOpen open onOpenChange={handleOpenChange}>
+      <DialogContent className="!max-w-[calc(40%-2rem)]">
+        <DialogTitle className="text-lg">{title}</DialogTitle>
+        {children}
+      </DialogContent>
+    </Dialog>
+  );
+}


### PR DESCRIPTION
Addresses: #696

Demo Video: 

https://github.com/user-attachments/assets/f4287795-7b46-4926-9e45-89e23a6017a1

Testings:

<img width="1906" height="397" alt="Screenshot 2025-08-05 032537" src="https://github.com/user-attachments/assets/33d75c9b-e547-4ba1-87c4-efeb9a9cf5da" />

### Summary
**New Features**
- Implemented company update modal using Parallel Routes + Intercepting Routes.
- Keeps URLs in sync with modal state for shareable modals.
- Allows adding future modals in `/dashboard` without extra state logic.

**Improvements**
- Removes dependency on local state for modal open/close.
- Preserves background page context when modal is open.
- Enables seamless navigation between modal and underlying routes.