### PR TITLE
feat: Update OTP Input styling

### DIFF
--- a/e2e/helpers/auth.ts
+++ b/e2e/helpers/auth.ts
@@ -5,6 +5,14 @@ import { users } from "@/db/schema";
 // Backend accepts "000000" when Rails.env.test? && ENV['ENABLE_DEFAULT_OTP'] == 'true'
 const TEST_OTP_CODE = "000000";
 
+/**
+ * Fill individual OTP slots with the test code
+ */
+export const fillOtpSlots = async (page: Page, code = TEST_OTP_CODE) => {
+  // Use the accessible textbox instead of individual div slots
+  await page.getByRole("textbox", { name: "Verification code" }).fill(code);
+};
+
 export const login = async (page: Page, user: typeof users.$inferSelect) => {
   await page.goto("/login");
 
@@ -12,11 +20,8 @@ export const login = async (page: Page, user: typeof users.$inferSelect) => {
   await page.getByLabel("Work email").fill(user.email);
   await page.getByRole("button", { name: "Log in" }).click();
 
-  // Wait for OTP step to appear
-  await page.getByLabel("Verification code").waitFor();
-
-  // Use test OTP code - backend should accept this in test environment
-  await page.getByLabel("Verification code").fill(TEST_OTP_CODE);
+  // Wait for OTP step and fill slots
+  await fillOtpSlots(page);
   await page.getByRole("button", { name: "Continue" }).click();
 
   // Wait for successful redirect
@@ -44,9 +49,8 @@ export const signup = async (page: Page, email: string) => {
   await page.getByLabel("Work email").fill(email);
   await page.getByRole("button", { name: "Sign up" }).click();
 
-  // Wait for OTP step and enter verification code
-  await page.getByLabel("Verification code").waitFor();
-  await page.getByLabel("Verification code").fill(TEST_OTP_CODE);
+  // Wait for OTP step and fill slots
+  await fillOtpSlots(page);
   await page.getByRole("button", { name: "Continue" }).click();
 
   // Wait for successful redirect to onboarding or dashboard

--- a/e2e/tests/company/administrator/onboarding/signup.spec.ts
+++ b/e2e/tests/company/administrator/onboarding/signup.spec.ts
@@ -1,5 +1,6 @@
 import { faker } from "@faker-js/faker";
 import { db, takeOrThrow } from "@test/db";
+import { fillOtpSlots } from "@test/helpers/auth";
 import { expect, test } from "@test/index";
 import { eq } from "drizzle-orm";
 import { users } from "@/db/schema";
@@ -26,9 +27,8 @@ test.describe("Company administrator signup", () => {
     await page.getByLabel("Work email").fill(email);
     await page.getByRole("button", { name: "Sign up" }).click();
 
-    // Wait for OTP step and enter verification code
-    await page.getByLabel("Verification code").waitFor();
-    await page.getByLabel("Verification code").fill("000000"); // Test OTP code
+    // Wait for OTP step and enter verification code using slots
+    await fillOtpSlots(page, "000000");
     await page.getByRole("button", { name: "Continue" }).click();
 
     // Wait for redirect to dashboard

--- a/e2e/tests/login.spec.ts
+++ b/e2e/tests/login.spec.ts
@@ -1,5 +1,6 @@
 import { db } from "@test/db";
 import { usersFactory } from "@test/factories/users";
+import { fillOtpSlots } from "@test/helpers/auth";
 import { expect, test } from "@test/index";
 import { eq } from "drizzle-orm";
 import { users } from "@/db/schema";
@@ -12,7 +13,7 @@ test("login", async ({ page }) => {
 
   await page.getByLabel("Work email").fill(email);
   await page.getByRole("button", { name: "Log in", exact: true }).click();
-  await page.getByLabel("Verification code").fill("000000");
+  await fillOtpSlots(page, "000000");
   await page.getByRole("button", { name: "Continue", exact: true }).click();
 
   await expect(page.getByRole("heading", { name: "Invoices" })).toBeVisible();
@@ -35,7 +36,7 @@ test("login with redirect_url", async ({ page }) => {
 
   await page.getByLabel("Work email").fill(email);
   await page.getByRole("button", { name: "Log in", exact: true }).click();
-  await page.getByLabel("Verification code").fill("000000");
+  await fillOtpSlots(page, "000000");
   await page.getByRole("button", { name: "Continue", exact: true }).click();
 
   await page.waitForLoadState("networkidle");

--- a/frontend/app/(auth)/login/page.tsx
+++ b/frontend/app/(auth)/login/page.tsx
@@ -6,6 +6,7 @@ import { AuthAlerts } from "@/components/auth/AuthAlerts";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
+import { InputOTP, InputOTPGroup, InputOTPSeparator, InputOTPSlot } from "@/components/ui/input-otp";
 import { Label } from "@/components/ui/label";
 import { useAuthApi } from "@/hooks/useAuthApi";
 import { useOtpFlowState } from "@/hooks/useOtpFlowState";
@@ -80,19 +81,30 @@ function LoginContent() {
                 className="space-y-4"
               >
                 <div className="space-y-2">
-                  <Label htmlFor="otp" className="block">
+                  <Label htmlFor="otp" className="flex justify-center">
                     Verification code
                   </Label>
-                  <Input
-                    id="otp"
-                    type="text"
-                    placeholder="Enter 6-digit code"
-                    value={state.otp}
-                    onChange={(e) => actions.setOtp(e.target.value)}
-                    maxLength={6}
-                    required
-                    disabled={state.loading}
-                  />
+                  <div className="flex justify-center">
+                    <InputOTP
+                      id="otp"
+                      maxLength={6}
+                      value={state.otp}
+                      onChange={(value) => actions.setOtp(value)}
+                      disabled={state.loading}
+                    >
+                      <InputOTPGroup>
+                        <InputOTPSlot index={0} />
+                        <InputOTPSlot index={1} />
+                        <InputOTPSlot index={2} />
+                      </InputOTPGroup>
+                      <InputOTPSeparator />
+                      <InputOTPGroup>
+                        <InputOTPSlot index={3} />
+                        <InputOTPSlot index={4} />
+                        <InputOTPSlot index={5} />
+                      </InputOTPGroup>
+                    </InputOTP>
+                  </div>
                 </div>
                 <Button type="submit" className="w-full" disabled={state.loading}>
                   {state.loading ? "Verifying..." : "Continue"}

--- a/frontend/app/(auth)/signup/[[...rest]]/page.tsx
+++ b/frontend/app/(auth)/signup/[[...rest]]/page.tsx
@@ -7,6 +7,7 @@ import { AuthAlerts } from "@/components/auth/AuthAlerts";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
+import { InputOTP, InputOTPGroup, InputOTPSeparator, InputOTPSlot } from "@/components/ui/input-otp";
 import { Label } from "@/components/ui/label";
 import { useAuthApi } from "@/hooks/useAuthApi";
 import { useOtpFlowState } from "@/hooks/useOtpFlowState";
@@ -87,19 +88,30 @@ function SignUpContent() {
                 className="space-y-4"
               >
                 <div className="space-y-2">
-                  <Label htmlFor="otp" className="block">
+                  <Label htmlFor="otp" className="flex justify-center">
                     Verification code
                   </Label>
-                  <Input
-                    id="otp"
-                    type="text"
-                    placeholder="Enter 6-digit code"
-                    value={state.otp}
-                    onChange={(e) => actions.setOtp(e.target.value)}
-                    maxLength={6}
-                    required
-                    disabled={state.loading}
-                  />
+                  <div className="flex justify-center">
+                    <InputOTP
+                      id="otp"
+                      maxLength={6}
+                      value={state.otp}
+                      onChange={(value) => actions.setOtp(value)}
+                      disabled={state.loading}
+                    >
+                      <InputOTPGroup>
+                        <InputOTPSlot index={0} />
+                        <InputOTPSlot index={1} />
+                        <InputOTPSlot index={2} />
+                      </InputOTPGroup>
+                      <InputOTPSeparator />
+                      <InputOTPGroup>
+                        <InputOTPSlot index={3} />
+                        <InputOTPSlot index={4} />
+                        <InputOTPSlot index={5} />
+                      </InputOTPGroup>
+                    </InputOTP>
+                  </div>
                 </div>
                 <Button type="submit" className="w-full" disabled={state.loading}>
                   {state.loading ? "Creating account..." : "Continue"}

--- a/frontend/components/ui/input-otp.tsx
+++ b/frontend/components/ui/input-otp.tsx
@@ -1,0 +1,65 @@
+"use client";
+
+import { OTPInput, OTPInputContext } from "input-otp";
+import { Minus } from "lucide-react";
+import * as React from "react";
+import { cn } from "../../utils";
+
+const InputOTP = React.forwardRef<React.ElementRef<typeof OTPInput>, React.ComponentPropsWithoutRef<typeof OTPInput>>(
+  ({ className, containerClassName, ...props }, ref) => (
+    <OTPInput
+      ref={ref}
+      data-slot="input-otp"
+      containerClassName={cn("flex items-center gap-2 has-[:disabled]:opacity-50", containerClassName)}
+      className={cn("disabled:cursor-not-allowed", className)}
+      {...props}
+    />
+  ),
+);
+InputOTP.displayName = "InputOTP";
+
+const InputOTPGroup = React.forwardRef<React.ElementRef<"div">, React.ComponentPropsWithoutRef<"div">>(
+  ({ className, ...props }, ref) => <div ref={ref} className={cn("flex items-center", className)} {...props} />,
+);
+InputOTPGroup.displayName = "InputOTPGroup";
+
+const InputOTPSlot = React.forwardRef<
+  React.ElementRef<"div">,
+  React.ComponentPropsWithoutRef<"div"> & { index: number }
+>(({ index, className, ...props }, ref) => {
+  const inputOTPContext = React.useContext(OTPInputContext);
+  const slot = inputOTPContext.slots[index];
+  const { char, hasFakeCaret, isActive } = slot || { char: null, hasFakeCaret: false, isActive: false };
+
+  return (
+    <div
+      ref={ref}
+      data-slot="input-otp-slot"
+      className={cn(
+        "border-input relative flex h-10 w-10 items-center justify-center border-y border-r text-sm transition-all first:rounded-l-md first:border-l last:rounded-r-md",
+        isActive && "ring-ring ring-offset-background z-10 ring-2",
+        className,
+      )}
+      {...props}
+    >
+      {char}
+      {hasFakeCaret ? (
+        <div className="pointer-events-none absolute inset-0 flex items-center justify-center">
+          <div className="animate-caret-blink bg-foreground h-4 w-px duration-1000" />
+        </div>
+      ) : null}
+    </div>
+  );
+});
+InputOTPSlot.displayName = "InputOTPSlot";
+
+const InputOTPSeparator = React.forwardRef<React.ElementRef<"div">, React.ComponentPropsWithoutRef<"div">>(
+  ({ ...props }, ref) => (
+    <div ref={ref} role="separator" {...props}>
+      <Minus />
+    </div>
+  ),
+);
+InputOTPSeparator.displayName = "InputOTPSeparator";
+
+export { InputOTP, InputOTPGroup, InputOTPSeparator, InputOTPSlot };

--- a/frontend/components/ui/input-otp.tsx
+++ b/frontend/components/ui/input-otp.tsx
@@ -34,7 +34,7 @@ const InputOTPSlot = React.forwardRef<
   return (
     <div
       ref={ref}
-      data-slot="input-otp-slot"
+      data-input-otp-slot={index}
       className={cn(
         "border-input relative flex h-10 w-10 items-center justify-center border-y border-r text-sm transition-all first:rounded-l-md first:border-l last:rounded-r-md",
         isActive && "ring-ring ring-offset-background z-10 ring-2",

--- a/package.json
+++ b/package.json
@@ -111,6 +111,7 @@
     "drizzle-zod": "^0.7.0",
     "immutable": "^5.0.3",
     "inngest": "^3.27.0",
+    "input-otp": "^1.4.2",
     "iso-3166": "^4.3.0",
     "jsonwebtoken": "^9.0.2",
     "lodash-es": "^4.17.21",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -199,6 +199,9 @@ importers:
       inngest:
         specifier: ^3.27.0
         version: 3.32.7(patch_hash=b859654a83fe3c45179ca9dbe71b7b6917366a67657f37658b146b1264870e28)(next@15.2.4(patch_hash=b88b2148998305bbdabddd07fbda67d9c9f6010995b25120053815e04bd5330b)(@opentelemetry/api@1.9.0)(@playwright/test@1.51.0)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(typescript@5.8.2)
+      input-otp:
+        specifier: ^1.4.2
+        version: 1.4.2(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       iso-3166:
         specifier: ^4.3.0
         version: 4.3.0
@@ -4721,6 +4724,12 @@ packages:
         optional: true
       typescript:
         optional: true
+
+  input-otp@1.4.2:
+    resolution: {integrity: sha512-l3jWwYNvrEa6NTCt7BECfCm48GvwuZzkoeG3gBL2w4CHeOXW3eKFmf9UNYkNfYc3mxMrthMnxjIE07MT0zLBQA==}
+    peerDependencies:
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0.0 || ^19.0.0-rc
 
   internal-slot@1.1.0:
     resolution: {integrity: sha512-4gd7VpWNQNB4UKKCFFVcp1AVv+FMOgs9NKzjHKusc8jTMhd5eL1NqQqOpE0KzMds804/yHlglp3uxgluOqAPLw==}
@@ -11969,6 +11978,11 @@ snapshots:
     transitivePeerDependencies:
       - encoding
       - supports-color
+
+  input-otp@1.4.2(react-dom@19.0.0(react@19.0.0))(react@19.0.0):
+    dependencies:
+      react: 19.0.0
+      react-dom: 19.0.0(react@19.0.0)
 
   internal-slot@1.1.0:
     dependencies:


### PR DESCRIPTION
Resolves #768

- [x] Updated OTP input styling for improved UI consistency
- [x] Applied changes to both Signup and Login pages
- [x] Updated corresponding E2E tests to reflect the new OTP input behavior

## Demo 
### Before
<img width="1919" height="944" alt="before-signup" src="https://github.com/user-attachments/assets/bf206e9b-411e-4b95-8727-fddef47bbf85" />
<img width="1919" height="944" alt="before-login" src="https://github.com/user-attachments/assets/cb9962be-02a4-4842-83b0-19ae4a38881d" />

### After

https://github.com/user-attachments/assets/7a6c7d9d-9258-472b-9317-3ecb7b00e862

https://github.com/user-attachments/assets/9c2660eb-a371-4fdf-9b04-17622135c11d


## Tests
<img width="1920" height="982" alt="tests-signup-login" src="https://github.com/user-attachments/assets/76d33662-4e4a-495a-b96d-c04e320d257e" />
All the tests related to the changes are passing successfully.
