### PR TITLE
feat: add equity events section with E2E tests

### DIFF
--- a/e2e/tests/company/equity/vesting-events.spec.ts
+++ b/e2e/tests/company/equity/vesting-events.spec.ts
@@ -167,7 +167,8 @@ test.describe("Equity Grant Vesting Events", () => {
 
     // Wait for the modal to open and vesting events to load
     await expect(page.getByRole("dialog")).toBeVisible();
-    await expect(page.getByText("Vesting events")).toBeVisible();
+
+    await expect(page.getByText("Vesting events")).toBeVisible({ timeout: 10000 });
 
     // Verify vesting events section shows up
     const vestingEventsSection = page.getByRole("dialog");

--- a/e2e/tests/company/equity/vesting-events.spec.ts
+++ b/e2e/tests/company/equity/vesting-events.spec.ts
@@ -254,8 +254,6 @@ test.describe("Equity Grant Vesting Events", () => {
 
     await page.getByRole("button", { name: "Create grant" }).click();
 
-    await page.waitForLoadState("networkidle");
-
     // Navigate to the people page and find the contractor
     await page.getByRole("link", { name: "People" }).click();
 

--- a/e2e/tests/company/equity/vesting-events.spec.ts
+++ b/e2e/tests/company/equity/vesting-events.spec.ts
@@ -186,11 +186,10 @@ test.describe("Equity Grant Vesting Events", () => {
     }
 
     // Verify some are marked as vested and others as scheduled
-    const vestingEventsContainer = vestingEventsSection.locator("h3:has-text('Vesting events') + div");
-    const vestedCount = await vestingEventsContainer.locator("text=(Vested)").count();
+    const vestedCount = await vestingEventsSection.getByText("(Vested)", { exact: false }).count();
     expect(vestedCount).toBe(4); // Cliff + 3 monthly
 
-    const scheduledCount = await vestingEventsContainer.locator("text=(Scheduled)").count();
+    const scheduledCount = await vestingEventsSection.getByText("(Scheduled)", { exact: false }).count();
     expect(scheduledCount).toBeGreaterThan(30); // Remaining monthly vesting events
 
     // Verify other sections are still present within the modal

--- a/e2e/tests/company/equity/vesting-events.spec.ts
+++ b/e2e/tests/company/equity/vesting-events.spec.ts
@@ -1,0 +1,283 @@
+import { db } from "@test/db";
+import { companiesFactory } from "@test/factories/companies";
+import { companyContractorsFactory } from "@test/factories/companyContractors";
+import { companyInvestorsFactory } from "@test/factories/companyInvestors";
+import { documentTemplatesFactory } from "@test/factories/documentTemplates";
+import { equityGrantsFactory } from "@test/factories/equityGrants";
+import { optionPoolsFactory } from "@test/factories/optionPools";
+import { usersFactory } from "@test/factories/users";
+import { fillDatePicker, selectComboboxOption } from "@test/helpers";
+import { login } from "@test/helpers/auth";
+import { mockDocuseal } from "@test/helpers/docuseal";
+import { expect, test } from "@test/index";
+import { addMonths, format } from "date-fns";
+import { and, eq } from "drizzle-orm";
+import { DocumentTemplateType } from "@/db/enums";
+import { equityGrants, vestingEvents, vestingSchedules } from "@/db/schema";
+import { assertDefined } from "@/utils/assert";
+
+test.describe.configure({ mode: "serial" });
+
+test.describe("Equity Grant Vesting Events", () => {
+  test("displays vesting events in the equity grant details modal", async ({ page, next }) => {
+    const { company, adminUser } = await companiesFactory.createCompletedOnboarding({
+      equityEnabled: true,
+      fmvPerShareInUsd: "1",
+      conversionSharePriceUsd: "1.00",
+      sharePriceInUsd: "1.00",
+    });
+
+    const { user: contractorUser } = await usersFactory.create();
+    const { mockForm } = mockDocuseal(next, {
+      submitters: () => ({ "Company Representative": adminUser, Signer: contractorUser }),
+    });
+    await mockForm(page);
+
+    await companyContractorsFactory.create({
+      companyId: company.id,
+      userId: contractorUser.id,
+    });
+
+    const { optionPool } = await optionPoolsFactory.create({
+      companyId: company.id,
+      authorizedShares: 100000n,
+      issuedShares: 0n,
+    });
+
+    await documentTemplatesFactory.create({
+      companyId: company.id,
+      type: DocumentTemplateType.EquityPlanContract,
+    });
+
+    // Create a vesting schedule (4 year vesting with 1 year cliff, monthly vesting)
+    let vestingSchedule = await db.query.vestingSchedules.findFirst({
+      where: and(
+        eq(vestingSchedules.totalVestingDurationMonths, 48),
+        eq(vestingSchedules.cliffDurationMonths, 12),
+        eq(vestingSchedules.vestingFrequencyMonths, 1),
+      ),
+    });
+
+    if (!vestingSchedule) {
+      [vestingSchedule] = await db
+        .insert(vestingSchedules)
+        .values({
+          totalVestingDurationMonths: 48, // 4 years
+          cliffDurationMonths: 12, // 1 year cliff
+          vestingFrequencyMonths: 1, // monthly vesting
+        })
+        .returning();
+    }
+
+    // Create investor record
+    const { companyInvestor } = await companyInvestorsFactory.create({
+      companyId: company.id,
+      userId: contractorUser.id,
+    });
+
+    // Create equity grant with vesting schedule
+    const vestingStartDate = new Date();
+    const { equityGrant } = await equityGrantsFactory.create({
+      companyInvestorId: companyInvestor.id,
+      optionPoolId: optionPool.id,
+      numberOfShares: 48000, // 48,000 shares total
+      vestedShares: 0,
+      unvestedShares: 48000,
+      exercisedShares: 0,
+      forfeitedShares: 0,
+      exercisePriceUsd: "1.00",
+      sharePriceUsd: "1.00",
+      optionGrantType: "nso",
+      vestingTrigger: "scheduled",
+      vestingScheduleId: assertDefined(vestingSchedule).id,
+      issuedAt: vestingStartDate,
+      acceptedAt: vestingStartDate,
+      periodStartedAt: vestingStartDate,
+      periodEndedAt: addMonths(vestingStartDate, 48),
+      expiresAt: addMonths(vestingStartDate, 120), // 10 year expiry
+      boardApprovalDate: vestingStartDate.toDateString(),
+      voluntaryTerminationExerciseMonths: 3,
+      involuntaryTerminationExerciseMonths: 3,
+      terminationWithCauseExerciseMonths: 0,
+      deathExerciseMonths: 12,
+      disabilityExerciseMonths: 12,
+      retirementExerciseMonths: 12,
+      optionHolderName: contractorUser.legalName ?? "",
+      issueDateRelationship: "employee",
+    });
+
+    // Create vesting events based on the schedule
+    // First year cliff: 12,000 shares vest at month 12
+    await db.insert(vestingEvents).values({
+      equityGrantId: equityGrant.id,
+      vestingDate: addMonths(vestingStartDate, 12),
+      vestedShares: 12000n, // 25% cliff
+    });
+
+    // Monthly vesting for remaining 36 months: 1,000 shares per month
+    for (let month = 13; month <= 48; month++) {
+      await db.insert(vestingEvents).values({
+        equityGrantId: equityGrant.id,
+        vestingDate: addMonths(vestingStartDate, month),
+        vestedShares: 1000n, // 1,000 shares per month
+      });
+    }
+
+    // Mark first few vesting events as processed (vested)
+    const allVestingEvents = await db.query.vestingEvents.findMany({
+      where: eq(vestingEvents.equityGrantId, equityGrant.id),
+      orderBy: (vestingEvents, { asc }) => [asc(vestingEvents.vestingDate)],
+    });
+
+    // Process the cliff and first 3 months of monthly vesting
+    for (let i = 0; i < 4 && i < allVestingEvents.length; i++) {
+      await db
+        .update(vestingEvents)
+        .set({ processedAt: new Date() })
+        .where(eq(vestingEvents.id, assertDefined(allVestingEvents[i]).id));
+    }
+
+    // Update the equity grant's vested shares count
+    await db
+      .update(equityGrants)
+      .set({
+        vestedShares: 15000, // 12,000 (cliff) + 3,000 (3 months)
+        unvestedShares: 33000, // 48,000 - 15,000
+      })
+      .where(eq(equityGrants.id, equityGrant.id));
+
+    await login(page, adminUser);
+
+    // Navigate to the people page and find the contractor
+    await page.getByRole("link", { name: "People" }).click();
+    await page.getByRole("link", { name: contractorUser.preferredName ?? "" }).click();
+
+    // Click on the Options tab
+    await page.getByRole("tab", { name: "Options" }).click();
+
+    // The grant should appear in the options table
+    await expect(page.getByRole("table")).toHaveCount(1);
+    const rows = page.getByRole("table").first().getByRole("row");
+    await expect(rows).toHaveCount(2);
+    const row = rows.nth(1);
+    await expect(row).toContainText("48,000");
+
+    // Click on the row to open the details modal
+    await row.click();
+
+    // Wait for the modal to open and vesting events to load
+    await expect(page.getByRole("dialog")).toBeVisible();
+    await expect(page.getByText("Vesting events")).toBeVisible();
+
+    // Verify vesting events section shows up
+    const vestingEventsSection = page.getByRole("dialog");
+
+    // Check cliff vesting event (12,000 shares at month 12)
+    const cliffDate = format(addMonths(vestingStartDate, 12), "MMM d, yyyy");
+    await expect(vestingEventsSection).toContainText(cliffDate);
+    await expect(vestingEventsSection).toContainText("12,000 options");
+    await expect(vestingEventsSection).toContainText("(Vested)");
+
+    // Check monthly vesting events
+    for (let month = 13; month <= 15; month++) {
+      const vestingDate = format(addMonths(vestingStartDate, month), "MMM d, yyyy");
+      await expect(vestingEventsSection).toContainText(vestingDate);
+      await expect(vestingEventsSection).toContainText("1,000 options");
+    }
+
+    // Verify some are marked as vested and others as scheduled
+    const vestingEventsContainer = vestingEventsSection.locator("h3:has-text('Vesting events') + div");
+    const vestedCount = await vestingEventsContainer.locator("text=(Vested)").count();
+    expect(vestedCount).toBe(4); // Cliff + 3 monthly
+
+    const scheduledCount = await vestingEventsContainer.locator("text=(Scheduled)").count();
+    expect(scheduledCount).toBeGreaterThan(30); // Remaining monthly vesting events
+
+    // Verify other sections are still present within the modal
+    const modalContent = page.getByRole("dialog");
+    await expect(modalContent.getByText("Total options granted")).toBeVisible();
+    await expect(modalContent.getByText("48,000 (NSO)")).toBeVisible();
+    await expect(modalContent.getByText("Vested").first()).toBeVisible();
+    await expect(modalContent.getByText("15,000").first()).toBeVisible();
+    await expect(modalContent.getByText("Unvested").first()).toBeVisible();
+    await expect(modalContent.getByText("33,000").first()).toBeVisible();
+  });
+
+  test("handles equity grants with invoice-based vesting", async ({ page, next }) => {
+    const { company, adminUser } = await companiesFactory.createCompletedOnboarding({
+      equityEnabled: true,
+      fmvPerShareInUsd: "1",
+      conversionSharePriceUsd: "1.00",
+      sharePriceInUsd: "1.00",
+    });
+
+    const { user: contractorUser } = await usersFactory.create();
+    const submitters = { "Company Representative": adminUser, Signer: contractorUser };
+    const { mockForm } = mockDocuseal(next, { submitters: () => submitters });
+    await mockForm(page);
+
+    await companyContractorsFactory.create({
+      companyId: company.id,
+      userId: contractorUser.id,
+    });
+
+    await optionPoolsFactory.create({
+      companyId: company.id,
+      authorizedShares: 50000n,
+      issuedShares: 0n,
+    });
+    await documentTemplatesFactory.create({
+      companyId: company.id,
+      type: DocumentTemplateType.EquityPlanContract,
+    });
+
+    await login(page, adminUser);
+    await page.getByRole("button", { name: "Equity" }).click();
+    await page.getByRole("link", { name: "Equity grants" }).click();
+
+    // Create grant with invoice-based vesting
+    await page.getByRole("button", { name: "New option grant" }).click();
+    await selectComboboxOption(page, "Recipient", contractorUser.preferredName ?? "");
+    await page.getByLabel("Number of options").fill("10000");
+    await selectComboboxOption(page, "Relationship to company", "Consultant");
+    await selectComboboxOption(page, "Grant type", "NSO");
+    await selectComboboxOption(page, "Shares will vest", "As invoices are paid");
+    await fillDatePicker(page, "Board approval date", new Date().toLocaleDateString("en-US"));
+
+    // Fill exercise periods
+    await page.getByRole("button", { name: "Customize post-termination exercise period" }).click();
+    await page.locator('input[name="voluntaryTerminationExerciseMonths"]').fill("3");
+    await page.locator('input[name="involuntaryTerminationExerciseMonths"]').fill("3");
+    await page.locator('input[name="terminationWithCauseExerciseMonths"]').fill("0");
+    await page.locator('input[name="deathExerciseMonths"]').fill("12");
+    await page.locator('input[name="disabilityExerciseMonths"]').fill("12");
+    await page.locator('input[name="retirementExerciseMonths"]').fill("12");
+
+    await page.getByRole("button", { name: "Create grant" }).click();
+
+    // Wait for the grant creation to complete - could redirect to a success page or back to grants list
+    await page.waitForTimeout(2000);
+
+    // Navigate to the people page and find the contractor
+    await page.getByRole("link", { name: "People" }).click();
+    await page.getByRole("link", { name: contractorUser.preferredName ?? "" }).click();
+
+    // Click on the Options tab
+    await page.getByRole("tab", { name: "Options" }).click();
+
+    // Open the details modal by clicking on the grant row
+    await page.getByRole("table").first().getByRole("row").nth(1).click();
+    await expect(page.getByRole("dialog")).toBeVisible();
+
+    // Invoice-based vesting grants should not show vesting events section within the modal
+    const modalContent = page.getByRole("dialog");
+    await expect(modalContent.getByText("Vesting events")).not.toBeVisible();
+
+    // But should show other standard sections within the modal
+    await expect(modalContent.getByText("Total options granted")).toBeVisible();
+    await expect(modalContent.getByText("10,000 (NSO)")).toBeVisible();
+    await expect(modalContent.getByText("Exercise details")).toBeVisible();
+    await expect(modalContent.getByText("Post-termination exercise windows")).toBeVisible();
+    await expect(modalContent.getByText("Compliance details")).toBeVisible();
+  });
+});

--- a/e2e/tests/company/equity/vesting-events.spec.ts
+++ b/e2e/tests/company/equity/vesting-events.spec.ts
@@ -255,11 +255,11 @@ test.describe("Equity Grant Vesting Events", () => {
 
     await page.getByRole("button", { name: "Create grant" }).click();
 
-    // Wait for the grant creation to complete - could redirect to a success page or back to grants list
-    await page.waitForTimeout(2000);
+    await page.waitForLoadState("networkidle");
 
     // Navigate to the people page and find the contractor
     await page.getByRole("link", { name: "People" }).click();
+
     await page.getByRole("link", { name: contractorUser.preferredName ?? "" }).click();
 
     // Click on the Options tab

--- a/frontend/app/(dashboard)/equity/grants/DetailsModal.tsx
+++ b/frontend/app/(dashboard)/equity/grants/DetailsModal.tsx
@@ -36,6 +36,7 @@ const DetailsModal = ({
 }) => {
   const company = useCurrentCompany();
   const [user] = trpc.users.get.useSuspenseQuery({ companyId: company.id, id: userId });
+  const { data: fullEquityGrant } = trpc.equityGrants.get.useQuery({ companyId: company.id, id: equityGrant.id });
 
   return (
     <Sheet open onOpenChange={onClose}>
@@ -122,6 +123,21 @@ const DetailsModal = ({
             }
           />
           <Item label="Role type" value={relationshipDisplayNames[equityGrant.issueDateRelationship]} />
+
+          {fullEquityGrant?.vestingEvents && fullEquityGrant.vestingEvents.length > 0 ? (
+            <>
+              <Separator />
+              <h3 className="text-md px-6 font-medium">Vesting events</h3>
+              {fullEquityGrant.vestingEvents.map((event, index) => (
+                <div key={index}>
+                  <Item
+                    label={`${formatDate(event.vestingDate)} ${event.processedAt ? "(Vested)" : event.cancelledAt ? "(Cancelled)" : "(Scheduled)"}`}
+                    value={`${event.vestedShares.toLocaleString()} options `}
+                  />
+                </div>
+              ))}
+            </>
+          ) : null}
         </div>
         {company.flags.includes("option_exercising") &&
         equityGrant.vestedShares > 0 &&

--- a/frontend/app/(dashboard)/equity/grants/DetailsModal.tsx
+++ b/frontend/app/(dashboard)/equity/grants/DetailsModal.tsx
@@ -128,11 +128,11 @@ const DetailsModal = ({
             <>
               <Separator />
               <h3 className="text-md px-6 font-medium">Vesting events</h3>
-              {fullEquityGrant.vestingEvents.map((event, index) => (
-                <div key={index}>
+              {fullEquityGrant.vestingEvents.map((event) => (
+                <div key={event.id}>
                   <Item
                     label={`${formatDate(event.vestingDate)} ${event.processedAt ? "(Vested)" : event.cancelledAt ? "(Cancelled)" : "(Scheduled)"}`}
-                    value={`${event.vestedShares.toLocaleString()} options `}
+                    value={`${event.vestedShares.toLocaleString()} options`}
                   />
                 </div>
               ))}

--- a/frontend/app/(dashboard)/equity/grants/DetailsModal.tsx
+++ b/frontend/app/(dashboard)/equity/grants/DetailsModal.tsx
@@ -38,6 +38,9 @@ const DetailsModal = ({
   const [user] = trpc.users.get.useSuspenseQuery({ companyId: company.id, id: userId });
   const { data: fullEquityGrant } = trpc.equityGrants.get.useQuery({ companyId: company.id, id: equityGrant.id });
 
+  const processedVestingEvents =
+    fullEquityGrant?.vestingEvents.filter((event) => event.processedAt && !event.cancelledAt) ?? [];
+
   return (
     <Sheet open onOpenChange={onClose}>
       <SheetContent>
@@ -124,21 +127,15 @@ const DetailsModal = ({
           />
           <Item label="Role type" value={relationshipDisplayNames[equityGrant.issueDateRelationship]} />
 
-          {fullEquityGrant?.vestingEvents &&
-          fullEquityGrant.vestingEvents.filter((event) => event.processedAt).length > 0 ? (
+          {processedVestingEvents.length > 0 ? (
             <>
               <Separator />
               <h3 className="text-md px-6 font-medium">Vesting events</h3>
-              {fullEquityGrant.vestingEvents
-                .filter((event) => event.processedAt)
-                .map((event) => (
-                  <div key={event.id}>
-                    <Item
-                      label={formatDate(event.vestingDate)}
-                      value={`${event.vestedShares.toLocaleString()} shares`}
-                    />
-                  </div>
-                ))}
+              {processedVestingEvents.map((event) => (
+                <div key={event.id}>
+                  <Item label={formatDate(event.vestingDate)} value={`${event.vestedShares.toLocaleString()} shares`} />
+                </div>
+              ))}
             </>
           ) : null}
         </div>

--- a/frontend/app/(dashboard)/equity/grants/DetailsModal.tsx
+++ b/frontend/app/(dashboard)/equity/grants/DetailsModal.tsx
@@ -124,18 +124,21 @@ const DetailsModal = ({
           />
           <Item label="Role type" value={relationshipDisplayNames[equityGrant.issueDateRelationship]} />
 
-          {fullEquityGrant?.vestingEvents && fullEquityGrant.vestingEvents.length > 0 ? (
+          {fullEquityGrant?.vestingEvents &&
+          fullEquityGrant.vestingEvents.filter((event) => event.processedAt).length > 0 ? (
             <>
               <Separator />
               <h3 className="text-md px-6 font-medium">Vesting events</h3>
-              {fullEquityGrant.vestingEvents.map((event) => (
-                <div key={event.id}>
-                  <Item
-                    label={`${formatDate(event.vestingDate)} ${event.processedAt ? "(Vested)" : event.cancelledAt ? "(Cancelled)" : "(Scheduled)"}`}
-                    value={`${event.vestedShares.toLocaleString()} options`}
-                  />
-                </div>
-              ))}
+              {fullEquityGrant.vestingEvents
+                .filter((event) => event.processedAt)
+                .map((event) => (
+                  <div key={event.id}>
+                    <Item
+                      label={formatDate(event.vestingDate)}
+                      value={`${event.vestedShares.toLocaleString()} shares`}
+                    />
+                  </div>
+                ))}
             </>
           ) : null}
         </div>

--- a/frontend/trpc/routes/equityGrants.ts
+++ b/frontend/trpc/routes/equityGrants.ts
@@ -61,6 +61,16 @@ export const equityGrantsRouter = createRouter({
       with: {
         optionPool: { columns: { name: true, companyId: true } },
         companyInvestor: { with: { user: { columns: { countryCode: true, state: true, email: true } } } },
+        vestingEvents: {
+          columns: {
+            id: true,
+            vestingDate: true,
+            vestedShares: true,
+            processedAt: true,
+            cancelledAt: true,
+          },
+          orderBy: (vestingEvents, { asc }) => [asc(vestingEvents.vestingDate)],
+        },
       },
     });
 


### PR DESCRIPTION
Fixes: https://github.com/antiwork/flexile/issues/775

Open up Details modal

![Screenshot 2025-08-07 at 12 34 32 AM](https://github.com/user-attachments/assets/9238a373-bfcf-45a8-a8bd-9cbd4df3666b)

Attaching screenshots of E2E tests passing locally

![Screenshot 2025-08-07 at 12 20 38 AM](https://github.com/user-attachments/assets/c1fceace-401c-4acc-ae87-e55acaae593d)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Added a "Vesting events" section in the equity grant details modal, displaying detailed vesting event information for applicable grants.
  * Vesting events are now shown with their date and number of vested shares; status indicators are omitted.
  * For grants with invoice-based vesting, the vesting events section is hidden.

* **Tests**
  * Introduced comprehensive end-to-end tests to verify the correct display and behavior of vesting events in equity grant details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->