### PR TITLE
Update Docker configuration to use nginx instead of OpenResty

### DIFF
--- a/docker/docker-compose-local-linux.yml
+++ b/docker/docker-compose-local-linux.yml
@@ -21,16 +21,13 @@ services:
       - ./tmp/redis:/data
 
   nginx:
-    image: openresty/openresty:alpine-fat
+    image: nginx:alpine
     network_mode: host
     volumes:
       - ./flexile_dev.conf:/etc/nginx/conf.d/default.conf
       - ../certificates:/etc/ssl/certs/
     extra_hosts:
       - "host.docker.internal:127.0.0.1"
-    command: >
-      sh -c "/usr/local/openresty/luajit/bin/luarocks install lua-resty-http &&
-            openresty -g 'daemon off;'"
 
 volumes:
   flexilepgdata:

--- a/docker/docker-compose-local-linux.yml
+++ b/docker/docker-compose-local-linux.yml
@@ -21,7 +21,7 @@ services:
       - ./tmp/redis:/data
 
   nginx:
-    image: nginx:alpine
+    image: nginx:1.29-alpine
     network_mode: host
     volumes:
       - ./flexile_dev.conf:/etc/nginx/conf.d/default.conf

--- a/docker/docker-compose-local.yml
+++ b/docker/docker-compose-local.yml
@@ -21,7 +21,7 @@ services:
       - ./tmp/redis:/data
 
   nginx:
-    image: openresty/openresty:alpine-fat
+    image: nginx:alpine
     volumes:
       - ./flexile_dev.conf:/etc/nginx/conf.d/default.conf
       - ../certificates:/etc/ssl/certs/
@@ -30,9 +30,6 @@ services:
       - 443:443
     extra_hosts:
       - "host.docker.internal:host-gateway"
-    command: >
-      sh -c "/usr/local/openresty/luajit/bin/luarocks install lua-resty-http &&
-            openresty -g 'daemon off;'"
 
 volumes:
   flexilepgdata:

--- a/docker/docker-compose-local.yml
+++ b/docker/docker-compose-local.yml
@@ -21,7 +21,7 @@ services:
       - ./tmp/redis:/data
 
   nginx:
-    image: nginx:alpine
+    image: nginx:1.29-alpine
     volumes:
       - ./flexile_dev.conf:/etc/nginx/conf.d/default.conf
       - ../certificates:/etc/ssl/certs/


### PR DESCRIPTION
Replaced the OpenResty image with the nginx:alpine image in both local Docker Compose files. Removed the command for installing LuaRocks and running OpenResty, simplifying the setup for local development.

Thanks to @sharang-d for the ping about the issue with luarocks.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Docker Compose configuration to use the standard nginx image instead of OpenResty for local development environments.
  * Simplified the nginx service startup by removing custom commands and package installations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->