### PR TITLE
fix: invite link flow for unauthenticated user test

### DIFF
--- a/e2e/tests/company/contractor/contractor-invite-link.spec.ts
+++ b/e2e/tests/company/contractor/contractor-invite-link.spec.ts
@@ -62,8 +62,7 @@ test.describe("Contractor Invite Link Joining flow", () => {
     await page.getByRole("button", { name: "Sign up" }).click();
 
     // Wait for OTP step and enter verification code
-    await page.locator('[data-slot="input-otp"]').fill("000000"); // Test OTP code
-    await page.getByRole("button", { name: "Continue" }).click();
+    await page.locator('[data-input-otp="true"]').fill("000000"); // Test OTP code
 
     await expect(page).toHaveURL(/documents/iu);
 


### PR DESCRIPTION
After:-
Screenshot of e2e test passing locally
![Screenshot 2025-08-09 at 7 54 03 PM](https://github.com/user-attachments/assets/b19ceb23-6ce5-4a7d-a206-f67d2263eba5)


Before:-

![Screenshot 2025-08-09 at 7 53 00 PM](https://github.com/user-attachments/assets/cbbf8286-c602-4b58-836f-9f0423dbecca)
