### PR TITLE
fix: login with redirect_uri test

### DIFF
--- a/e2e/tests/login.spec.ts
+++ b/e2e/tests/login.spec.ts
@@ -46,10 +46,9 @@ test("login with redirect_url", async ({ page }) => {
   // Fill the OTP code using the InputOTP component's hidden input
   // The form should auto-submit when all 6 digits are entered
   const otpCode = "000000";
-  await page.locator('[data-slot="input-otp"]').fill(otpCode);
+  await page.locator('[data-input-otp="true"]').fill(otpCode);
 
-  // No need to click the button as it should auto-submit
-  await page.waitForLoadState("networkidle");
+  await page.waitForURL(/.*\/people.*/u);
 
   await expect(page.getByRole("heading", { name: "People" })).toBeVisible();
 


### PR DESCRIPTION
Before:- Test failing on latest main branch CI

![Screenshot 2025-08-09 at 7 53 00 PM](https://github.com/user-attachments/assets/c568ea98-fab4-4578-840a-8e5d69446035)


After:-
login with redirect_url test passing locally

![Screenshot 2025-08-09 at 8 04 29 PM](https://github.com/user-attachments/assets/4a7e37ad-bc28-43df-90c8-addb340f0287)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated the login test to use a new selector for the OTP input field.
  * Improved test reliability by waiting for navigation to the correct page after OTP submission.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->