### PR TITLE
feat: add floating action button for support and documents page

### DIFF
--- a/frontend/app/(dashboard)/support/ConversationsList.tsx
+++ b/frontend/app/(dashboard)/support/ConversationsList.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useConversations, useCreateConversation } from "@helperai/react";
-import { CircleCheck, Paperclip, SendIcon, X } from "lucide-react";
+import { CircleCheck, Paperclip, Plus, SendIcon, X } from "lucide-react";
 import React, { useRef, useState } from "react";
 import { helperTools } from "@/app/(dashboard)/support/tools";
 import { DashboardHeader } from "@/components/DashboardHeader";
@@ -14,12 +14,14 @@ import { Input } from "@/components/ui/input";
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
 import { Textarea } from "@/components/ui/textarea";
 import { useCurrentCompany, useCurrentUser } from "@/global";
+import { useIsMobile } from "@/utils/use-mobile";
 
 interface ConversationsListProps {
   onSelectConversation: (slug: string) => void;
 }
 
 export const ConversationsList = ({ onSelectConversation }: ConversationsListProps) => {
+  const isMobile = useIsMobile();
   const { data: conversationsData, isLoading: loading, refetch } = useConversations();
   const [isModalOpen, setIsModalOpen] = useState(false);
   const [subject, setSubject] = useState("");
@@ -67,14 +69,24 @@ export const ConversationsList = ({ onSelectConversation }: ConversationsListPro
     setAttachments((prev) => prev.filter((_, i) => i !== index));
   };
 
+  const handleContactSupportClick = () => {
+    setIsModalOpen(true);
+  };
+
   return (
     <>
       <DashboardHeader
         title="Support center"
         headerActions={
-          <Button onClick={() => setIsModalOpen(true)} size="small">
-            Contact support
-          </Button>
+          isMobile ? (
+            <Button variant="floating-action" onClick={handleContactSupportClick}>
+              <Plus />
+            </Button>
+          ) : (
+            <Button onClick={handleContactSupportClick} size="small">
+              Contact support
+            </Button>
+          )
         }
       />
 


### PR DESCRIPTION
**--In Progress--**

Description:

- Support Page
   Add FAB for support page

- Documents Page
  Update FAB flow to include below scenarios 
  - If only one action button is visible from Edit templates and Invite lawyer : Trigger respective action on FAB click
  - If both Edit templates and Invite lawyer buttons are visible: Trigger dialog showing both action button on FAB click
  

Part of 449

Before / After : Support

<img width="300" height="537" alt="Screenshot 2025-08-09 at 9 46 13 AM" src="https://github.com/user-attachments/assets/399b7f77-c7e4-4be1-8927-a78c10b45067" />
<img width="300" height="537" alt="Screenshot 2025-08-09 at 9 46 58 AM" src="https://github.com/user-attachments/assets/f6a3be69-0ab0-4cf2-a80d-55c3093fe306" />

--

Test Suite:

 1 failing test is not related to changes and is failing on main branch also.

<img width="1575" height="146" alt="Screenshot 2025-08-09 at 11 02 57 PM" src="https://github.com/user-attachments/assets/b94baec9-16ec-4150-90da-d21c8555b292" />


