### PR TITLE
Improve development setup with better SSL handling and Resend API documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,18 @@ pnpm playwright test
    WISE_PROFILE_ID=your_membership_number_here
    WISE_API_KEY=your_full_api_token_here
    ```
+   </details>
+
+<details> 
+<summary>Resend</summary>
+1. Create account at [resend.com](https://resend.com) and complete email verification
+2. Navigate to **API Keys** in the dashboard
+3. Click **Create API Key**, give it a name (e.g., "Flexile Development")
+4. Copy the API key immediately (starts with re_)
+5. Add to `.env`:
+   ```
+   RESEND_API_KEY=re_your_api_key_here
+   ```
 
 **Note**: Keep credentials secure and never commit to version control.
 

--- a/bin/dev
+++ b/bin/dev
@@ -6,42 +6,68 @@ if [ -f ".vercel/project.json" ]; then
     pnpx vercel env pull .env
 elif [ ! -f ".env" ]; then
     echo ".env file not found. Please run bin/setup first."
+    exit 1
 fi
 
+# Install Node.js dependencies first (before generating certificates)
+echo "Installing Node.js dependencies..."
+pnpm install
 
 # Generate SSL certificates and start local services
+echo "Starting Docker services..."
 make local
 
-export NODE_EXTRA_CA_CERTS="$(node docker/createCertificate.js)"
+# Generate SSL certificates
+echo "Generating SSL certificates..."
+mkdir -p certificates
+NODE_EXTRA_CA_CERTS_FILE="$(node docker/createCertificate.js)"
 
 # Generate combined SSL certificates and set environment variables
 mkdir -p tmp
 default_cert_file=$(ruby -ropenssl -e 'puts OpenSSL::X509::DEFAULT_CERT_FILE')
 combined_cert_file="tmp/combined_ca_certs.pem"
 
-if [ -f "$default_cert_file" ] && [ -f "$NODE_EXTRA_CA_CERTS" ]; then
-  cat "$default_cert_file" "$NODE_EXTRA_CA_CERTS" > "$combined_cert_file"
+if [ -f "$default_cert_file" ] && [ -f "$NODE_EXTRA_CA_CERTS_FILE" ]; then
+  cat "$default_cert_file" "$NODE_EXTRA_CA_CERTS_FILE" > "$combined_cert_file"
   echo "Combined certificates created at $combined_cert_file"
-  export SSL_CERT_FILE="$combined_cert_file"
+  export SSL_CERT_FILE="$(pwd)/$combined_cert_file"
+  export NODE_EXTRA_CA_CERTS="$(pwd)/$combined_cert_file"
 else
   echo "Warning: Could not create combined cert file. Using default certificates."
 fi
 
-# Install dependencies and prepare database
-pnpm install
+# Prepare backend dependencies and database
+echo "Installing backend dependencies..."
 cd backend
+
 bundle install
-bin/rails db:prepare
+
+# Check if database exists and has seed data
+if bin/rails runner "DocumentTemplate.first" 2>/dev/null; then
+  echo "Database already seeded, skipping db:prepare"
+else
+  echo "Preparing database and seeding..."
+  # Use environment variables to handle SSL for this session only
+  SSL_CERT_FILE="$(pwd)/../$combined_cert_file" bin/rails db:prepare
+fi
+
 cd ..
 
 function kill_process_listening_on_port {
-  lsof -i :$1 | grep LISTEN | awk '{print $2}' | xargs -r kill -9
+  lsof -i :$1 2>/dev/null | grep LISTEN | awk '{print $2}' | xargs -r kill -9 2>/dev/null || true
 }
 
-echo "Starting application services"
+echo "Cleaning up existing processes..."
 kill_process_listening_on_port 3000
 kill_process_listening_on_port 3001
 kill_process_listening_on_port 8288 # inngest
 rm -f backend/tmp/pids/server.pid
 
+# Create necessary directories
+mkdir -p docker/tmp/postgres
+mkdir -p docker/tmp/redis
+
+echo "Starting application services..."
+# Export SSL environment variables for the foreman processes
+export SSL_CERT_FILE NODE_EXTRA_CA_CERTS
 foreman start -f Procfile.dev "$@"


### PR DESCRIPTION
Improve development setup with better SSL handling and Resend API documentation

- Fix SSL certificate handling in bin/dev to use environment variables 
- Add proper error handling and logging throughout bin/dev script
- Fix dependency installation order (pnpm install before certificate generation)
- Add smart database seeding check to skip if already seeded
- Improve process cleanup and directory creation
- Add comprehensive Resend API Key documentation to README