### PR TITLE
Add comprehensive Resend API documentation to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,18 @@ pnpm playwright test
    WISE_PROFILE_ID=your_membership_number_here
    WISE_API_KEY=your_full_api_token_here
    ```
+   </details>
+
+<details> 
+<summary>Resend</summary>
+1. Create account at [resend.com](https://resend.com) and complete email verification
+2. Navigate to **API Keys** in the dashboard
+3. Click **Create API Key**, give it a name (e.g., "Flexile Development")
+4. Copy the API key immediately (starts with re_)
+5. Add to `.env`:
+   ```
+   RESEND_API_KEY=re_your_api_key_here
+   ```
 
 **Note**: Keep credentials secure and never commit to version control.
 


### PR DESCRIPTION
Purpose - If we dont include the Resend API, the dev setup shows errors.

- Add detailed setup instructions for Resend service
- Include step-by-step configuration guide
- Document environment variable usage for RESEND_API_KEY