### PR TITLE
fix: remove skeleton loader for video in company updates

### DIFF
--- a/frontend/app/(dashboard)/updates/company/ViewUpdateDialog.tsx
+++ b/frontend/app/(dashboard)/updates/company/ViewUpdateDialog.tsx
@@ -31,10 +31,10 @@ function ViewUpdateDialog({ updateId, onOpenChange }: { updateId: string; onOpen
             )}
           </DialogTitle>
         </DialogHeader>
-        <div className="flex flex-col gap-5">
+        <div className="flex flex-col gap-8">
           {isLoading ? (
             <>
-              <SkeletonList>
+              <SkeletonList count={4}>
                 <div className="flex flex-col gap-5">
                   <Skeleton className="h-6 max-w-60" />
                   <div className="flex flex-col gap-2">
@@ -44,7 +44,6 @@ function ViewUpdateDialog({ updateId, onOpenChange }: { updateId: string; onOpen
                   </div>
                 </div>
               </SkeletonList>
-              <Skeleton className="aspect-video" />
               <Skeleton className="h-4 max-w-40" />
             </>
           ) : isError ? (


### PR DESCRIPTION
Description:

Remove skeleton loader for video in company updates as video url has been removed in #806 

- Before:

   <img width="1017" height="955" alt="Screenshot 2025-08-13 at 12 32 51 AM" src="https://github.com/user-attachments/assets/a5bcbc42-903c-47bb-b322-ab93f78187db" />


- After:

   <img width="909" height="825" alt="Screenshot 2025-08-13 at 12 21 20 AM" src="https://github.com/user-attachments/assets/4ade00ba-3f93-44ba-a8e4-3cdb9dd32667" />


Test Suite:

Doesn't impact any test. 
