### PR TITLE
Add note about default OTP for development in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,8 @@ You can start the local app using the [`bin/dev` script](bin/dev) - or feel free
 
 Once the local services are up and running, the application will be available at `https://flexile.dev`
 
+**Development shortcut**: If `ENABLE_DEFAULT_OTP=true` is set in your `.env`, you can use `000000` as the OTP for logging in or signing up.
+
 Check [the seeds](backend/config/data/seed_templates/gumroad.json) for default data created during setup.
 
 ## Common Issues / Debugging


### PR DESCRIPTION
Updated README to include a note about using the default OTP (000000) when ENABLE_DEFAULT_OTP=true is set in the .env.

Helps developers quickly log in or sign up during local development without needing a real OTP.

Placed the note under the existing credentials security section for visibility.