### PR TITLE
fix: hide floating action for non worker user in invoices page

### DIFF
--- a/frontend/app/(dashboard)/invoices/page.tsx
+++ b/frontend/app/(dashboard)/invoices/page.tsx
@@ -395,7 +395,7 @@ export default function InvoicesPage() {
 
   return (
     <>
-      {isMobile ? (
+      {isMobile && user.roles.worker ? (
         <Button variant="floating-action" {...(!canSubmitInvoices ? { disabled: true } : { asChild: true })}>
           <Link href="/invoices/new" inert={!canSubmitInvoices}>
             <Plus />


### PR DESCRIPTION
Description:

FAB which is for adding new invoice shows for non worker user in invoice page.

Cause: This bug is introduced due to latest changes made in #872 for table design.

Part of #449 

- Before and After:

   <img width="300" height="657" alt="Screenshot 2025-08-13 at 6 35 15 PM" src="https://github.com/user-attachments/assets/02961796-d7e1-4dce-bb2f-08d041274aed" />
  <img width="300" height="657" alt="Screenshot 2025-08-13 at 6 36 13 PM" src="https://github.com/user-attachments/assets/ad27a0cb-1651-4a60-9ec6-a3086823b085" />

Test Suite:

Change doesn't impact any test as no test added / updated in 872 changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * On mobile, the “New invoice” floating action button now appears only for users with the worker role. Previously, it could display for any mobile user. This update ensures the button is visible solely to authorized users on smaller screens, aligning visibility with role-based permissions while leaving other button behavior unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->