### PR TITLE
fix: empty account options after connecting quickbook

### DIFF
--- a/frontend/trpc/routes/quickbooks.ts
+++ b/frontend/trpc/routes/quickbooks.ts
@@ -43,7 +43,8 @@ export const quickbooksRouter = createRouter({
       expenseAccounts: [],
       bankAccounts: [],
     };
-    if (integration.status !== "active") return data;
+
+    if (!["active", "initialized"].includes(integration.status)) return data;
 
     const qbo = getQuickbooksClient(integration);
     const [expenseAccounts, bankAccounts] = await Promise.all([


### PR DESCRIPTION
Issue:- I tried connecting quickbooks online locally and after connecting i could select any option because it was empty because of a bug on the backend.

Just after connecting integration is in initialized state but on the backend we were only returning options when integration is active.