### PR TITLE
fix(invoices): Preserve equity split and block premature approval

### DIFF
--- a/backend/app/services/approve_invoice.rb
+++ b/backend/app/services/approve_invoice.rb
@@ -24,6 +24,8 @@ class ApproveInvoice
     attr_reader :invoice, :approver
 
     def can_approve?
-      !invoice.status.in?(INVOICE_STATUSES_THAT_DENY_APPROVAL)
+      return false if invoice.status.in?(INVOICE_STATUSES_THAT_DENY_APPROVAL)
+      return false if invoice.equity_percentage.positive? && invoice.equity_amount_in_options.zero?
+      true
     end
 end

--- a/backend/app/services/invoice_equity_calculator.rb
+++ b/backend/app/services/invoice_equity_calculator.rb
@@ -24,10 +24,12 @@ class InvoiceEquityCalculator
       else
         (equity_amount_in_cents / (share_price_usd * 100.to_d)).round
       end
-    if equity_amount_in_options <= 0 || !unvested_grant.present? || unvested_grant.unvested_shares < equity_amount_in_options
-      equity_percentage = 0
-      equity_amount_in_cents = 0
-      equity_amount_in_options = 0
+
+    if equity_percentage.nonzero?
+      if !unvested_grant.present? || equity_amount_in_options <= 0 || unvested_grant.unvested_shares < equity_amount_in_options
+        equity_amount_in_cents = 0
+        equity_amount_in_options = 0
+      end
     end
 
     {

--- a/backend/spec/services/create_or_update_invoice_service_spec.rb
+++ b/backend/spec/services/create_or_update_invoice_service_spec.rb
@@ -128,7 +128,7 @@ RSpec.describe CreateOrUpdateInvoiceService do
         end.to change { user.invoices.count }.by(1)
       end
 
-      it "does not apply an equity split if the equity portion makes up less than one share" do
+      it "preserves the equity split selection but sets equity amounts to zero if the equity portion makes up less than one share" do
         contractor.update!(equity_percentage: 1)
         equity_grant.update!(share_price_usd: 20)
 
@@ -139,7 +139,7 @@ RSpec.describe CreateOrUpdateInvoiceService do
 
           expect(invoice.total_amount_in_usd_cents).to eq(expected_total_amount_in_cents)
           expect(invoice.equity_amount_in_options).to eq(0)
-          expect(invoice.equity_percentage).to eq(0)
+          expect(invoice.equity_percentage).to eq(1)
           expect(invoice.equity_amount_in_cents).to eq(0)
           expect(invoice.cash_amount_in_cents).to eq(expected_total_amount_in_cents)
           expect(invoice.flexile_fee_cents).to eq(50 + (1.5 * expected_total_amount_in_cents / 100).round)


### PR DESCRIPTION
I have implemented a two-part solution to ensure the contractor's equity split selection is never lost and that invoices are not approved until the necessary grant is in 

#### 1. Preserve Equity Split (`InvoiceEquityCalculator.rb`)

- The calculator is modified to always **preserve the `equity_percentage`** that the contractor selected.
- If a valid grant is not found or has insufficient shares:
  - `equity_amount_in_options` and `equity_amount_in_cents` are set to `0`
  - **However**, the `equity_percentage` is still saved correctly on the invoice.

#### 2. Block Premature Approval (`ApproveInvoice.rb`)

- Added a new validation check in the `can_approve?` method.
- Prevents an invoice from being approved if:
  - `equity_percentage` > 0 **and**
  - `equity_amount_in_options` = 0
- This creates a soft lock, ensuring an admin must first create the grant before the invoice can proceed to payment.

Specs tested locally:
<img width="1854" height="1048" alt="image" src="https://github.com/user-attachments/assets/10752572-8a9c-4d63-9da6-23db85780f7b" />

