### PR TITLE
Fix #882: Prevent equity splits from being wiped during invoice submission

### DIFF
--- a/backend/app/services/approve_invoice.rb
+++ b/backend/app/services/approve_invoice.rb
@@ -12,6 +12,12 @@ class ApproveInvoice
     invoice.with_lock do
       return unless can_approve?
 
+      # Check if equity grant is required before allowing approval
+      if requires_equity_grant?
+        invoice.errors.add(:base, "Admin must create an equity grant before this invoice can be approved")
+        raise ActiveRecord::RecordInvalid.new(invoice)
+      end
+
       invoice.reload.invoice_approvals.find_or_create_by!(approver:)
       invoice.update!(status: Invoice::APPROVED)
       return unless invoice.company.active? && invoice.fully_approved?
@@ -25,5 +31,21 @@ class ApproveInvoice
 
     def can_approve?
       !invoice.status.in?(INVOICE_STATUSES_THAT_DENY_APPROVAL)
+    end
+
+    def requires_equity_grant?
+      return false unless invoice.company.equity_enabled?
+      return false if invoice.company_worker.equity_percentage.zero?
+
+      # Check if equity calculation would fail due to missing/insufficient grants
+      services_in_cents = invoice.total_amount_in_usd_cents - (invoice.invoice_expenses.sum(&:total_amount_in_cents) || 0)
+      equity_calculation_result = InvoiceEquityCalculator.new(
+        company_worker: invoice.company_worker,
+        company: invoice.company,
+        service_amount_cents: services_in_cents,
+        invoice_year: invoice.invoice_date.year,
+      ).calculate
+
+      equity_calculation_result.nil?
     end
 end

--- a/backend/app/services/create_or_update_invoice_service.rb
+++ b/backend/app/services/create_or_update_invoice_service.rb
@@ -67,7 +67,11 @@ class CreateOrUpdateInvoiceService
         invoice_year:,
       ).calculate
       if equity_calculation_result.nil?
-        error = "Something went wrong. Please contact the company administrator."
+        if contractor.equity_percentage.nonzero?
+          error = "Admin must create an equity grant before this invoice can be submitted with equity allocation."
+        else
+          error = "Something went wrong. Please contact the company administrator."
+        end
         raise ActiveRecord::Rollback
       end
 

--- a/backend/app/services/invoice_equity_calculator.rb
+++ b/backend/app/services/invoice_equity_calculator.rb
@@ -24,7 +24,12 @@ class InvoiceEquityCalculator
       else
         (equity_amount_in_cents / (share_price_usd * 100.to_d)).round
       end
-    if equity_amount_in_options <= 0 || !unvested_grant.present? || unvested_grant.unvested_shares < equity_amount_in_options
+    # Don't wipe equity splits - return nil to indicate grant creation required
+    if equity_percentage.nonzero? && (!unvested_grant.present? || (equity_amount_in_options > 0 && unvested_grant.unvested_shares < equity_amount_in_options))
+      return
+    end
+    # Only set to zero if there's actually no equity intended
+    if equity_amount_in_options <= 0
       equity_percentage = 0
       equity_amount_in_cents = 0
       equity_amount_in_options = 0

--- a/backend/spec/services/approve_invoice_equity_grant_spec.rb
+++ b/backend/spec/services/approve_invoice_equity_grant_spec.rb
@@ -1,0 +1,133 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe ApproveInvoice do
+  let(:company) { create(:company, equity_enabled: true, fmv_per_share_in_usd: 1.0, conversion_share_price_usd: 1.0) }
+  let(:company_worker) { create(:company_worker, company:, equity_percentage: 50) }
+  let(:invoice) { create(:invoice, company:, company_worker:, user: company_worker.user) }
+  let(:approver) { create(:company_administrator, company:).user }
+  let(:service) { described_class.new(invoice:, approver:) }
+
+  before do
+    # Ensure there's a company administrator for grant creation
+    create(:company_administrator, company:)
+  end
+
+  describe "#perform" do
+    context "when equity is enabled and contractor has equity percentage" do
+      context "and no equity grant exists" do
+        it "raises error requiring admin to create grant" do
+          expect do
+            service.perform
+          end.to raise_error(ActiveRecord::RecordInvalid, /Admin must create an equity grant/)
+
+          expect(invoice.reload.status).to eq(Invoice::RECEIVED)
+          expect(invoice.invoice_approvals_count).to eq(0)
+        end
+      end
+
+      context "and equity grant has insufficient shares" do
+        before do
+          company_worker.user.company_investors.create!(company:, investment_amount_in_cents: 0)
+          option_pool = create(:option_pool, company:)
+
+          # Create grant with insufficient shares
+          GrantStockOptions.new(
+            company_worker,
+            option_pool:,
+            board_approval_date: Date.current,
+            vesting_commencement_date: Date.current,
+            number_of_shares: 10,
+            issue_date_relationship: "consultant",
+            option_grant_type: "nso",
+            option_expiry_months: 120,
+            vesting_trigger: "invoice_paid",
+            vesting_schedule_params: nil,
+            voluntary_termination_exercise_months: 12,
+            involuntary_termination_exercise_months: 3,
+            termination_with_cause_exercise_months: 0,
+            death_exercise_months: 12,
+            disability_exercise_months: 12,
+            retirement_exercise_months: 12
+          ).process
+        end
+
+        it "raises error requiring admin to create sufficient grant" do
+          expect do
+            service.perform
+          end.to raise_error(ActiveRecord::RecordInvalid, /Admin must create an equity grant/)
+
+          expect(invoice.reload.status).to eq(Invoice::RECEIVED)
+          expect(invoice.invoice_approvals_count).to eq(0)
+        end
+      end
+
+      context "and sufficient equity grant exists" do
+        before do
+          # Create a grant with sufficient shares
+          company_worker.user.company_investors.create!(company:, investment_amount_in_cents: 0)
+          option_pool = create(:option_pool, company:, authorized_shares: 20_000, issued_shares: 0)
+
+          GrantStockOptions.new(
+            company_worker,
+            option_pool:,
+            board_approval_date: Date.current,
+            vesting_commencement_date: Date.current,
+            number_of_shares: 10000, # Large number to ensure it's sufficient
+            issue_date_relationship: "consultant",
+            option_grant_type: "nso",
+            option_expiry_months: 120,
+            vesting_trigger: "invoice_paid",
+            vesting_schedule_params: nil,
+            voluntary_termination_exercise_months: 12,
+            involuntary_termination_exercise_months: 3,
+            termination_with_cause_exercise_months: 0,
+            death_exercise_months: 12,
+            disability_exercise_months: 12,
+            retirement_exercise_months: 12
+          ).process
+        end
+
+        it "successfully approves the invoice" do
+          expect do
+            service.perform
+          end.not_to raise_error
+
+          expect(invoice.reload.status).to eq(Invoice::APPROVED)
+          expect(invoice.invoice_approvals_count).to eq(1)
+        end
+      end
+    end
+
+    context "when contractor has zero equity percentage" do
+      before do
+        company_worker.update!(equity_percentage: 0)
+      end
+
+      it "approves invoice without requiring equity grant" do
+        expect do
+          service.perform
+        end.not_to raise_error
+
+        expect(invoice.reload.status).to eq(Invoice::APPROVED)
+        expect(invoice.invoice_approvals_count).to eq(1)
+      end
+    end
+
+    context "when equity is disabled" do
+      before do
+        company.update!(equity_enabled: false)
+      end
+
+      it "approves invoice without requiring equity grant" do
+        expect do
+          service.perform
+        end.not_to raise_error
+
+        expect(invoice.reload.status).to eq(Invoice::APPROVED)
+        expect(invoice.invoice_approvals_count).to eq(1)
+      end
+    end
+  end
+end

--- a/backend/spec/services/create_or_update_invoice_service_spec.rb
+++ b/backend/spec/services/create_or_update_invoice_service_spec.rb
@@ -156,7 +156,7 @@ RSpec.describe CreateOrUpdateInvoiceService do
         expect do
           result = invoice_service.process
           expect(result[:success]).to eq(false)
-          expect(result[:error_message]).to eq("Something went wrong. Please contact the company administrator.")
+          expect(result[:error_message]).to eq("Admin must create an equity grant before this invoice can be submitted with equity allocation.")
         end.to_not change(user.invoices, :count)
       end
 

--- a/backend/spec/services/invoice_equity_calculator_spec.rb
+++ b/backend/spec/services/invoice_equity_calculator_spec.rb
@@ -30,13 +30,13 @@ RSpec.describe InvoiceEquityCalculator do
     context "and computed equity component is too low to make up a whole share" do
       let(:share_price_usd) { 14.90 }
 
-      it "returns zero for all equity values" do
+      it "returns zero for all equity values when calculation results in zero shares" do
         company_worker.update!(equity_percentage: 1)
         result = calculator.calculate
 
         # Equity portion = $720 * 1% = $7.20
         # Shares = $7.20 / $14.9 = 0.4832214765100671 = 0 (rounded)
-        # Don't allocate any portion to equity as the number of shares comes to 0
+        # Since this results in 0 shares (not insufficient grant), set equity to zero
         expect(result[:equity_cents]).to eq(0)
         expect(result[:equity_options]).to eq(0)
         expect(result[:equity_percentage]).to eq(0)
@@ -53,14 +53,25 @@ RSpec.describe InvoiceEquityCalculator do
       end
     end
 
+    context "and computed equity component exceeds available unvested shares" do
+      before do
+        # Reduce unvested shares to just 1, moving them to vested (700 -> 1, 100 -> 799)
+        # Total remains 1000: 799 vested + 1 unvested + 200 exercised + 0 forfeited = 1000
+        equity_grant.update!(unvested_shares: 1, vested_shares: 799)
+      end
+
+      it "returns nil to indicate grant creation required" do
+        result = calculator.calculate
+        expect(result).to be_nil
+      end
+    end
+
     context "and an eligible unvested equity grant for the year is absent" do
       let(:invoice_year) { Date.current.year + 2 }
 
-      it "returns zero for all equity values" do
+      it "returns nil to indicate grant creation required" do
         result = calculator.calculate
-        expect(result[:equity_cents]).to eq(0)
-        expect(result[:equity_options]).to eq(0)
-        expect(result[:equity_percentage]).to eq(0)
+        expect(result).to be_nil
       end
 
       context "and the company does not have a share price" do
@@ -84,6 +95,91 @@ RSpec.describe InvoiceEquityCalculator do
       expect(result[:equity_cents]).to eq(0)
       expect(result[:equity_options]).to eq(0)
       expect(result[:equity_percentage]).to eq(0)
+    end
+  end
+
+  # Test for GitHub issue #882: Ensure equity splits are not wiped when submitted
+  context "when equity grants are missing or insufficient" do
+    context "when no equity grant exists" do
+      let(:company_worker_no_grant) { create(:company_worker, company:, equity_percentage: 50) }
+      let(:calculator_no_grant) do
+        described_class.new(
+          company_worker: company_worker_no_grant,
+          company: company,
+          service_amount_cents: service_amount_cents,
+          invoice_year: invoice_year
+        )
+      end
+
+      it "returns nil instead of wiping equity split" do
+        result = calculator_no_grant.calculate
+
+        expect(result).to be_nil
+        # Verify the equity percentage is preserved on the company_worker
+        expect(company_worker_no_grant.reload.equity_percentage).to eq(50)
+      end
+    end
+
+    context "when equity grant has insufficient shares" do
+      let(:company_worker_insufficient) { create(:company_worker, company:, equity_percentage: 50) }
+      let(:option_pool) { create(:option_pool, company:) }
+      let!(:insufficient_grant) do
+        GrantStockOptions.new(
+          company_worker_insufficient,
+          option_pool:,
+          board_approval_date: Date.current,
+          vesting_commencement_date: Date.current,
+          number_of_shares: 1, # Insufficient for 50% equity
+          issue_date_relationship: "consultant",
+          option_grant_type: "nso",
+          option_expiry_months: 120,
+          vesting_trigger: "invoice_paid",
+          vesting_schedule_params: nil,
+          voluntary_termination_exercise_months: 12,
+          involuntary_termination_exercise_months: 3,
+          termination_with_cause_exercise_months: 0,
+          death_exercise_months: 12,
+          disability_exercise_months: 12,
+          retirement_exercise_months: 12
+        ).process
+      end
+      let(:calculator_insufficient) do
+        described_class.new(
+          company_worker: company_worker_insufficient,
+          company: company,
+          service_amount_cents: 100000, # Large amount to require more shares
+          invoice_year: invoice_year
+        )
+      end
+
+      it "returns nil instead of wiping equity split" do
+        result = calculator_insufficient.calculate
+
+        expect(result).to be_nil
+        # Verify the equity percentage is preserved on the company_worker
+        expect(company_worker_insufficient.reload.equity_percentage).to eq(50)
+      end
+    end
+
+    context "when contractor has zero equity percentage" do
+      let(:company_worker_zero) { create(:company_worker, company:, equity_percentage: 0) }
+      let(:calculator_zero) do
+        described_class.new(
+          company_worker: company_worker_zero,
+          company: company,
+          service_amount_cents: service_amount_cents,
+          invoice_year: invoice_year
+        )
+      end
+
+      it "returns valid result without requiring equity grant" do
+        result = calculator_zero.calculate
+
+        expect(result).not_to be_nil
+        expect(result[:equity_cents]).to eq(0)
+        expect(result[:equity_options]).to eq(0)
+        expect(result[:equity_percentage]).to eq(0)
+      end
     end
   end
 end

--- a/frontend/trpc/routes/invoices.ts
+++ b/frontend/trpc/routes/invoices.ts
@@ -147,9 +147,12 @@ export const invoicesRouter = createRouter({
       });
 
       if (!equityResult) {
+        const hasEquityPercentage = companyWorker.equityPercentage > 0;
         throw new TRPCError({
           code: "BAD_REQUEST",
-          message: "Recipient has insufficient unvested equity",
+          message: hasEquityPercentage
+            ? "Admin must create an equity grant before this invoice can be submitted with equity allocation"
+            : "Recipient has insufficient unvested equity",
         });
       }
 
@@ -265,9 +268,12 @@ export const invoicesRouter = createRouter({
       });
 
       if (!equityResult) {
+        const hasEquityPercentage = ctx.companyContractor.equityPercentage > 0;
         throw new TRPCError({
           code: "BAD_REQUEST",
-          message: "Error calculating equity. Please contact the administrator.",
+          message: hasEquityPercentage
+            ? "Admin must create an equity grant before this can be processed."
+            : "Error calculating equity. Please contact the administrator.",
         });
       }
 


### PR DESCRIPTION

- Modified InvoiceEquityCalculator to return nil instead of wiping equity splits when grants are missing/insufficient
- Enhanced ApproveInvoice service to validate equity grants before approval
- Updated CreateOrUpdateInvoiceService to provide specific error messages for equity grant issues
- Added comprehensive test coverage for equity splits preservation scenarios
- Fixed test expectations to match improved error messaging


Comprehensive testing (15/15 tests passing):

5 new tests in [approve_invoice_equity_grant_spec.rb] covering all equity grant validation scenarios

<img width="559" height="200" alt="Screenshot 2025-08-14 at 10 39 21 PM" src="https://github.com/user-attachments/assets/2463b2a2-725e-40a7-9771-9ede2d0ba794" />

10 existing tests in invoice_equity_calculator_spec.rb including 3 new tests for equity preservation
<img width="665" height="394" alt="Screenshot 2025-08-14 at 10 27 36 PM" src="https://github.com/user-attachments/assets/8abde5a6-1fa3-41ad-8da6-11c02ee2baaa" />


All tests verify the solution prevents equity splits from being wiped
<img width="504" height="91" alt="Screenshot 2025-08-14 at 10 27 17 PM" src="https://github.com/user-attachments/assets/63ae3676-b378-4c09-b0f3-9764941453ff" />
<img width="512" height="92" alt="Screenshot 2025-08-14 at 10 27 11 PM" src="https://github.com/user-attachments/assets/211b96de-addd-4d45-bd81-70ccdb9043e7" />

This ensures equity allocations are preserved when grants are missing, with clear guidance for admins to create appropriate grants.