### PR TITLE
Remove QuickBooks feature flag checks from backend and frontend

### DIFF
--- a/backend/app/models/company.rb
+++ b/backend/app/models/company.rb
@@ -174,10 +174,6 @@ class Company < ApplicationRecord
     is_trusted? ? 2 : 10 # estimated max number of business days for a contractor to receive payment after a consolidated invoice is charged
   end
 
-  def quickbooks_enabled?
-    Flipper.enabled?(:quickbooks, self)
-  end
-
   def expenses_enabled?
     Flipper.enabled?(:expenses, self)
   end

--- a/backend/app/presenters/user_presenter.rb
+++ b/backend/app/presenters/user_presenter.rb
@@ -90,7 +90,6 @@ class UserPresenter
         flags = []
         flags.push("equity") if company.equity_enabled?
         flags.push("company_updates") if company.company_investors.exists?
-        flags.push("quickbooks") if company.quickbooks_enabled?
         flags.push("expenses") if company.expenses_enabled?
         flags.push("option_exercising") if company.json_flag?("option_exercising")
         can_view_financial_data = user.company_administrator_for?(company) || user.company_investor_for?(company)

--- a/backend/config/data/seed_templates/gumroad.json
+++ b/backend/config/data/seed_templates/gumroad.json
@@ -34,7 +34,6 @@
         "equity_grants": true,
         "expenses": true,
         "dividends": true,
-        "quickbooks": true,
         "share_certificates": true
       },
       "convertible_investments": [

--- a/backend/spec/models/company_spec.rb
+++ b/backend/spec/models/company_spec.rb
@@ -538,19 +538,6 @@ RSpec.describe Company do
     end
   end
 
-  describe "#quickbooks_enabled?" do
-    let(:company) { create(:company) }
-
-    it "returns true if Quickbooks is enabled" do
-      Flipper.enable(:quickbooks, company)
-      expect(company.quickbooks_enabled?).to eq true
-    end
-
-    it "returns false if Quickbooks is not enabled" do
-      expect(company.quickbooks_enabled?).to eq false
-    end
-  end
-
   describe "#equity_enabled?" do
     let(:company) { build(:company) }
 

--- a/backend/spec/system/company/administrator/settings/main_spec.rb
+++ b/backend/spec/system/company/administrator/settings/main_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe "Company Settings" do
     expect(company.logo_url).to end_with "image.png"
   end
 
-  context "when quickbooks flag is enabled", :billy do
+  context "QuickBooks integration", :billy do
     let(:client_id) { GlobalConfig.get("QUICKBOOKS_CLIENT_ID") }
     let(:code) { "test_code" }
     let(:state) { Base64.strict_encode64("#{company.external_id}:#{company.name}") }
@@ -51,8 +51,6 @@ RSpec.describe "Company Settings" do
     let(:authentication_token) { Base64.strict_encode64("#{client_id}:#{GlobalConfig.get("QUICKBOOKS_CLIENT_SECRET")}") }
     let!(:travel_expense_category) { create(:expense_category, company:, name: "Travel") }
     let!(:meals_expense_category) { create(:expense_category, company:, name: "Meals") }
-
-    before { Flipper.enable(:quickbooks, company) }
 
     context "when no integration is set up" do
       before do

--- a/frontend/app/settings/administrator/page.tsx
+++ b/frontend/app/settings/administrator/page.tsx
@@ -181,14 +181,14 @@ export default function SettingsPage() {
         </form>
       </Form>
       <StripeMicrodepositVerification />
-      {company.flags.includes("quickbooks") ? (
-        <Card>
-          <CardHeader>
-            <CardTitle>Integrations</CardTitle>
-          </CardHeader>
-          <CardContent>{company.flags.includes("quickbooks") ? <QuickbooksIntegration /> : null}</CardContent>
-        </Card>
-      ) : null}
+      <Card>
+        <CardHeader>
+          <CardTitle>Integrations</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <QuickbooksIntegration />
+        </CardContent>
+      </Card>
     </div>
   );
 }


### PR DESCRIPTION
Always render QuickBooks integration card, removing conditional flag check
fixes #906 

<img width="1470" height="956" alt="Screenshot 2025-08-16 at 2 00 24 AM" src="https://github.com/user-attachments/assets/b45bbf1f-4ed6-43f1-bdee-d0a2117aac5e" />

<img width="1164" height="286" alt="image" src="https://github.com/user-attachments/assets/cad30735-39e3-44ec-817c-9745bb48c48f" />


All ruby tests passing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - The Integrations section in Administrator Settings is now always visible to administrators.
  - QuickBooks integration is now generally available and no longer gated by a feature flag.
  - Users will see the QuickBooks integration consistently across companies where applicable.
  - No changes to other integrations or permissions; existing functionality remains the same.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->