### PR TITLE
fix: use correct label for roles page

### DIFF
--- a/frontend/lib/settingsNavLinks.ts
+++ b/frontend/lib/settingsNavLinks.ts
@@ -33,8 +33,8 @@ export const settingsNavLinks = [
     category: "company",
   },
   {
-    label: "Workspace admins",
-    route: "/settings/administrator/admins" as const,
+    label: "Roles",
+    route: "/settings/administrator/roles" as const,
     icon: ShieldUser,
     isVisible: (user: CurrentUser) => !!user.roles.administrator,
     category: "company",


### PR DESCRIPTION
# Before
<img width="2940" height="1912" alt="image" src="https://github.com/user-attachments/assets/a8ecf578-169c-492e-835a-f49303efb1ba" />


# After

<img width="2940" height="1912" alt="image" src="https://github.com/user-attachments/assets/c963c5ac-ab47-4398-964d-2b0b7c8daa5e" />



@slavingia this was caused by https://github.com/antiwork/flexile/commit/67df17023f530ecac7d1a901c190c561532fbcb9
in https://github.com/antiwork/flexile/pull/870