### PR TITLE
Remove expenses feature flag and related checks

### DIFF
--- a/backend/app/models/company.rb
+++ b/backend/app/models/company.rb
@@ -174,10 +174,6 @@ class Company < ApplicationRecord
     is_trusted? ? 2 : 10 # estimated max number of business days for a contractor to receive payment after a consolidated invoice is charged
   end
 
-  def expenses_enabled?
-    Flipper.enabled?(:expenses, self)
-  end
-
   def find_company_worker!(user:)
     company_workers.find_by!(user:)
   end

--- a/backend/app/presenters/invoice_presenter.rb
+++ b/backend/app/presenters/invoice_presenter.rb
@@ -83,7 +83,7 @@ class InvoicePresenter
         is_trusted: company.is_trusted?,
         completed_payment_method_setup: company.bank_account_ready?,
         expenses: {
-          enabled: company.expenses_enabled?,
+          enabled: true,
           categories: company.expense_categories.map { |category| { id: category.id, name: category.name } }.sort_by { _1[:name] },
         },
       }

--- a/backend/app/presenters/invoice_presenter.rb
+++ b/backend/app/presenters/invoice_presenter.rb
@@ -82,10 +82,7 @@ class InvoicePresenter
         address: AddressPresenter.new(company).props,
         is_trusted: company.is_trusted?,
         completed_payment_method_setup: company.bank_account_ready?,
-        expenses: {
-          enabled: true,
-          categories: company.expense_categories.map { |category| { id: category.id, name: category.name } }.sort_by { _1[:name] },
-        },
+        expense_categories: company.expense_categories.map { |category| { id: category.id, name: category.name } }.sort_by { _1[:name] },
       }
     end
 

--- a/backend/app/presenters/user_presenter.rb
+++ b/backend/app/presenters/user_presenter.rb
@@ -90,7 +90,6 @@ class UserPresenter
         flags = []
         flags.push("equity") if company.equity_enabled?
         flags.push("company_updates") if company.company_investors.exists?
-        flags.push("expenses") if company.expenses_enabled?
         flags.push("option_exercising") if company.json_flag?("option_exercising")
         can_view_financial_data = user.company_administrator_for?(company) || user.company_investor_for?(company)
         {

--- a/backend/app/services/seed_data_generator_from_template.rb
+++ b/backend/app/services/seed_data_generator_from_template.rb
@@ -537,8 +537,6 @@ class SeedDataGeneratorFromTemplate
     end
 
     def create_expense_categories!(company, categories)
-      return unless company.expenses_enabled?
-
       categories.each do |category|
         company.expense_categories.create!(name: category["name"])
       end

--- a/backend/config/data/seed_templates/gumroad.json
+++ b/backend/config/data/seed_templates/gumroad.json
@@ -32,7 +32,6 @@
       "feature_flags": {
         "company_updates": true,
         "equity_grants": true,
-        "expenses": true,
         "dividends": true,
         "share_certificates": true
       },

--- a/frontend/app/(dashboard)/invoices/Edit.tsx
+++ b/frontend/app/(dashboard)/invoices/Edit.tsx
@@ -57,7 +57,7 @@ const dataSchema = z.object({
     id: z.string(),
     name: z.string(),
     address: addressSchema,
-    expenses: z.object({ categories: z.array(z.object({ id: z.number(), name: z.string() })) }),
+    expense_categories: z.array(z.object({ id: z.number(), name: z.string() })),
   }),
   invoice: z.object({
     id: z.string().optional(),
@@ -206,7 +206,7 @@ const Edit = () => {
   const createNewExpenseEntries = (e: React.ChangeEvent<HTMLInputElement>) => {
     const files = e.target.files;
     if (!files) return;
-    const expenseCategory = assertDefined(data.company.expenses.categories[0]);
+    const expenseCategory = assertDefined(data.company.expense_categories[0]);
     setShowExpenses(true);
     setExpenses((expenses) =>
       expenses.push(
@@ -395,7 +395,7 @@ const Edit = () => {
                       <PlusIcon className="inline size-4" />
                       Add line item
                     </Button>
-                    {data.company.expenses.categories.length && !showExpensesTable ? (
+                    {data.company.expense_categories.length && !showExpensesTable ? (
                       <Button variant="link" onClick={() => uploadExpenseRef.current?.click()}>
                         <ArrowUpTrayIcon className="inline size-4" />
                         Add expense
@@ -406,7 +406,7 @@ const Edit = () => {
               </TableRow>
             </TableFooter>
           </Table>
-          {data.company.expenses.categories.length ? (
+          {data.company.expense_categories.length ? (
             <input
               ref={uploadExpenseRef}
               type="file"
@@ -447,7 +447,7 @@ const Edit = () => {
                     <TableCell>
                       <ComboBox
                         value={expense.category_id.toString()}
-                        options={data.company.expenses.categories.map((category) => ({
+                        options={data.company.expense_categories.map((category) => ({
                           value: category.id.toString(),
                           label: category.name,
                         }))}

--- a/frontend/app/(dashboard)/invoices/Edit.tsx
+++ b/frontend/app/(dashboard)/invoices/Edit.tsx
@@ -57,7 +57,7 @@ const dataSchema = z.object({
     id: z.string(),
     name: z.string(),
     address: addressSchema,
-    expenses: z.object({ enabled: z.boolean(), categories: z.array(z.object({ id: z.number(), name: z.string() })) }),
+    expenses: z.object({ categories: z.array(z.object({ id: z.number(), name: z.string() })) }),
   }),
   invoice: z.object({
     id: z.string().optional(),


### PR DESCRIPTION
<img width="1470" height="956" alt="Screenshot 2025-08-16 at 11 58 19 AM" src="https://github.com/user-attachments/assets/f616c6d4-d2e6-4848-9426-e83a16734f0b" />
ref: #911 

<img width="1102" height="288" alt="image" src="https://github.com/user-attachments/assets/8e0ff89d-d54a-4d0e-8727-cf7ccdf43ee3" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Expenses are now always available across the app; the previous feature flag is removed.
  * Invoice editing relies only on expense categories; no “enabled” state is shown.

* **Chores**
  * Seed data and templates updated to always include expense categories by default.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->