### PR TITLE
Refactor InviteLawyer service to improve user invitation logic

### DIFF
--- a/backend/app/services/invite_lawyer.rb
+++ b/backend/app/services/invite_lawyer.rb
@@ -3,30 +3,35 @@
 class InviteLawyer
   def initialize(company:, email:, current_user:)
     @company = company
-    @email = email
+    @user = User.find_or_initialize_by(email: email)
     @current_user = current_user
   end
 
   def perform
-    user = User.find_or_initialize_by(email:)
-    return { success: false, field: "email", error_message: "Email has already been taken" } if user.persisted?
+    company_lawyer = @user.company_lawyers.find_or_initialize_by(company: @company)
+    return { success: false, field: "email", error_message: "User is already a lawyer for this company." } if company_lawyer.persisted?
 
-    company_lawyer = user.company_lawyers.find_or_initialize_by(company: company)
-    user.invite!(current_user) { |u| u.skip_invitation = true }
-
-    if user.errors.blank?
-      CompanyLawyerMailer.invitation_instructions(lawyer_id: company_lawyer.id, url: SIGNUP_URL).deliver_later
-      { success: true }
+    if @user.persisted?
+      @user.invited_by = @current_user
+      @user.save
+      company_lawyer.save
     else
-      error_object = if company_lawyer.errors.any?
-        company_lawyer
-      else
-        user
-      end
-      { success: false, field: error_object.errors.first.attribute, error_message: error_object.errors.first.full_message }
+      @user.invite!(@current_user) { |u| u.skip_invitation = true }
+      company_lawyer.save if @user.persisted?
     end
-  end
 
-  private
-    attr_reader :company, :email, :current_user
+    if @user.errors.blank? && company_lawyer.errors.blank?
+      CompanyLawyerMailer.invitation_instructions(lawyer_id: company_lawyer.id, url: SIGNUP_URL).deliver_later
+      return { success: true }
+    end
+
+    error_object = company_lawyer.errors.any? ? company_lawyer : @user
+    field = error_object.errors.attribute_names.first
+    message = if company_lawyer.errors.details[:user_id].any? { |e| e[:error] == :taken }
+      "User is already a lawyer for this company."
+    else
+      error_object.errors.full_messages.to_sentence
+    end
+    { success: false, field: field, error_message: message }
+  end
 end


### PR DESCRIPTION
<img width="2940" height="1912" alt="Screenshot 2025-08-16 at 12 43 48 PM" src="https://github.com/user-attachments/assets/36788c63-6348-4cc2-ba83-6e4183f05381" />

Before: Would reject any user who already existed in the database
After: Only rejects users who are already lawyers for the specific company

ref #911 