### PR TITLE
fix: correct label and route for Workspace Roles in settings navigation

### DIFF
--- a/frontend/lib/settingsNavLinks.ts
+++ b/frontend/lib/settingsNavLinks.ts
@@ -33,7 +33,7 @@ export const settingsNavLinks = [
     category: "company",
   },
   {
-    label: "Workspace Roles",
+    label: "Workspace roles",
     route: "/settings/administrator/roles" as const,
     icon: ShieldUser,
     isVisible: (user: CurrentUser) => !!user.roles.administrator,

--- a/frontend/lib/settingsNavLinks.ts
+++ b/frontend/lib/settingsNavLinks.ts
@@ -33,8 +33,8 @@ export const settingsNavLinks = [
     category: "company",
   },
   {
-    label: "Workspace admins",
-    route: "/settings/administrator/admins" as const,
+    label: "Workspace Roles",
+    route: "/settings/administrator/roles" as const,
     icon: ShieldUser,
     isVisible: (user: CurrentUser) => !!user.roles.administrator,
     category: "company",


### PR DESCRIPTION
Fixes #915 
- [x] Rename Workspace admins to Workspace roles
- [x] Fixes page not found for `/settings/administrator/admins`
- [x] Proper routing on click
<img width="1916" height="935" alt="image" src="https://github.com/user-attachments/assets/863e37cd-f168-4523-b2f3-0569279c7e5c" />

