### PR TITLE
feat: Update table design for company updates in mobile view

### DIFF
--- a/frontend/app/(dashboard)/updates/company/page.tsx
+++ b/frontend/app/(dashboard)/updates/company/page.tsx
@@ -211,10 +211,11 @@ const AdminList = ({ onEditUpdate }: { onEditUpdate: (update: UpdateListItem) =>
 };
 
 const ViewList = () => {
+  const isMobile = useIsMobile();
   const { updates } = useData();
   const [selectedUpdateId, setSelectedUpdateId] = useState<string | null>(null);
   const columnHelper = createColumnHelper<(typeof updates)[number]>();
-  const columns = useMemo(
+  const desktopColumns = useMemo(
     () => [
       columnHelper.simple("title", "Title"),
       columnHelper.accessor("summary", {
@@ -225,6 +226,40 @@ const ViewList = () => {
     ],
     [],
   );
+
+  const mobileColumns = useMemo(
+    () => [
+      columnHelper.display({
+        id: "titleSummary",
+        cell: (info) => {
+          const update = info.row.original;
+          return (
+            <div className="flex w-3xs flex-col gap-1 text-base">
+              <div className="truncate font-medium">{update.title}</div>
+              <div className="truncate leading-5 font-[350] text-gray-600">{update.summary}</div>
+            </div>
+          );
+        },
+        meta: {
+          cellClassName: "w-full",
+        },
+      }),
+      columnHelper.display({
+        id: "publishedOn",
+        cell: (info) => {
+          const update = info.row.original;
+          return (
+            <div className="flex h-full">
+              <div className="font-[350] text-gray-600">{update.sentAt ? formatDate(update.sentAt) : "-"}</div>
+            </div>
+          );
+        },
+      }),
+    ],
+    [],
+  );
+
+  const columns = isMobile ? mobileColumns : desktopColumns;
   const table = useTable({ columns, data: updates });
   const handleRowClick = (row: { id: string }) => setSelectedUpdateId(row.id);
 


### PR DESCRIPTION
Description:

Update mobile [table design](https://www.figma.com/design/L4SUjxa7JOfnhq9d0HCCAO/Mobile-navigation?node-id=610-1981&t=B6e4lcg2EFD3o5Mb-0) for company updates for non-admin users.

Part of #911 

Before / After

<table>
<tr><th>Before</th><th>After</th></tr>
<tr>
<td>
<img width="430" height="930" alt="updates_mobile_table_before" src="https://github.com/user-attachments/assets/d05048fb-5663-45fe-bffe-45311afe255a" />
</td/>
<td>
<img width="430" height="931" alt="updates_mobile_table_after" src="https://github.com/user-attachments/assets/3dc1579e-f693-46db-8147-71f0d7ef92eb" />
</td>
</tr>
</table>

Test Suite:

Failing test are not related to changes.

<img width="1778" height="147" alt="Screenshot 2025-08-16 at 4 13 48 PM" src="https://github.com/user-attachments/assets/4f0c27d5-c33f-4c21-8c37-a891ca8fc0cf" />



