### PR TITLE
Remove json_data column and option_exercising flag checks

### DIFF
--- a/backend/app/models/company.rb
+++ b/backend/app/models/company.rb
@@ -194,10 +194,6 @@ class Company < ApplicationRecord
     email.split("@").last
   end
 
-  def json_flag?(flag)
-    json_data&.dig("flags")&.include?(flag)
-  end
-
   def checklist_items(user)
     [
       user.company_administrator_for?(self) && ADMIN_CHECKLIST_ITEMS,

--- a/backend/app/policies/equity_grant_exercise_policy.rb
+++ b/backend/app/policies/equity_grant_exercise_policy.rb
@@ -2,21 +2,15 @@
 
 class EquityGrantExercisePolicy < ApplicationPolicy
   def create?
-    return false unless company.json_flag?("option_exercising")
-
     company_investor.present? && company_worker.present?
   end
 
   def resend?
-    return false unless company.json_flag?("option_exercising")
-
     company_investor.present? && company_worker.present? &&
       record.status == EquityGrantExercise::SIGNED
   end
 
   def process?
-    return false unless company.json_flag?("option_exercising")
-
     company_administrator.present?
   end
 end

--- a/backend/app/presenters/user_presenter.rb
+++ b/backend/app/presenters/user_presenter.rb
@@ -91,7 +91,6 @@ class UserPresenter
         flags.push("equity") if company.equity_enabled?
         flags.push("company_updates") if company.company_investors.exists?
         flags.push("expenses") if company.expenses_enabled?
-        flags.push("option_exercising") if company.json_flag?("option_exercising")
         can_view_financial_data = user.company_administrator_for?(company) || user.company_investor_for?(company)
         {
           **company_navigation_props(
@@ -165,7 +164,6 @@ class UserPresenter
       end
       if company_investor.present?
         result[:flags][:equity] ||= true if company.equity_enabled?
-        result[:flags][:option_exercising] = company.json_flag?("option_exercising")
       end
       result
     end

--- a/backend/db/migrate/20250816111712_remove_json_data_from_companies.rb
+++ b/backend/db/migrate/20250816111712_remove_json_data_from_companies.rb
@@ -1,0 +1,5 @@
+class RemoveJsonDataFromCompanies < ActiveRecord::Migration[8.0]
+  def change
+    remove_column :companies, :json_data, :jsonb
+  end
+end

--- a/backend/db/schema.rb
+++ b/backend/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_08_12_170245) do
+ActiveRecord::Schema[8.0].define(version: 2025_08_16_111712) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -103,7 +103,6 @@ ActiveRecord::Schema[8.0].define(version: 2025_08_12_170245) do
     t.boolean "show_analytics_to_contractors", default: false, null: false
     t.string "default_currency", default: "usd", null: false
     t.decimal "conversion_share_price_usd"
-    t.jsonb "json_data", default: {"flags" => []}, null: false
     t.boolean "equity_enabled", default: false, null: false
     t.string "invite_link"
     t.index ["external_id"], name: "index_companies_on_external_id", unique: true

--- a/e2e/tests/company/equity/grants.spec.ts
+++ b/e2e/tests/company/equity/grants.spec.ts
@@ -231,7 +231,6 @@ test.describe("Equity Grants", () => {
     const { company } = await companiesFactory.createCompletedOnboarding({
       equityEnabled: true,
       conversionSharePriceUsd: "1",
-      jsonData: { flags: ["option_exercising"] },
     });
     const { user } = await usersFactory.create();
     const { mockForm } = mockDocuseal(next, {});

--- a/frontend/app/(dashboard)/equity/grants/DetailsModal.tsx
+++ b/frontend/app/(dashboard)/equity/grants/DetailsModal.tsx
@@ -139,10 +139,7 @@ const DetailsModal = ({
             </>
           ) : null}
         </div>
-        {company.flags.includes("option_exercising") &&
-        equityGrant.vestedShares > 0 &&
-        isFuture(equityGrant.expiresAt) &&
-        canExercise ? (
+        {equityGrant.vestedShares > 0 && isFuture(equityGrant.expiresAt) && canExercise ? (
           <SheetFooter>
             <div className="grid gap-4">
               <Button onClick={onUpdateExercise}>Exercise options</Button>

--- a/frontend/app/(dashboard)/equity/options/page.tsx
+++ b/frontend/app/(dashboard)/equity/options/page.tsx
@@ -103,47 +103,43 @@ export default function OptionsPage() {
         </div>
       ) : (
         <>
-          {company.flags.includes("option_exercising") && (
-            <>
-              {totalUnexercisedVestedShares > 0 && !exerciseInProgress && (
-                <Alert className="mx-4 mb-4">
-                  <Info />
-                  <AlertDescription>
-                    <div className="flex items-center justify-between">
-                      <span className="font-bold">
-                        You have {totalUnexercisedVestedShares.toLocaleString()} vested options available for exercise.
-                      </span>
-                      <Button size="small" onClick={openExerciseModal}>
-                        Exercise Options
-                      </Button>
-                    </div>
-                  </AlertDescription>
-                </Alert>
-              )}
-
-              {exerciseInProgress ? (
-                <Alert className="mx-4 mb-4">
-                  <Info />
-                  <AlertDescription>
-                    <div className="flex items-center justify-between">
-                      <span className="font-bold">
-                        We're awaiting a payment of {formatMoneyFromCents(exerciseInProgress.totalCostCents)} to
-                        exercise {exerciseInProgress.numberOfOptions.toLocaleString()} options.
-                      </span>
-                      <MutationButton
-                        size="small"
-                        mutation={resendPaymentInstructions}
-                        param={exerciseInProgress.id}
-                        successText="Payment instructions sent!"
-                      >
-                        Resend payment instructions
-                      </MutationButton>
-                    </div>
-                  </AlertDescription>
-                </Alert>
-              ) : null}
-            </>
+          {totalUnexercisedVestedShares > 0 && !exerciseInProgress && (
+            <Alert className="mx-4 mb-4">
+              <Info />
+              <AlertDescription>
+                <div className="flex items-center justify-between">
+                  <span className="font-bold">
+                    You have {totalUnexercisedVestedShares.toLocaleString()} vested options available for exercise.
+                  </span>
+                  <Button size="small" onClick={openExerciseModal}>
+                    Exercise Options
+                  </Button>
+                </div>
+              </AlertDescription>
+            </Alert>
           )}
+
+          {exerciseInProgress ? (
+            <Alert className="mx-4 mb-4">
+              <Info />
+              <AlertDescription>
+                <div className="flex items-center justify-between">
+                  <span className="font-bold">
+                    We're awaiting a payment of {formatMoneyFromCents(exerciseInProgress.totalCostCents)} to exercise{" "}
+                    {exerciseInProgress.numberOfOptions.toLocaleString()} options.
+                  </span>
+                  <MutationButton
+                    size="small"
+                    mutation={resendPaymentInstructions}
+                    param={exerciseInProgress.id}
+                    successText="Payment instructions sent!"
+                  >
+                    Resend payment instructions
+                  </MutationButton>
+                </div>
+              </AlertDescription>
+            </Alert>
+          ) : null}
 
           <DataTable table={table} onRowClicked={setSelectedEquityGrant} />
 

--- a/frontend/db/schema.ts
+++ b/frontend/db/schema.ts
@@ -1640,7 +1640,6 @@ export const companies = pgTable(
     defaultCurrency: varchar("default_currency").default("usd").notNull(),
 
     conversionSharePriceUsd: numeric("conversion_share_price_usd"),
-    jsonData: jsonb("json_data").notNull().$type<{ flags: string[] }>().default({ flags: [] }),
     inviteLink: varchar("invite_link"),
   },
   (table) => [


### PR DESCRIPTION
- Dropped `json_flag?` method and removed :json_data column from companies
- Removed option_exercising checks in policies and presenters
- Updated equity grant and options flows to no longer rely on json_data flags
- Cleaned up frontend UI by always showing option exercising actions when applicable
- Removed jsonData from frontend DB schema and test factories

<img width="2940" height="1912" alt="image" src="https://github.com/user-attachments/assets/057c4ab5-43e6-41e7-b544-6d9f4581f32a" />


