### PR TITLE
feat: improve invoice details page ui

### DIFF
--- a/frontend/app/(dashboard)/invoices/[id]/page.tsx
+++ b/frontend/app/(dashboard)/invoices/[id]/page.tsx
@@ -255,17 +255,17 @@ export default function InvoicePage() {
         </Dialog>
       ) : null}
       {!taxRequirementsMet(invoice) && (
-        <Alert className="mx-4 print:hidden" variant="destructive">
+        <Alert className="m-4 print:hidden" variant="destructive">
           <ExclamationTriangleIcon />
           <AlertTitle>Missing tax information.</AlertTitle>
           <AlertDescription>Invoice is not payable until contractor provides tax information.</AlertDescription>
         </Alert>
       )}
 
-      <StatusDetails invoice={invoice} className="print:hidden" />
+      <StatusDetails invoice={invoice} className="my-4 print:hidden" />
 
       {payRateInSubunits && invoice.lineItems.some((lineItem) => lineItem.payRateInSubunits > payRateInSubunits) ? (
-        <Alert className="mx-4 print:hidden" variant="warning">
+        <Alert className="m-4 print:hidden" variant="warning">
           <CircleAlert />
           <AlertDescription>
             This invoice includes rates above the default of {formatMoneyFromCents(payRateInSubunits)}/
@@ -275,7 +275,7 @@ export default function InvoicePage() {
       ) : null}
 
       {invoice.equityAmountInCents > 0 ? (
-        <Alert className="mx-4 print:hidden">
+        <Alert className="m-4 print:hidden">
           <InformationCircleIcon />
           <AlertDescription>
             When this invoice is paid, you'll receive an additional {formatMoneyFromCents(invoice.equityAmountInCents)}{" "}
@@ -327,7 +327,7 @@ export default function InvoicePage() {
             </div>
 
             {invoice.lineItems.length > 0 ? (
-              <div className="w-full overflow-x-auto">
+              <div className="w-full overflow-x-auto px-4">
                 <Table className="w-full min-w-[600px] table-fixed md:max-w-full md:min-w-full print:my-3 print:w-full print:border-collapse print:text-xs">
                   <TableHeader>
                     <TableRow className="print:border-b print:border-gray-300">
@@ -370,7 +370,7 @@ export default function InvoicePage() {
             ) : null}
 
             {invoice.expenses.length > 0 && (
-              <Card className="print:my-3 print:border print:border-gray-300 print:bg-white print:p-2">
+              <Card className="mx-4 print:my-3 print:border print:border-gray-300 print:bg-white print:p-2">
                 <CardContent>
                   <div className="flex justify-between gap-2">
                     <div>Expense</div>
@@ -397,7 +397,7 @@ export default function InvoicePage() {
               </Card>
             )}
 
-            <footer className="flex justify-between print:mt-4 print:flex print:items-start print:justify-between">
+            <footer className="mx-4 flex justify-between gap-2 print:mt-4 print:flex print:items-start print:justify-between">
               <div className="print:mr-4 print:flex-1">
                 {invoice.notes ? (
                   <div>

--- a/frontend/app/(dashboard)/invoices/[id]/page.tsx
+++ b/frontend/app/(dashboard)/invoices/[id]/page.tsx
@@ -327,7 +327,7 @@ export default function InvoicePage() {
             </div>
 
             {invoice.lineItems.length > 0 ? (
-              <div className="w-full overflow-x-auto px-4">
+              <div className="w-full overflow-x-auto px-4 print:px-0">
                 <Table className="w-full min-w-[600px] table-fixed md:max-w-full md:min-w-full print:my-3 print:w-full print:border-collapse print:text-xs">
                   <TableHeader>
                     <TableRow className="print:border-b print:border-gray-300">
@@ -370,7 +370,7 @@ export default function InvoicePage() {
             ) : null}
 
             {invoice.expenses.length > 0 && (
-              <Card className="mx-4 print:my-3 print:border print:border-gray-300 print:bg-white print:p-2">
+              <Card className="mx-4 print:mx-0 print:my-3 print:border print:border-gray-300 print:bg-white print:p-2">
                 <CardContent>
                   <div className="flex justify-between gap-2">
                     <div>Expense</div>
@@ -397,8 +397,8 @@ export default function InvoicePage() {
               </Card>
             )}
 
-            <footer className="mx-4 flex justify-between gap-2 print:mt-4 print:flex print:items-start print:justify-between">
-              <div className="print:mr-4 print:flex-1">
+            <footer className="mx-4 flex justify-between gap-2 print:mx-0 print:mt-4 print:flex print:items-start print:justify-between">
+              <div className="print:flex-1">
                 {invoice.notes ? (
                   <div>
                     <b className="print:text-sm print:font-bold">Notes</b>


### PR DESCRIPTION
Description

Improve invoice details page ui

- No spacing between alert and header buttons
- Alert overlap on each other in case of multiple alerts on  page.
- Spacing is not uniform in invoice details
- No spacing between notes and total card

Part of #911 

- Before:

   <img width="1355" height="789" alt="before_invoice_details" src="https://github.com/user-attachments/assets/747f1a9a-4990-4005-81dc-edb893751aba" />


- After:

   <img width="1389" height="842" alt="after_invoice_details" src="https://github.com/user-attachments/assets/72e19320-21f1-4a27-81c8-d69dcd9eca9b" />

Test Suite:

 PR contains only css change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* Style
  * Tightened side margins for destructive, warning, and info alerts.
  * Added vertical spacing to status details (remains hidden when printing).
  * Added horizontal padding to the line-items table container (applies in print too).
  * Added side margins to the expenses section while preserving print styles.
  * Updated footer with side margins and a small gap for spacing.
  * Harmonized print layout spacing with on-screen layout.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->