### PR TITLE
fix(auth): improve OTP flow with numeric-only validation, auto-submit, and clearer redirect states

### DIFF
--- a/frontend/app/(auth)/index.tsx
+++ b/frontend/app/(auth)/index.tsx
@@ -158,7 +158,7 @@ export function AuthPage({
                     </FormItem>
                   )}
                 />
-                <div className="pt-5 text-center">
+                <div className="text-center">
                   {verifyOtp.isPending || redirectInProgress ? (
                     <div className="flex items-center justify-center gap-2 text-sm text-gray-600">
                       <div className="h-4 w-4 animate-spin rounded-full border-2 border-gray-300 border-t-blue-600"></div>

--- a/frontend/app/(auth)/index.tsx
+++ b/frontend/app/(auth)/index.tsx
@@ -151,20 +151,18 @@ export function AuthPage({
                           </InputOTPGroup>
                         </InputOTP>
                       </FormControl>
-                      <FormMessage />
+                      {/* Reserve space for error message to prevent layout shift */}
+                      <div className="min-h-5 text-center text-sm">
+                        <FormMessage />
+                      </div>
                     </FormItem>
                   )}
                 />
-                <div className="pt-6 text-center">
-                  {verifyOtp.isPending ? (
+                <div className="pt-5 text-center">
+                  {verifyOtp.isPending || redirectInProgress ? (
                     <div className="flex items-center justify-center gap-2 text-sm text-gray-600">
                       <div className="h-4 w-4 animate-spin rounded-full border-2 border-gray-300 border-t-blue-600"></div>
-                      Verifying...
-                    </div>
-                  ) : redirectInProgress ? (
-                    <div className="flex items-center justify-center gap-2 text-sm text-gray-600">
-                      <div className="h-4 w-4 animate-spin rounded-full border-2 border-gray-300 border-t-blue-600"></div>
-                      Redirecting...
+                      Verifying your code...
                     </div>
                   ) : (
                     <Button className="text-gray-600" variant="link" onClick={() => sendOtp.reset()}>

--- a/frontend/app/(auth)/index.tsx
+++ b/frontend/app/(auth)/index.tsx
@@ -17,7 +17,9 @@ import logo from "@/public/logo-icon.svg";
 import { request } from "@/utils/request";
 
 const emailSchema = z.object({ email: z.string().email() });
-const otpSchema = z.object({ otp: z.string().min(1, "Please enter the 6-digit verification code") });
+const otpSchema = z.object({
+  otp: z.string().length(6, "Please enter the 6-digit verification code"),
+});
 
 export function AuthPage({
   title,
@@ -127,8 +129,10 @@ export function AuthPage({
                           {...field}
                           maxLength={6}
                           onChange={(value) => {
-                            field.onChange(value);
-                            if (value.length === 6) setTimeout(() => void submitOtpForm(), 100);
+                            // Filter out non-numeric characters
+                            const numericValue = value.replace(/[^0-9]/gu, "");
+                            field.onChange(numericValue);
+                            if (numericValue.length === 6) setTimeout(() => void submitOtpForm(), 100);
                           }}
                           aria-label="Verification code"
                           disabled={verifyOtp.isPending || redirectInProgress}

--- a/frontend/app/(auth)/index.tsx
+++ b/frontend/app/(auth)/index.tsx
@@ -17,7 +17,7 @@ import logo from "@/public/logo-icon.svg";
 import { request } from "@/utils/request";
 
 const emailSchema = z.object({ email: z.string().email() });
-const otpSchema = z.object({ otp: z.string().length(6) });
+const otpSchema = z.object({ otp: z.string().min(1, "Please enter the 6-digit verification code") });
 
 export function AuthPage({
   title,
@@ -151,23 +151,22 @@ export function AuthPage({
                     </FormItem>
                   )}
                 />
-                <MutationStatusButton
-                  mutation={verifyOtp}
-                  type="submit"
-                  className="w-[342px]"
-                  disabled={verifyOtp.isPending || redirectInProgress}
-                >
-                  {redirectInProgress ? "Redirecting..." : verifyOtp.isPending ? "Verifying..." : "Continue"}
-                </MutationStatusButton>
                 <div className="pt-6 text-center">
-                  <Button
-                    className="text-gray-600"
-                    variant="link"
-                    onClick={() => sendOtp.reset()}
-                    disabled={verifyOtp.isPending || redirectInProgress}
-                  >
-                    Back to email
-                  </Button>
+                  {verifyOtp.isPending ? (
+                    <div className="flex items-center justify-center gap-2 text-sm text-gray-600">
+                      <div className="h-4 w-4 animate-spin rounded-full border-2 border-gray-300 border-t-blue-600"></div>
+                      Verifying...
+                    </div>
+                  ) : redirectInProgress ? (
+                    <div className="flex items-center justify-center gap-2 text-sm text-gray-600">
+                      <div className="h-4 w-4 animate-spin rounded-full border-2 border-gray-300 border-t-blue-600"></div>
+                      Redirecting...
+                    </div>
+                  ) : (
+                    <Button className="text-gray-600" variant="link" onClick={() => sendOtp.reset()}>
+                      Back to email
+                    </Button>
+                  )}
                 </div>
               </form>
             </Form>

--- a/frontend/components/ui/input-otp.tsx
+++ b/frontend/components/ui/input-otp.tsx
@@ -12,7 +12,7 @@ function InputOTP({
   return (
     <OTPInput
       data-slot="input-otp"
-      containerClassName={cn("flex items-center gap-1 has-disabled:opacity-50", containerClassName)}
+      containerClassName={cn("flex items-center gap-0 has-disabled:opacity-50", containerClassName)}
       className={cn("disabled:cursor-not-allowed", className)}
       {...props}
     />
@@ -20,7 +20,7 @@ function InputOTP({
 }
 
 function InputOTPGroup({ className, ...props }: React.ComponentProps<"div">) {
-  return <div data-slot="input-otp-group" className={cn("flex items-center gap-1", className)} {...props} />;
+  return <div data-slot="input-otp-group" className={cn("flex items-center gap-0", className)} {...props} />;
 }
 
 function InputOTPSlot({
@@ -32,6 +32,7 @@ function InputOTPSlot({
 }) {
   const inputOTPContext = React.useContext(OTPInputContext);
   const { char, hasFakeCaret, isActive } = inputOTPContext.slots[index] ?? {};
+  const lastIndex = Object.keys(inputOTPContext.slots).length - 1;
 
   return (
     <div
@@ -39,7 +40,10 @@ function InputOTPSlot({
       data-active={isActive}
       data-index={index}
       className={cn(
-        "data-[active=true]:border-ring data-[active=true]:ring-ring/50 data-[active=true]:aria-invalid:ring-destructive/20 dark:data-[active=true]:aria-invalid:ring-destructive/40 aria-invalid:border-destructive data-[active=true]:aria-invalid:border-destructive dark:bg-input/30 border-input relative flex h-11 w-11 items-center justify-center rounded-md border bg-white text-sm shadow-xs transition-all outline-none data-[active=true]:z-10 data-[active=true]:ring-[3px]",
+        "data-[active=true]:border-ring data-[active=true]:ring-ring/50 data-[active=true]:aria-invalid:ring-destructive/20 dark:data-[active=true]:aria-invalid:ring-destructive/40 aria-invalid:border-destructive data-[active=true]:aria-invalid:border-destructive dark:bg-input/30 border-input relative flex h-11 w-11 items-center justify-center border bg-white text-sm shadow-xs transition-all outline-none data-[active=true]:z-10 data-[active=true]:ring-[3px]",
+        index === 0 ? "rounded-l-md" : "",
+        index === lastIndex ? "rounded-r-md" : "",
+        index < lastIndex ? "border-r-0" : "",
         className,
       )}
       {...props}

--- a/frontend/components/ui/input-otp.tsx
+++ b/frontend/components/ui/input-otp.tsx
@@ -12,7 +12,7 @@ function InputOTP({
   return (
     <OTPInput
       data-slot="input-otp"
-      containerClassName={cn("flex items-center gap-4 has-disabled:opacity-50", containerClassName)}
+      containerClassName={cn("flex items-center gap-1 has-disabled:opacity-50", containerClassName)}
       className={cn("disabled:cursor-not-allowed", className)}
       {...props}
     />
@@ -20,7 +20,7 @@ function InputOTP({
 }
 
 function InputOTPGroup({ className, ...props }: React.ComponentProps<"div">) {
-  return <div data-slot="input-otp-group" className={cn("flex items-center gap-4", className)} {...props} />;
+  return <div data-slot="input-otp-group" className={cn("flex items-center gap-1", className)} {...props} />;
 }
 
 function InputOTPSlot({


### PR DESCRIPTION
**Before**

* Users could type letters/symbols in OTP field.
* Validation showed a generic `"string must contain 6 characters"`.
* Button flickered active before redirect.
* No explicit "Redirecting..." feedback.

https://github.com/user-attachments/assets/16840bdc-a50c-4221-b53f-fdbc89aff2ce

**After**

* OTP field accepts numbers only.
* Specific error message shown for invalid input.
* All inputs/buttons disabled during verification and redirect.
* Clear inline status with spinner for **Verifying… → Redirecting…**.
* Auto-submit works seamlessly when all 6 digits are entered.

https://github.com/user-attachments/assets/a6b66e02-b9de-4843-b311-43109419fe87

