### PR TITLE
fix: mobile nav issues

### DIFF
--- a/frontend/components/navigation/MobileBottomNav.tsx
+++ b/frontend/components/navigation/MobileBottomNav.tsx
@@ -75,7 +75,7 @@ const SheetOverlay = ({ open }: { open: boolean }) =>
     <div
       className={cn(
         "pointer-events-none fixed inset-0 z-35 bg-black/50 transition-opacity duration-200",
-        open ? "opacity-100" : "opacity-0",
+        open ? "pointer-events-auto opacity-100" : "opacity-0",
       )}
       aria-hidden="true"
     />,
@@ -421,7 +421,7 @@ export function MobileBottomNav() {
     <nav
       role="navigation"
       aria-label="Mobile navigation"
-      className="bg-background border-border fixed right-0 bottom-0 left-0 z-60 h-15 border-t"
+      className="bg-background border-border pointer-events-auto fixed right-0 bottom-0 left-0 z-60 h-15 border-t"
     >
       <ul role="list" className="flex items-center justify-around">
         {mainItems.map((item) => (


### PR DESCRIPTION
Description:

Fix mobile nav issues listed below (shown in same sequence in before / after video)

1. User click on equity/more nav and then on invoices nav, the options sheet flicker.
2. When any dialog opens, mobile nav becomes irresponsive on first click.
3. If equity/more options sheet is open and user click on overlay , the event also propagate to the background ui causing side effects.

Part of #911 

Before: 

https://github.com/user-attachments/assets/15c0a080-fcf7-40b0-bebe-e6c61d88235e


After:


https://github.com/user-attachments/assets/b8ab63c2-de54-4e7e-9844-6df101468bc8


Test Suite:

Related test:

<img width="1150" height="108" alt="tests-mobile-nav" src="https://github.com/user-attachments/assets/307f0071-50fd-4a91-bf01-4bcfb6c56c1a" />

