### PR TITLE
fix: failing payment details spec

### DIFF
--- a/e2e/tests/settings/administrator/payment-details.spec.ts
+++ b/e2e/tests/settings/administrator/payment-details.spec.ts
@@ -72,7 +72,7 @@ test.describe("Company administrator settings - payment details", () => {
     await page.getByRole("button", { name: "Link your bank account" }).click();
 
     const stripeFrame = page.frameLocator("[src^='https://js.stripe.com/v3/elements-inner-payment']");
-    await stripeFrame.getByRole("button", { name: "Enter bank details manually instead" }).click();
+    await stripeFrame.getByRole("button", { name: /Enter bank details manually/u }).click();
 
     const bankFrame = page.frameLocator("[src^='https://js.stripe.com/v3/linked-accounts-inner']");
     await bankFrame.getByLabel("Routing number").fill("110000000");


### PR DESCRIPTION
Description:

Test fails for e2e/tests/settings/administrator/payment-details.spec.ts: › Company administrator settings - payment details › allows manually connecting a bank account with microdeposit verification 

Cause: In test env, stripe frame is showing bit different text for button

<table>
<tr>
<th>Dev</th>
<th>Test</th>
</tr>
<tr>
<td>
<img width="638" height="489" alt="dev_billing_text" src="https://github.com/user-attachments/assets/0dca2e21-ff41-4a0a-a53c-780950b82534" />
</td>
<td>
<img width="610" height="452" alt="test_billing_text" src="https://github.com/user-attachments/assets/d686d34a-62ea-4bf6-88c0-176ac22907ec" />
</td>
</tr>
</table>

Part of #911 

- Before:

   <img width="1665" height="281" alt="before_billiing_test" src="https://github.com/user-attachments/assets/e7dc344c-b529-45fe-a5d4-7e6fa05c607c" />


- After / Test Suite / Related Tests:

   <img width="1751" height="114" alt="after_billing_test" src="https://github.com/user-attachments/assets/f7df700b-b5ee-41da-ab5b-021d85771447" />






