### PR TITLE
fix(ui): enhance styling and layout for document templates and dialogs

### DIFF
--- a/frontend/app/(dashboard)/document_templates/[id]/page.tsx
+++ b/frontend/app/(dashboard)/document_templates/[id]/page.tsx
@@ -344,9 +344,40 @@ export default function EditTemplatePage() {
               background-color: var(--accent, #f3f4f6) !important;
               color: var(--accent-foreground, black) !important;
             }
+
+
+            /* Override existing padding classes */
+            *[class*="pr-3.5"] {
+              padding-right: 0.7rem !important;
+            }
+
+            *[class*="pl-0.5"] {
+              padding-left: 0 !important;
+            }
+
+            /* Override existing padding classes on mobile */
+            @media (max-width: 640px) {
+              *[class*="pr-3.5"] {
+              padding-right: 0 !important;
+            }}
+
+            /* Add px-4 to main container */
+            #main_container {
+              padding-left: 1rem !important;
+              padding-right: 1rem !important;
+            }
           `}
         />
       </div>
     </>
   );
 }
+
+// /* Override inline styles */
+// [style*="padding-right: 0.875rem"] {
+//   padding-right: 1rem !important;
+// }
+
+// [style*="padding-left: 0.125rem"] {
+//   padding-left: 1rem !important;
+// }

--- a/frontend/app/(dashboard)/document_templates/[id]/page.tsx
+++ b/frontend/app/(dashboard)/document_templates/[id]/page.tsx
@@ -372,12 +372,3 @@ export default function EditTemplatePage() {
     </>
   );
 }
-
-// /* Override inline styles */
-// [style*="padding-right: 0.875rem"] {
-//   padding-right: 1rem !important;
-// }
-
-// [style*="padding-left: 0.125rem"] {
-//   padding-left: 1rem !important;
-// }

--- a/frontend/app/(dashboard)/documents/page.tsx
+++ b/frontend/app/(dashboard)/documents/page.tsx
@@ -144,7 +144,7 @@ const EditTemplates = () => {
             </TableBody>
           </Table>
           <h3 className="text-lg font-medium">Create a new template</h3>
-          <Alert className="mx-4">
+          <Alert>
             <Info className="size-4" />
             <AlertDescription>
               By creating a custom document template, you acknowledge that Flexile shall not be liable for any claims,
@@ -155,7 +155,7 @@ const EditTemplates = () => {
               for more details.
             </AlertDescription>
           </Alert>
-          <div className="grid grid-cols-3 gap-4">
+          <div className="grid grid-cols-2 gap-4">
             <MutationButton
               idleVariant="outline"
               className="h-auto rounded-md p-6"

--- a/frontend/app/(dashboard)/documents/page.tsx
+++ b/frontend/app/(dashboard)/documents/page.tsx
@@ -410,18 +410,18 @@ export default function DocumentsPage() {
       <DashboardHeader
         title="Documents"
         headerActions={
-          isMobile ? (
-            table.options.enableRowSelection ? (
+          <>
+            {isMobile && table.options.enableRowSelection ? (
               <button
                 className="text-blue-600"
                 onClick={() => table.toggleAllRowsSelected(!table.getIsAllRowsSelected())}
               >
                 {table.getIsAllRowsSelected() ? "Unselect all" : "Select all"}
               </button>
-            ) : null
-          ) : isCompanyRepresentative && documents.length === 0 ? (
-            <EditTemplates />
-          ) : null
+            ) : null}
+
+            {isCompanyRepresentative && documents.length === 0 ? <EditTemplates /> : null}
+          </>
         }
       />
 

--- a/frontend/components/ui/dialog.tsx
+++ b/frontend/components/ui/dialog.tsx
@@ -55,7 +55,7 @@ function DialogContent({
         {showCloseButton && !isMobile ? (
           <DialogPrimitive.Close
             data-slot="dialog-close"
-            className="ring-offset-background focus:ring-ring data-[state=open]:bg-accent data-[state=open]:text-muted-foreground absolute top-[26px] right-5 mt-2 mr-2 rounded-xs opacity-70 transition-opacity hover:opacity-100 focus:ring-2 focus:ring-offset-2 focus:outline-hidden disabled:pointer-events-none [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4"
+            className="ring-offset-background focus:ring-ring data-[state=open]:bg-accent data-[state=open]:text-muted-foreground absolute top-[26px] right-5 mt-2 mr-2 cursor-pointer rounded-xs opacity-70 transition-opacity hover:opacity-100 focus:ring-2 focus:ring-offset-2 focus:outline-hidden disabled:pointer-events-none [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4"
           >
             <XIcon />
             <span className="sr-only">Close</span>

--- a/frontend/components/ui/dialog.tsx
+++ b/frontend/components/ui/dialog.tsx
@@ -55,7 +55,7 @@ function DialogContent({
         {showCloseButton && !isMobile ? (
           <DialogPrimitive.Close
             data-slot="dialog-close"
-            className="ring-offset-background focus:ring-ring data-[state=open]:bg-accent data-[state=open]:text-muted-foreground absolute top-[26px] right-5 mt-2 mr-2 cursor-pointer rounded-xs opacity-70 transition-opacity hover:opacity-100 focus:ring-2 focus:ring-offset-2 focus:outline-hidden disabled:pointer-events-none [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4"
+            className="ring-offset-background focus:ring-ring data-[state=open]:bg-accent data-[state=open]:text-muted-foreground absolute top-[26px] right-5 mt-2 mr-2 rounded-xs opacity-70 transition-opacity hover:opacity-100 focus:ring-2 focus:ring-offset-2 focus:outline-hidden disabled:pointer-events-none [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4"
           >
             <XIcon />
             <span className="sr-only">Close</span>


### PR DESCRIPTION
ref #911 

fixes layout of document on mobile and desktop also fixes the logic to show add template icon on mobile

### Changes
- Updated padding styles in the EditTemplatePage to improve layout consistency, including overrides for mobile responsiveness.
- Adjusted the Alert component in the EditTemplates page to remove unnecessary margin, streamlining the design.
- Modified the Dialog component's close button to change cursor behavior, enhancing user interaction.
- Fixes logic to render add template button on mobile

### Before
<img width="1470" height="956" alt="Screenshot 2025-08-19 at 2 05 05 AM" src="https://github.com/user-attachments/assets/37ad6c7a-b203-4550-a33a-2f8102c6124a" />

### After
<img width="1470" height="956" alt="Screenshot 2025-08-19 at 2 05 28 AM" src="https://github.com/user-attachments/assets/51be4abf-e536-4fb7-94de-7be63d4b3182" />

### Before
<img width="1470" height="956" alt="Screenshot 2025-08-19 at 2 02 43 AM" src="https://github.com/user-attachments/assets/2110d517-cd4e-47b2-b32a-358377e34cae" />


### After
<img width="1470" height="956" alt="Screenshot 2025-08-19 at 2 04 12 AM" src="https://github.com/user-attachments/assets/c3501f14-e143-4f20-b556-d7deecc5d357" />

### Before
<img width="422" height="800" alt="Screenshot 2025-08-19 at 2 05 18 AM" src="https://github.com/user-attachments/assets/a5a0f81a-dbd2-4978-8bd6-c105310490ff" />


### After
<img width="495" height="780" alt="Screenshot 2025-08-19 at 2 05 45 AM" src="https://github.com/user-attachments/assets/3fbff871-9932-4d23-a4c4-2b7bd27ddf2b" />

### Before
<img width="1470" height="956" alt="Screenshot 2025-08-19 at 6 34 15 AM" src="https://github.com/user-attachments/assets/0b9b49fd-5753-4879-969f-ecd723ba37a2" />

### After
<img width="1470" height="956" alt="Screenshot 2025-08-19 at 6 34 20 AM" src="https://github.com/user-attachments/assets/4ece1c5d-056c-4355-876f-825012c82706" />

### Before 
<img width="506" height="789" alt="Screenshot 2025-08-19 at 7 06 12 AM" src="https://github.com/user-attachments/assets/05864399-ed9d-400b-a566-6248dd7fb79b" />

### After 
<img width="545" height="795" alt="Screenshot 2025-08-19 at 7 06 24 AM" src="https://github.com/user-attachments/assets/8c83a213-236f-4c6b-95bf-e1966eb400d3" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * “Edit templates” is now available on mobile for company representatives when no documents exist.
  * Adjusted “Select All” button availability on mobile to appear only when row selection is enabled.

* **Style**
  * Refined layout spacing: reduced alert margins and switched the “Create a new template” section to a 2‑column layout.
  * Updated padding across the builder and main container for more consistent spacing, including mobile-specific tweaks to reduce horizontal padding.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->