### PR TITLE
Add ParseInvoiceDocService to support use of existing invoice PDF

### DIFF
--- a/backend/app/services/parse_invoice_doc_service.rb
+++ b/backend/app/services/parse_invoice_doc_service.rb
@@ -1,0 +1,201 @@
+# frozen_string_literal: true
+
+class ParseInvoiceDocService
+  require "mini_magick"
+  require "openai"
+
+  def initialize(file:, company:)
+    @file = file
+    @company = company
+    @openai_client = OpenAI::Client.new(request_timeout: 30)
+  end
+
+  def process
+    image_data = convert_pdf_to_image_data(@file)
+    process_invoice(image_data)
+  end
+
+  private
+    attr_reader :file, :company, :openai_client
+
+    def process_invoice(image_data)
+      messages = build_initial_messages(image_data)
+      parsed_data = parse_invoice_with_openai(messages)
+      sanitized_params = sanitize_openai_response(parsed_data)
+
+      {
+        success: true,
+        data: sanitized_params,
+      }
+    end
+
+    def convert_pdf_to_image_data(file)
+      image = MiniMagick::Image.read(file)
+      image.format "png"
+      image.quality 300
+      image.resize "2048x2048>"
+
+      image_blob = image.to_blob
+      [Base64.strict_encode64(image_blob)]
+
+    rescue StandardError => e
+      raise "Failed to convert PDF to image: #{e.message}"
+    end
+
+    def build_initial_messages(base64_image_data)
+      messages = [
+        {
+          role: "system",
+          content: build_system_prompt,
+        },
+        {
+          role: "user",
+          content: [
+            { type: "text", text: build_parsing_prompt }
+          ],
+        }
+      ]
+
+      base64_image_data.each do |base64_image|
+        messages.last[:content] << {
+          type: "image_url",
+          image_url: {
+            url: "data:image/png;base64,#{base64_image}",
+          },
+        }
+      end
+
+      messages
+    end
+
+    def parse_invoice_with_openai(messages)
+      response = openai_client.chat(
+        parameters: {
+          model: "gpt-4o",
+          messages: messages,
+          max_tokens: 2000,
+          temperature: 0,
+          response_format: { type: "json_object" },
+        }
+      )
+
+      content = response.dig("choices", 0, "message", "content")
+
+      JSON.parse(content)
+    end
+
+    def build_system_prompt
+      <<~SYSTEM_PROMPT
+        You are an expert invoice data extraction assistant. Your job is to accurately extract structured data from invoice images and return it as valid JSON.
+
+        Key responsibilities:
+        1. Extract invoice metadata (date, number, notes)
+        2. Parse line items for services/work performed
+        3. Extract reimbursable expenses with proper categorization
+        4. Ensure all monetary amounts are converted to cents (multiply by 100)
+        5. Maintain data accuracy and consistency
+
+        Critical formatting rules:
+        - ALL monetary amounts must be in CENTS (multiply dollar amounts by 100)
+        - Dates must be in YYYY-MM-DD format
+        - Use null for missing/unclear fields
+        - Be conservative when determining if work is hourly vs fixed-quantity
+        - Match expense descriptions to available categories when possible
+
+        Always respond with properly formatted JSON.
+      SYSTEM_PROMPT
+    end
+
+    def build_parsing_prompt
+      expense_categories = company.expense_categories.pluck(:id, :name).map { |id, name| "#{id}: #{name}" }.join(", ")
+
+      <<~PROMPT
+      Please analyze this invoice image and extract the following information as a JSON object.
+
+      I need you to extract:
+
+      1. **Invoice metadata:**
+         - invoice_date (YYYY-MM-DD format)
+         - invoice_number (string)
+         - notes (any additional notes or description, optional)
+
+      2. **Line items** (array of service/work items):
+         - description (string)
+         - quantity (number, can be decimal for hours)
+         - pay_rate_in_subunits (rate per unit in CENTS - multiply dollar amounts by 100)
+         - hourly (boolean - true if this is hourly work, false if it's a fixed quantity)
+
+      3. **Expenses** (array of reimbursable expenses):
+         - description (string)
+         - expense_category_id (integer - match to one of these categories: #{expense_categories.presence || "No categories available"})
+         - total_amount_in_cents (total amount in CENTS - multiply dollar amounts by 100)
+
+      **Important formatting rules:**
+      - All monetary amounts must be in CENTS (multiply by 100)
+      - Dates must be in YYYY-MM-DD format
+      - If you can't find a field, use null
+      - For expenses, try to match descriptions to the available expense categories, or use null if no good match
+      - Be conservative with hourly vs non-hourly determination
+
+      Return ONLY a JSON object in this exact format:
+
+      ```
+      {
+        "invoice": {
+          "invoice_date": "2024-01-15",
+          "invoice_number": "INV-001",
+          "notes": "Optional notes"
+        },
+        "invoice_line_items": [
+          {
+            "description": "Software Development",
+            "quantity": 40.0,
+            "pay_rate_in_subunits": 10000,
+            "hourly": true
+          }
+        ],
+        "invoice_expenses": [
+          {
+            "description": "Travel expenses",
+            "expense_category_id": 1,
+            "total_amount_in_cents": 5000
+          }
+        ]
+      }
+      ```
+      PROMPT
+    end
+
+    def sanitize_openai_response(parsed_data)
+      params_hash = ActionController::Parameters.new(parsed_data)
+
+      {
+        invoice: invoice_params(params_hash),
+        invoice_line_items: invoice_line_items_params(params_hash),
+        invoice_expenses: invoice_expenses_params(params_hash),
+      }
+    end
+
+    def invoice_params(params)
+      params.permit(invoice: [:invoice_date, :invoice_number, :notes])[:invoice]
+    end
+
+    def invoice_line_items_params(params)
+      permitted_params = [:description, :quantity, :pay_rate_in_subunits, :hourly]
+
+      params.permit(invoice_line_items: permitted_params).fetch(:invoice_line_items, [])
+    end
+
+    def invoice_expenses_params(params)
+      return [] unless params[:invoice_expenses].present?
+
+      params.permit(invoice_expenses: [:description, :expense_category_id, :total_amount_in_cents])
+            .fetch(:invoice_expenses)
+    end
+end
+
+=begin
+file = File.open("./invoice.pdf")
+company = Company.last
+ParseInvoiceDocService.new(file:, company:).process
+=end

--- a/backend/spec/services/parse_invoice_doc_service_spec.rb
+++ b/backend/spec/services/parse_invoice_doc_service_spec.rb
@@ -1,0 +1,265 @@
+# frozen_string_literal: true
+
+RSpec.describe ParseInvoiceDocService do
+  let(:company) { create(:company) }
+  let!(:expense_category) { create(:expense_category, company:, name: "Travel") }
+  let(:file) { fixture_file_upload("sample.pdf", "application/pdf") }
+  let(:service) { described_class.new(file:, company:) }
+
+  let(:openai_response) do
+    {
+      "choices" => [
+        {
+          "message" => {
+            "content" => JSON.generate({
+              "invoice" => {
+                "invoice_date" => "2024-01-15",
+                "invoice_number" => "INV-2024-001",
+                "notes" => "Consulting services for Q1",
+              },
+              "invoice_line_items" => [
+                {
+                  "description" => "Software Development",
+                  "quantity" => 40.0,
+                  "pay_rate_in_subunits" => 7500,
+                  "hourly" => true,
+                },
+                {
+                  "description" => "Code Review",
+                  "quantity" => 8.0,
+                  "pay_rate_in_subunits" => 8000,
+                  "hourly" => true,
+                }
+              ],
+              "invoice_expenses" => [
+                {
+                  "description" => "Flight to client site",
+                  "expense_category_id" => expense_category.id,
+                  "total_amount_in_cents" => 50000,
+                }
+              ],
+            }),
+          },
+        }
+      ],
+    }
+  end
+
+  before do
+    allow_any_instance_of(OpenAI::Client).to receive(:chat).and_return(openai_response)
+  end
+
+  describe "#process" do
+    context "with valid PDF file and OpenAI response" do
+      it "returns success with sanitized data" do
+        result = service.process
+
+        expect(result[:success]).to be true
+        expect(result[:data]).to be_present
+      end
+
+      it "extracts and sanitizes all invoice data correctly" do
+        result = service.process
+
+        invoice_data = result[:data][:invoice]
+        expect(invoice_data[:invoice_date]).to eq("2024-01-15")
+        expect(invoice_data[:invoice_number]).to eq("INV-2024-001")
+        expect(invoice_data[:notes]).to eq("Consulting services for Q1")
+
+        line_items = result[:data][:invoice_line_items]
+        expect(line_items.size).to eq(2)
+
+        expect(line_items[0][:description]).to eq("Software Development")
+        expect(line_items[0][:quantity]).to eq(40.0)
+        expect(line_items[0][:pay_rate_in_subunits]).to eq(7500)
+        expect(line_items[0][:hourly]).to be true
+
+        expect(line_items[1][:description]).to eq("Code Review")
+        expect(line_items[1][:quantity]).to eq(8.0)
+        expect(line_items[1][:pay_rate_in_subunits]).to eq(8000)
+        expect(line_items[1][:hourly]).to be true
+
+        expenses = result[:data][:invoice_expenses]
+        expect(expenses.size).to eq(1)
+        expect(expenses[0][:description]).to eq("Flight to client site")
+        expect(expenses[0][:expense_category_id]).to eq(expense_category.id)
+        expect(expenses[0][:total_amount_in_cents]).to eq(50000)
+      end
+
+      it "filters out unpermitted parameters from all data types" do
+        openai_response["choices"][0]["message"]["content"] = JSON.generate({
+          "invoice" => {
+            "invoice_date" => "2024-01-15",
+            "invoice_number" => "INV-2024-001",
+            "notes" => "Test notes",
+            "unauthorized_field" => "should be filtered",
+          },
+          "invoice_line_items" => [
+            {
+              "description" => "Software Development",
+              "quantity" => 40.0,
+              "pay_rate_in_subunits" => 7500,
+              "hourly" => true,
+              "malicious_field" => "should be filtered",
+            }
+          ],
+          "invoice_expenses" => [
+            {
+              "description" => "Travel",
+              "expense_category_id" => expense_category.id,
+              "total_amount_in_cents" => 50000,
+              "evil_field" => "should be filtered",
+            }
+          ],
+        })
+
+        result = service.process
+
+        expect(result[:data][:invoice].keys).to match_array(["invoice_date", "invoice_number", "notes"])
+        expect(result[:data][:invoice_line_items][0].keys).to match_array(["description", "quantity", "pay_rate_in_subunits", "hourly"])
+        expect(result[:data][:invoice_expenses][0].keys).to match_array(["description", "expense_category_id", "total_amount_in_cents"])
+
+        expect(result[:data][:invoice]).not_to have_key(:unauthorized_field)
+        expect(result[:data][:invoice_line_items][0]).not_to have_key(:malicious_field)
+        expect(result[:data][:invoice_expenses][0]).not_to have_key(:evil_field)
+      end
+    end
+
+    context "with minimal OpenAI response" do
+      let(:minimal_response) do
+        {
+          "choices" => [
+            {
+              "message" => {
+                "content" => JSON.generate({
+                  "invoice" => {
+                    "invoice_date" => "2024-01-15",
+                    "invoice_number" => "INV-001",
+                  },
+                  "invoice_line_items" => [
+                    {
+                      "description" => "Work done",
+                      "quantity" => 1,
+                      "pay_rate_in_subunits" => 10000,
+                      "hourly" => false,
+                    }
+                  ],
+                }),
+              },
+            }
+          ],
+        }
+      end
+
+      before do
+        allow_any_instance_of(OpenAI::Client).to receive(:chat).and_return(minimal_response)
+      end
+
+      it "handles missing optional fields" do
+        result = service.process
+
+        expect(result[:success]).to be true
+        expect(result[:data][:invoice][:notes]).to be_nil
+        expect(result[:data][:invoice_expenses]).to eq([])
+      end
+    end
+
+    context "with empty or missing data in OpenAI response" do
+      let(:no_expenses_response) do
+        {
+          "choices" => [
+            {
+              "message" => {
+                "content" => JSON.generate({
+                  "invoice" => {
+                    "invoice_date" => "2024-01-15",
+                    "invoice_number" => "INV-001",
+                  },
+                  "invoice_line_items" => [
+                    {
+                      "description" => "Work done",
+                      "quantity" => 1,
+                      "pay_rate_in_subunits" => 10000,
+                      "hourly" => false,
+                    }
+                  ],
+                  "invoice_expenses" => [],
+                }),
+              },
+            }
+          ],
+        }
+      end
+
+      before do
+        allow_any_instance_of(OpenAI::Client).to receive(:chat).and_return(no_expenses_response)
+      end
+
+      it "handles empty expenses gracefully" do
+        result = service.process
+
+        expect(result[:success]).to be true
+        expect(result[:data][:invoice_expenses]).to eq([])
+      end
+    end
+
+    context "when PDF conversion fails" do
+      before do
+        allow(MiniMagick::Image).to receive(:read).and_raise(StandardError.new("Invalid PDF"))
+      end
+
+      it "raises an error with descriptive message" do
+        expect { service.process }.to raise_error("Failed to convert PDF to image: Invalid PDF")
+      end
+    end
+
+    context "when OpenAI returns invalid JSON" do
+      let(:invalid_json_response) do
+        {
+          "choices" => [
+            {
+              "message" => {
+                "content" => "invalid json content",
+              },
+            }
+          ],
+        }
+      end
+
+      before do
+        allow_any_instance_of(OpenAI::Client).to receive(:chat).and_return(invalid_json_response)
+      end
+    end
+  end
+
+
+
+  describe "OpenAI integration" do
+    it "calls OpenAI API with correct model and gets response" do
+      expect_any_instance_of(OpenAI::Client).to receive(:chat)
+        .with(hash_including(
+                parameters: hash_including(
+                  model: "gpt-4o",
+                  max_tokens: 2000,
+                  temperature: 0,
+                  response_format: { type: "json_object" }
+                )
+              ))
+        .and_return(openai_response)
+
+      result = service.process
+      expect(result[:success]).to be true
+    end
+
+    it "includes company expense categories in the prompt" do
+      expect_any_instance_of(OpenAI::Client).to receive(:chat) do |_, args|
+        user_message = args[:parameters][:messages].find { |m| m[:role] == "user" }
+        prompt_text = user_message[:content].find { |c| c[:type] == "text" }[:text]
+        expect(prompt_text).to include("#{expense_category.id}: #{expense_category.name}")
+        openai_response
+      end
+
+      service.process
+    end
+  end
+end


### PR DESCRIPTION
Partially fixes #937

Usage: This can be used on rails console using

```ruby
file = File.open("./invoice.pdf")
company = Company.last
ParseInvoiceDocService.new(file:, company:).process
```

Passing specs:

<img width="1181" height="315" alt="image" src="https://github.com/user-attachments/assets/3d508b38-ec94-4179-8645-51e07eae7fa2" />
