### PR TITLE
feat: allow to drag and drop files when creating a support ticket

### DIFF
--- a/frontend/app/(dashboard)/support/ConversationsList.tsx
+++ b/frontend/app/(dashboard)/support/ConversationsList.tsx
@@ -1,8 +1,9 @@
 "use client";
 
 import { useConversations, useCreateConversation } from "@helperai/react";
-import { CircleCheck, Paperclip, Plus, SendIcon, X } from "lucide-react";
+import { CircleCheck, Paperclip, Plus, SendIcon, Upload, X } from "lucide-react";
 import React, { useRef, useState } from "react";
+import { useDropzone } from "react-dropzone";
 import { helperTools } from "@/app/(dashboard)/support/tools";
 import { DashboardHeader } from "@/components/DashboardHeader";
 import { MutationStatusButton } from "@/components/MutationButton";
@@ -64,6 +65,23 @@ export const ConversationsList = ({ onSelectConversation }: ConversationsListPro
       fileInputRef.current.value = "";
     }
   };
+
+  const onDrop = (acceptedFiles: File[]) => {
+    setAttachments((prev) => [...prev, ...acceptedFiles]);
+  };
+
+  const { getRootProps, getInputProps, isDragActive } = useDropzone({
+    onDrop,
+    accept: {
+      "image/*": [],
+      "application/pdf": [".pdf"],
+      "application/msword": [".doc"],
+      "application/vnd.openxmlformats-officedocument.wordprocessingml.document": [".docx"],
+      "text/plain": [".txt"],
+    },
+    multiple: true,
+    noClick: true,
+  });
 
   const removeAttachment = (index: number) => {
     setAttachments((prev) => prev.filter((_, i) => i !== index));
@@ -141,7 +159,8 @@ export const ConversationsList = ({ onSelectConversation }: ConversationsListPro
           <DialogHeader>
             <DialogTitle>How can we help you today?</DialogTitle>
           </DialogHeader>
-          <div className="space-y-4">
+          <div {...getRootProps()} className="space-y-4">
+            <input {...getInputProps()} />
             <div className="relative">
               <Input
                 id="subject"
@@ -150,26 +169,39 @@ export const ConversationsList = ({ onSelectConversation }: ConversationsListPro
                 placeholder="Subject"
                 className="mt-1"
               />
-              <Textarea
-                id="message"
-                value={message}
-                onChange={(e) => setMessage(e.target.value)}
-                placeholder="Tell us about your issue or question..."
-                className="mt-4 min-h-40 resize-none pr-12"
-                rows={4}
-              />
-              <div className="absolute right-2 bottom-2">
-                <Button
-                  type="button"
-                  variant="ghost"
-                  size="small"
-                  onClick={() => fileInputRef.current?.click()}
-                  className="h-8 w-8 p-0"
-                >
-                  <Paperclip className="size-4" />
-                </Button>
+              <div className="relative">
+                <Textarea
+                  id="message"
+                  value={message}
+                  onChange={(e) => setMessage(e.target.value)}
+                  placeholder="Tell us about your issue or question..."
+                  className="mt-4 min-h-40 resize-none pr-12"
+                  rows={4}
+                />
+                <div className="absolute right-2 bottom-2">
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    size="small"
+                    onClick={() => fileInputRef.current?.click()}
+                    className="h-8 w-8 p-0"
+                    title="Attach files"
+                  >
+                    <Paperclip className="size-4" />
+                  </Button>
+                </div>
               </div>
             </div>
+
+            {isDragActive ? (
+              <div className="absolute inset-0 z-10 mb-0 flex items-center justify-center rounded-lg border-2 border-dashed border-blue-400 bg-blue-50/90">
+                <div className="text-center">
+                  <Upload className="mx-auto h-12 w-12 text-blue-400" />
+                  <p className="mt-2 text-sm font-medium text-blue-600">Drop files here to attach</p>
+                  <p className="text-xs text-blue-500">Supports images, PDF, DOC, DOCX, and TXT files</p>
+                </div>
+              </div>
+            ) : null}
 
             {attachments.length > 0 && (
               <div className="flex flex-wrap gap-2">
@@ -183,6 +215,7 @@ export const ConversationsList = ({ onSelectConversation }: ConversationsListPro
                       type="button"
                       onClick={() => removeAttachment(index)}
                       className="cursor-pointer text-gray-500 hover:text-gray-700"
+                      title="Remove file"
                     >
                       <X className="size-3" />
                     </button>

--- a/package.json
+++ b/package.json
@@ -126,6 +126,7 @@
     "react": "^19.0.0-rc.1",
     "react-aria-components": "^1.8.0",
     "react-dom": "^19.0.0-rc.1",
+    "react-dropzone": "^14.3.8",
     "react-hook-form": "^7.54.2",
     "resend": "^4.0.1-alpha.0",
     "rsa-pem-from-mod-exp": "^0.8.6",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -244,6 +244,9 @@ importers:
       react-dom:
         specifier: ^19.0.0-rc.1
         version: 19.0.0(react@19.0.0)
+      react-dropzone:
+        specifier: ^14.3.8
+        version: 14.3.8(react@19.0.0)
       react-hook-form:
         specifier: ^7.54.2
         version: 7.54.2(react@19.0.0)
@@ -3644,6 +3647,10 @@ packages:
   asynckit@0.4.0:
     resolution: {integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==}
 
+  attr-accept@2.2.5:
+    resolution: {integrity: sha512-0bDNnY/u6pPwHDMoF0FieU354oBi0a8rD9FcsLwzcGWbc8KS8KPIi7y+s13OlVY+gMWc/9xEMUgNE6Qm8ZllYQ==}
+    engines: {node: '>=4'}
+
   available-typed-arrays@1.0.7:
     resolution: {integrity: sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==}
     engines: {node: '>= 0.4'}
@@ -4424,6 +4431,10 @@ packages:
   file-entry-cache@8.0.0:
     resolution: {integrity: sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==}
     engines: {node: '>=16.0.0'}
+
+  file-selector@2.1.2:
+    resolution: {integrity: sha512-QgXo+mXTe8ljeqUFaX3QVHc5osSItJ/Km+xpocx0aSqWGMSCf6qYs/VnzZgS864Pjn5iceMRFigeAV7AfTlaig==}
+    engines: {node: '>= 12'}
 
   fill-range@7.1.1:
     resolution: {integrity: sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==}
@@ -5923,6 +5934,12 @@ packages:
     resolution: {integrity: sha512-4GV5sHFG0e/0AD4X+ySy6UJd3jVl1iNsNHdpad0qhABJ11twS3TTBnseqsKurKcsNqCEFeGL3uLpVChpIO3QfQ==}
     peerDependencies:
       react: ^19.0.0
+
+  react-dropzone@14.3.8:
+    resolution: {integrity: sha512-sBgODnq+lcA4P296DY4wacOZz3JFpD99fp+hb//iBO2HHnyeZU3FwWyXJ6salNpqQdsZrgMrotuko/BdJMV8Ug==}
+    engines: {node: '>= 10.13'}
+    peerDependencies:
+      react: '>= 16.8 || 18.0.0'
 
   react-hook-form@7.54.2:
     resolution: {integrity: sha512-eHpAUgUjWbZocoQYUHposymRb4ZP6d0uwUnooL2uOybA9/3tPUvoAKqEWK1WaSiTxxOfTpffNZP7QwlnM3/gEg==}
@@ -10752,6 +10769,8 @@ snapshots:
 
   asynckit@0.4.0: {}
 
+  attr-accept@2.2.5: {}
+
   available-typed-arrays@1.0.7:
     dependencies:
       possible-typed-array-names: 1.1.0
@@ -11598,6 +11617,10 @@ snapshots:
   file-entry-cache@8.0.0:
     dependencies:
       flat-cache: 4.0.1
+
+  file-selector@2.1.2:
+    dependencies:
+      tslib: 2.8.1
 
   fill-range@7.1.1:
     dependencies:
@@ -13351,6 +13374,13 @@ snapshots:
     dependencies:
       react: 19.0.0
       scheduler: 0.25.0
+
+  react-dropzone@14.3.8(react@19.0.0):
+    dependencies:
+      attr-accept: 2.2.5
+      file-selector: 2.1.2
+      prop-types: 15.8.1
+      react: 19.0.0
 
   react-hook-form@7.54.2(react@19.0.0):
     dependencies:


### PR DESCRIPTION
Drag and drop files

https://github.com/user-attachments/assets/1b3a0c9e-1f1d-415b-b2c6-c9cd9ce35034

In case file is not supported nothing happens:

https://github.com/user-attachments/assets/87c5d613-6a53-42db-875f-f8e8a2e411f4


- Added react-dropzone to enable drag-and-drop file uploads.
- Implemented file acceptance criteria for images, PDFs, DOC, DOCX, and TXT files.
- Enhanced UI to provide visual feedback during file attachment process.
- Updated ConversationsList component to manage file attachments more effectively.

@slavingia Should we also add frontend validations to prevent uploading, for example, files larger than 5 MB each?


