### PR TITLE
Add column `external_id` to table dividends

### DIFF
--- a/backend/app/models/dividend.rb
+++ b/backend/app/models/dividend.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class Dividend < ApplicationRecord
+  include ExternalId
+
   belongs_to :company
   belongs_to :dividend_round
   belongs_to :company_investor

--- a/backend/db/migrate/20250821084120_add_external_id_to_dividend.rb
+++ b/backend/db/migrate/20250821084120_add_external_id_to_dividend.rb
@@ -1,0 +1,5 @@
+class AddExternalIdToDividend < ActiveRecord::Migration[8.0]
+  def change
+    add_column :dividends, :external_id, :string
+  end
+end

--- a/backend/db/schema.rb
+++ b/backend/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_08_18_160001) do
+ActiveRecord::Schema[8.0].define(version: 2025_08_21_084120) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -368,6 +368,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_08_18_160001) do
     t.bigint "qualified_amount_cents", null: false
     t.datetime "signed_release_at"
     t.bigint "investment_amount_cents"
+    t.string "external_id"
     t.index ["company_id"], name: "index_dividends_on_company_id"
     t.index ["company_investor_id"], name: "index_dividends_on_company_investor_id"
     t.index ["dividend_round_id"], name: "index_dividends_on_dividend_round_id"

--- a/frontend/db/schema.ts
+++ b/frontend/db/schema.ts
@@ -449,6 +449,7 @@ export const dividends = pgTable(
     qualifiedAmountCents: bigint("qualified_amount_cents", { mode: "bigint" }).notNull(),
     signedReleaseAt: timestamp("signed_release_at", { precision: 6, mode: "date" }),
     investmentAmountCents: bigint("investment_amount_cents", { mode: "bigint" }),
+    externalId: varchar("external_id").$default(nanoid),
   },
   (table) => [
     index("index_dividends_on_company_id").using("btree", table.companyId.asc().nullsLast().op("int8_ops")),


### PR DESCRIPTION
Follows https://github.com/antiwork/flexile/pull/767

I noticed we expose the ID when reviewing that PR, so I had made a note to fix it.

We need to add this column and populate it. Then we can make all dividend/dividend_computation pages use the external ID in the URL.