### PR TITLE
Fix failing specs

### DIFF
--- a/backend/app/models/tender_offer.rb
+++ b/backend/app/models/tender_offer.rb
@@ -13,6 +13,7 @@ class TenderOffer < ApplicationRecord
   validates :attachment, presence: true
   validates :starts_at, presence: true
   validates :ends_at, presence: true
+  validates :letter_of_transmittal, presence: true
   validates :minimum_valuation, presence: true, numericality: { only_integer: true, greater_than_or_equal_to: 0 }
   validates :number_of_shares, numericality: { only_integer: true, greater_than_or_equal_to: 0 }, allow_nil: true
   validates :number_of_shareholders, numericality: { only_integer: true, greater_than: 0 }, allow_nil: true

--- a/backend/config/data/seed_templates/gumroad.json
+++ b/backend/config/data/seed_templates/gumroad.json
@@ -108,7 +108,8 @@
         }
       },
       "tender_offer": {
-        "minimum_valuation": 99000000
+        "minimum_valuation": 99000000,
+        "letter_of_transmittal": "<h1>Letter of transmittal</h1>"
       },
       "equity_buyback_rounds": [
         {

--- a/backend/spec/factories/tender_offers.rb
+++ b/backend/spec/factories/tender_offers.rb
@@ -7,5 +7,6 @@ FactoryBot.define do
     starts_at { 20.days.ago }
     ends_at { 10.days.from_now }
     minimum_valuation { 100_000 }
+    letter_of_transmittal { "<h1>Letter of transmittal</h1>" }
   end
 end

--- a/backend/spec/models/tender_offer_spec.rb
+++ b/backend/spec/models/tender_offer_spec.rb
@@ -12,6 +12,7 @@ RSpec.describe TenderOffer do
     it { is_expected.to validate_presence_of(:starts_at) }
     it { is_expected.to validate_presence_of(:ends_at) }
     it { is_expected.to validate_presence_of(:minimum_valuation) }
+    it { is_expected.to validate_presence_of(:letter_of_transmittal) }
     it { is_expected.to validate_numericality_of(:minimum_valuation).only_integer.is_greater_than_or_equal_to(0) }
     it { is_expected.to validate_numericality_of(:number_of_shares).only_integer.is_greater_than_or_equal_to(0).allow_nil }
     it { is_expected.to validate_numericality_of(:number_of_shareholders).only_integer.is_greater_than(0).allow_nil }

--- a/backend/spec/services/create_tender_offer_spec.rb
+++ b/backend/spec/services/create_tender_offer_spec.rb
@@ -8,6 +8,7 @@ RSpec.describe CreateTenderOffer do
       ends_at: Date.new(2024, 12, 30).to_s,
       minimum_valuation: 1_000_000.to_s,
       attachment: fixture_file_upload("sample.zip"),
+      letter_of_transmittal: "<h1>Letter of transmittal</h1>",
     }
   end
 


### PR DESCRIPTION
Introduced a change on https://github.com/antiwork/flexile/commit/1a1280e3d96cd4f96a67486065eddafdc5a8fbf7 that's now causing specs to fail, this addresses the issue.

<img width="1281" height="558" alt="image" src="https://github.com/user-attachments/assets/4d8ef9ce-b6f6-4b03-8ad2-6548c3f065e0" />
