### PR TITLE
fix: incorrect contract ended date

### DIFF
--- a/frontend/app/(dashboard)/people/[id]/page.tsx
+++ b/frontend/app/(dashboard)/people/[id]/page.tsx
@@ -48,7 +48,7 @@ import { trpc } from "@/trpc/client";
 import { formatMoney, formatMoneyFromCents } from "@/utils/formatMoney";
 import { request } from "@/utils/request";
 import { approve_company_invoices_path, company_equity_exercise_payment_path } from "@/utils/routes";
-import { formatDate } from "@/utils/time";
+import { formatDate, formatServerDate } from "@/utils/time";
 import { useIsMobile } from "@/utils/use-mobile";
 import FormFields, { schema as formSchema } from "../FormFields";
 
@@ -490,7 +490,8 @@ const DetailsTab = ({
               <AlertTriangle />
               <AlertDescription>
                 <div className="flex items-center justify-between">
-                  Contract {isFuture(contractor.endedAt) ? "ends" : "ended"} on {formatDate(contractor.endedAt)}.
+                  Contract {isFuture(contractor.endedAt) ? "ends" : "ended"} on{" "}
+                  {formatDate(formatServerDate(contractor.endedAt))}.
                   {isFuture(contractor.endedAt) && (
                     <Button variant="outline" onClick={() => setCancelModalOpen(true)}>
                       Cancel contract end

--- a/frontend/app/(dashboard)/people/page.tsx
+++ b/frontend/app/(dashboard)/people/page.tsx
@@ -34,7 +34,7 @@ import { Switch } from "@/components/ui/switch";
 import { useCurrentCompany } from "@/global";
 import { countries } from "@/models/constants";
 import { DocumentTemplateType, PayRateType, trpc } from "@/trpc/client";
-import { formatDate } from "@/utils/time";
+import { formatDate, formatServerDate } from "@/utils/time";
 import { useIsMobile } from "@/utils/use-mobile";
 import FormFields, { schema as formSchema } from "./FormFields";
 import InviteLinkModal from "./InviteLinkModal";
@@ -121,11 +121,11 @@ export default function PeoplePage() {
         meta: { filterOptions: ["Active", "Onboarding", "Alumni"] },
         cell: (info) =>
           info.row.original.endedAt ? (
-            <Status variant="critical">Ended on {formatDate(info.row.original.endedAt)}</Status>
+            <Status variant="critical">Ended on {formatDate(formatServerDate(info.row.original.endedAt))}</Status>
           ) : info.row.original.startedAt <= new Date() ? (
-            <Status variant="success">Started on {formatDate(info.row.original.startedAt)}</Status>
+            <Status variant="success">Started on {formatDate(formatServerDate(info.row.original.startedAt))}</Status>
           ) : info.row.original.user.onboardingCompleted ? (
-            <Status variant="success">Starts on {formatDate(info.row.original.startedAt)}</Status>
+            <Status variant="success">Starts on {formatDate(formatServerDate(info.row.original.startedAt))}</Status>
           ) : info.row.original.user.invitationAcceptedAt ? (
             <Status variant="primary">In Progress</Status>
           ) : (


### PR DESCRIPTION
Resolves https://github.com/antiwork/flexile/issues/868

### Root cause
The `contractor.endedAt` is a server date but was not properly formatted as a server date using `formatServerDate` before getting displayed. So the displayed end date was shifted backwards when the timezone is `UTC−08:00`/`UTC−07:00` because the front-end tries to convert an UTC date to a date of such timezone.

This doesn't happen on CI because on CI the browser date is also UTC.
`
### Before
The contract end date was set to Aug 21.
<img width="1005" height="50" alt="Screenshot 2025-08-21 at 9 14 08 AM" src="https://github.com/user-attachments/assets/80c7131c-90e2-48f0-ac34-708fef0d27fa" />


### After
<img width="1001" height="50" alt="Screenshot 2025-08-21 at 9 13 37 AM" src="https://github.com/user-attachments/assets/7df5c9d9-03af-4aeb-99fc-19aad135c58f" />

### E2e tests still passing
<img width="976" height="86" alt="Screenshot 2025-08-21 at 9 19 18 AM" src="https://github.com/user-attachments/assets/9ac443f9-b338-4002-a784-65911ed039d1" />

