### PR TITLE
feat: Implement place bid modal for buybacks/tender offers with multistep flow

### DIFF
--- a/e2e/factories/tenderOffers.ts
+++ b/e2e/factories/tenderOffers.ts
@@ -1,0 +1,48 @@
+import { faker } from "@faker-js/faker";
+import { db } from "@test/db";
+import { companiesFactory } from "@test/factories/companies";
+import { addDays, subDays } from "date-fns";
+import { activeStorageAttachments, activeStorageBlobs, tenderOffers } from "@/db/schema";
+import { assert } from "@/utils/assert";
+
+export const tenderOffersFactory = {
+  create: async (overrides: Partial<typeof tenderOffers.$inferInsert> = {}) => {
+    const companyId = overrides.companyId || (await companiesFactory.create()).company.id;
+
+    const startsAt = overrides.startsAt || subDays(new Date(), 5);
+    const endsAt = overrides.endsAt || addDays(new Date(), 1);
+
+    const [createdTenderOffer] = await db
+      .insert(tenderOffers)
+      .values({
+        companyId,
+        startsAt,
+        endsAt,
+        minimumValuation: 100000n,
+        letterOfTransmittal: overrides.letterOfTransmittal || faker.lorem.paragraph(),
+        ...overrides,
+      })
+      .returning();
+    assert(createdTenderOffer !== undefined);
+
+    const [blob] = await db
+      .insert(activeStorageBlobs)
+      .values({
+        key: `${createdTenderOffer.externalId}-tender-offer-attachment`,
+        filename: "attachment.zip",
+        serviceName: "test",
+        byteSize: 100n,
+        contentType: "application/zip",
+      })
+      .returning();
+    assert(blob !== undefined);
+    await db.insert(activeStorageAttachments).values({
+      recordId: createdTenderOffer.id,
+      recordType: "TenderOffer",
+      blobId: blob.id,
+      name: "attachment",
+    });
+
+    return { tenderOffer: createdTenderOffer };
+  },
+};

--- a/e2e/helpers/money.ts
+++ b/e2e/helpers/money.ts
@@ -1,0 +1,17 @@
+import { Decimal } from "decimal.js";
+
+export const formatMoney = (
+  price: number | bigint | string | Decimal,
+  options?: { precise: boolean },
+  currency = "USD",
+) =>
+  new Intl.NumberFormat(undefined, {
+    style: "currency",
+    currency,
+    trailingZeroDisplay: "stripIfInteger",
+    currencyDisplay: "narrowSymbol",
+    maximumFractionDigits: options?.precise ? 10 : undefined,
+  }).format(price instanceof Decimal ? price.toString() : price);
+
+export const formatMoneyFromCents = (cents: number | bigint | string | Decimal, options?: { precise: boolean }) =>
+  formatMoney(Number(cents) / 100, options);

--- a/e2e/tests/company/tender-offers/creation.spec.ts
+++ b/e2e/tests/company/tender-offers/creation.spec.ts
@@ -24,10 +24,8 @@ test.describe("Buyback creation", () => {
       })
       .then(takeOrThrow);
 
-    await login(page, user);
+    await login(page, user, "/equity/tender_offers");
 
-    await page.getByRole("button", { name: "Equity" }).click();
-    await page.getByRole("link", { name: "Buybacks" }).click();
     await page.getByRole("link", { name: "New buyback" }).click();
 
     const startDate = new Date();
@@ -50,9 +48,7 @@ test.describe("Buyback creation", () => {
         name: new RegExp(`${format(startDate, "MMM d, yyyy")}.*${format(endDate, "MMM d, yyyy")}.*\\$100,000,000`, "u"),
       })
       .click();
-
-    await expect(page.getByRole("article", { name: "Letter of transmittal" })).toContainText(letterOfTransmittal, {
-      useInnerText: true,
-    });
+    await expect(page).toHaveURL(/\/equity\/tender_offers\/.*/u);
+    await expect(page.getByRole("button", { name: "Place bid" })).toBeVisible();
   });
 });

--- a/e2e/tests/company/tender-offers/place-bid.spec.ts
+++ b/e2e/tests/company/tender-offers/place-bid.spec.ts
@@ -1,0 +1,97 @@
+import { faker } from "@faker-js/faker";
+import { db, takeOrThrow } from "@test/db";
+import { companiesFactory } from "@test/factories/companies";
+import { companyAdministratorsFactory } from "@test/factories/companyAdministrators";
+import { companyInvestorsFactory } from "@test/factories/companyInvestors";
+import { shareHoldingsFactory } from "@test/factories/shareHoldings";
+import { tenderOffersFactory } from "@test/factories/tenderOffers";
+import { login } from "@test/helpers/auth";
+import { formatMoney } from "@test/helpers/money";
+import { expect, test, withinModal } from "@test/index";
+import { addDays, format } from "date-fns";
+import { eq } from "drizzle-orm";
+import { companies, companyInvestors, users } from "@/db/schema";
+
+test.describe("Tender offer place bid", () => {
+  let company: typeof companies.$inferSelect;
+  let companyInvestor: typeof companyInvestors.$inferSelect;
+  let investorUser: typeof users.$inferSelect;
+  test.beforeAll(async () => {
+    company = (await companiesFactory.create({ equityEnabled: true })).company;
+    await companyAdministratorsFactory.create({ companyId: company.id });
+    companyInvestor = (
+      await companyInvestorsFactory.create({
+        companyId: company.id,
+        totalShares: 100000000n,
+        investmentAmountInCents: 100000000n,
+      })
+    ).companyInvestor;
+
+    investorUser = await db.query.users.findFirst({ where: eq(users.id, companyInvestor.userId) }).then(takeOrThrow);
+
+    await shareHoldingsFactory.create({
+      companyInvestorId: companyInvestor.id,
+      name: "SH-1",
+    });
+  });
+
+  test("allows investor to place bid on tender offer", async ({ page }) => {
+    const minimumValuation = 1000000;
+    const numberOfShares = 50;
+    const bidPrice = 20;
+    const startDate = new Date();
+    const endDate = addDays(new Date(), 30);
+    const letterOfTransmittal = faker.lorem.paragraphs();
+
+    await tenderOffersFactory.create({
+      companyId: company.id,
+      totalAmountInCents: BigInt(minimumValuation * 100),
+      minimumValuation: BigInt(minimumValuation),
+      startsAt: startDate,
+      endsAt: endDate,
+      letterOfTransmittal,
+    });
+
+    await login(page, investorUser, "/equity/tender_offers");
+
+    const row = page.getByRole("row", {
+      name: new RegExp(`${format(startDate, "MMM d, yyyy")}.*${format(endDate, "MMM d, yyyy")}.*\\$1,000,000`, "u"),
+    });
+
+    await row.getByRole("button", { name: "Place bid" }).click();
+
+    await withinModal(
+      async (modal) => {
+        await expect(modal.getByText("Buyback details")).toBeVisible();
+        await expect(modal.getByText("Start date")).toBeVisible();
+        await expect(modal.getByText("End date")).toBeVisible();
+        await expect(modal.getByText("Starting valuation")).toBeVisible();
+        await expect(modal.getByText(formatMoney(minimumValuation))).toBeVisible();
+        await expect(modal.getByText("Starting price per share")).toBeVisible();
+
+        await modal.getByRole("button", { name: "Continue" }).click();
+        await expect(modal.getByRole("article", { name: "Letter of transmittal" })).toContainText(letterOfTransmittal, {
+          useInnerText: true,
+        });
+        await modal.getByRole("button", { name: "Add your signature" }).click();
+        await modal.getByRole("checkbox", { name: /I've reviewed the/u }).click();
+        await modal.getByRole("button", { name: "Continue" }).click();
+        await page.getByRole("combobox", { name: "Share class" }).click();
+        await page.getByRole("option").first().click();
+        await modal.getByLabel("Number of shares").fill(`${numberOfShares}`);
+        await modal.getByLabel("Price per share").fill(`${bidPrice}`);
+        await modal.getByRole("button", { name: "Submit bid" }).click();
+        await modal.waitFor({ state: "detached" });
+      },
+      { page, title: "Buyback details" },
+    );
+
+    await row.click();
+
+    await expect(
+      page.getByRole("row", {
+        name: new RegExp(`${numberOfShares}.*\\$${bidPrice}`, "u"),
+      }),
+    ).toBeVisible();
+  });
+});

--- a/frontend/app/(dashboard)/equity/tender_offers/[id]/PlaceBidModal.tsx
+++ b/frontend/app/(dashboard)/equity/tender_offers/[id]/PlaceBidModal.tsx
@@ -1,0 +1,371 @@
+import { zodResolver } from "@hookform/resolvers/zod";
+import Decimal from "decimal.js";
+import { Download } from "lucide-react";
+import Link from "next/link";
+import { useMemo, useState } from "react";
+import { useForm } from "react-hook-form";
+import { z } from "zod";
+import { VESTED_SHARES_CLASS } from "@/app/(dashboard)/equity/tender_offers";
+import ComboBox from "@/components/ComboBox";
+import { MutationStatusButton } from "@/components/MutationButton";
+import NumberInput from "@/components/NumberInput";
+import SignForm from "@/components/SignForm";
+import { Button } from "@/components/ui/button";
+import { Checkbox } from "@/components/ui/checkbox";
+import {
+  Dialog,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogStackContent,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Form, FormControl, FormField, FormItem, FormLabel, FormMessage } from "@/components/ui/form";
+import { useCurrentCompany, useCurrentUser } from "@/global";
+import type { RouterOutput } from "@/trpc";
+import { trpc } from "@/trpc/client";
+import { formatMoney } from "@/utils/formatMoney";
+import { formatDate } from "@/utils/time";
+
+type TenderOffer = RouterOutput["tenderOffers"]["get"];
+
+type PlaceBidModalProps = {
+  tenderOfferId: string;
+  onClose: () => void;
+  data: TenderOffer;
+};
+
+type ConfirmationSectionProps = {
+  onNext: () => void;
+  data: TenderOffer;
+};
+
+type LetterOfTransmittalSectionProps = {
+  onBack: () => void;
+  onNext: () => void;
+  data: TenderOffer;
+};
+
+type SubmitBidSectionProps = {
+  tenderOfferId: string;
+  onBack: () => void;
+  data: TenderOffer;
+  mutation: ReturnType<typeof trpc.tenderOffers.bids.create.useMutation>;
+};
+
+const formSchema = z.object({
+  shareClass: z.string().min(1, "This field is required"),
+  numberOfShares: z.number().min(1),
+  pricePerShare: z.number().min(0),
+});
+
+type BuybackBidFormValues = z.infer<typeof formSchema>;
+
+const PlaceTenderOfferBidModal = ({ onClose, data, tenderOfferId }: PlaceBidModalProps) => {
+  const [currentStep, setCurrentStep] = useState(0);
+
+  const createMutation = trpc.tenderOffers.bids.create.useMutation({
+    onSuccess: () => {
+      onClose();
+    },
+  });
+
+  const goToNextStep = () => {
+    setCurrentStep(currentStep + 1);
+  };
+
+  const goToPreviousStep = () => {
+    setCurrentStep(currentStep - 1);
+  };
+
+  return (
+    <Dialog open onOpenChange={onClose}>
+      <DialogStackContent step={currentStep}>
+        <ConfirmationSection data={data} onNext={goToNextStep} />
+
+        <LetterOfTransmittalSection onBack={goToPreviousStep} onNext={goToNextStep} data={data} />
+
+        <SubmitBidSection
+          onBack={goToPreviousStep}
+          data={data}
+          mutation={createMutation}
+          tenderOfferId={tenderOfferId}
+        />
+      </DialogStackContent>
+    </Dialog>
+  );
+};
+
+const ConfirmationSection = ({ onNext, data }: ConfirmationSectionProps) => {
+  const company = useCurrentCompany();
+  return (
+    <>
+      <DialogHeader>
+        <DialogTitle>Buyback details</DialogTitle>
+        <DialogDescription>
+          Review the buyback terms below and continue to confirm your participation.
+        </DialogDescription>
+      </DialogHeader>
+
+      <div className="space-y-0">
+        <div className="flex justify-between border-b border-gray-200 pb-4">
+          <span className="font-medium">Start date</span>
+          <span>{formatDate(data.startsAt)}</span>
+        </div>
+
+        <div className="flex justify-between border-b border-gray-200 py-4">
+          <span className="font-medium">End date</span>
+          <span>{formatDate(data.endsAt)}</span>
+        </div>
+
+        {data.minimumValuation ? (
+          <div className="flex justify-between border-b border-gray-200 py-4">
+            <span className="font-medium">Starting valuation</span>
+            <span>{formatMoney(data.minimumValuation)}</span>
+          </div>
+        ) : null}
+
+        {company.fullyDilutedShares && data.minimumValuation ? (
+          <div className="flex justify-between border-b border-gray-200 py-4">
+            <span className="font-medium">Starting price per share</span>
+            <span>{formatMoney(new Decimal(data.minimumValuation.toString()).div(company.fullyDilutedShares))}</span>
+          </div>
+        ) : null}
+
+        {data.attachment ? (
+          <div className="flex justify-between border-b border-gray-200 py-4">
+            <span className="font-medium">Buyback documents</span>
+            <Button asChild variant="outline" size="small">
+              <Link href={`/download/${data.attachment.key}/${data.attachment.filename}`}>
+                <Download className="size-4" />
+                Download
+              </Link>
+            </Button>
+          </div>
+        ) : null}
+      </div>
+
+      <DialogFooter className="mt-4 flex flex-col-reverse gap-2 sm:flex-row sm:justify-end sm:gap-0">
+        <Button onClick={onNext} className="w-full sm:w-auto">
+          Continue
+        </Button>
+      </DialogFooter>
+    </>
+  );
+};
+
+const LetterOfTransmittalSection = ({ onBack, onNext, data }: LetterOfTransmittalSectionProps) => {
+  const [reviewed, setReviewed] = useState(false);
+  const [signed, setSigned] = useState(false);
+  const [showDocument, setShowDocument] = useState(true);
+
+  const canContinue = reviewed && signed;
+
+  return (
+    <>
+      <DialogHeader>
+        <DialogTitle>Letter of transmittal</DialogTitle>
+        <DialogDescription>
+          Review and sign the Letter of Transmittal to confirm your participation in this buyback.
+        </DialogDescription>
+      </DialogHeader>
+
+      <div className="flex min-h-0 flex-1 flex-col">
+        {showDocument ? (
+          <article aria-label="Letter of transmittal">
+            <SignForm content={data.letterOfTransmittal} signed={signed} onSign={() => setSigned(true)} />
+          </article>
+        ) : null}
+
+        <div className="mt-auto grid shrink-0 gap-4 pt-4">
+          <div className="flex items-start space-x-2">
+            <Checkbox
+              id="reviewed"
+              checked={reviewed}
+              onCheckedChange={() => setReviewed(!reviewed)}
+              className="shrink-0"
+            />
+            <label htmlFor="reviewed" className="cursor-pointer text-sm leading-tight font-medium">
+              I've reviewed the{" "}
+              <span
+                className="text-blue-600 underline hover:text-blue-800"
+                onClick={(e) => {
+                  e.stopPropagation();
+                  e.preventDefault();
+                  setShowDocument(!showDocument);
+                }}
+              >
+                Letter of Transmittal
+              </span>
+            </label>
+          </div>
+        </div>
+      </div>
+
+      <DialogFooter className="mt-4 flex shrink-0 flex-col-reverse gap-2 sm:flex-row sm:justify-end sm:gap-2">
+        <Button variant="outline" onClick={onBack} className="w-full sm:w-24">
+          Back
+        </Button>
+        <Button
+          onClick={() => onNext()}
+          disabled={!canContinue}
+          className={`w-full sm:w-24 ${!canContinue ? "cursor-not-allowed opacity-50" : ""}`}
+        >
+          Continue
+        </Button>
+      </DialogFooter>
+    </>
+  );
+};
+
+const SubmitBidSection = ({ onBack, mutation, data, tenderOfferId }: SubmitBidSectionProps) => {
+  const company = useCurrentCompany();
+  const user = useCurrentUser();
+  const investorId = user.roles.investor?.id;
+
+  const { data: ownShareHoldings } = trpc.shareHoldings.sumByShareClass.useQuery(
+    { companyId: company.id, investorId },
+    { enabled: !!investorId },
+  );
+  const { data: ownTotalVestedShares } = trpc.equityGrants.sumVestedShares.useQuery(
+    { companyId: company.id, investorId },
+    { enabled: !!investorId },
+  );
+
+  const holdings = useMemo(
+    () =>
+      [
+        ...(ownShareHoldings || []),
+        ...(ownTotalVestedShares ? [{ className: VESTED_SHARES_CLASS, count: ownTotalVestedShares }] : []),
+      ].filter(Boolean),
+    [ownShareHoldings, ownTotalVestedShares],
+  );
+
+  const form = useForm<BuybackBidFormValues>({
+    defaultValues: { shareClass: holdings[0]?.className ?? "", pricePerShare: 0, numberOfShares: 0 },
+    resolver: zodResolver(formSchema),
+  });
+
+  const numberOfShares = form.watch("numberOfShares") || 0;
+  const pricePerShare = form.watch("pricePerShare") || 0;
+  const shareClass = form.watch("shareClass");
+  const maxShares = holdings.find((h) => h.className === shareClass)?.count || 0;
+  const impliedValuation = company.fullyDilutedShares ? company.fullyDilutedShares * pricePerShare : 0;
+  const totalAmount = new Decimal(numberOfShares).mul(pricePerShare || 0);
+
+  const handleSubmit = form.handleSubmit((values) => {
+    if (new Decimal(values.numberOfShares).gt(maxShares)) {
+      return form.setError("numberOfShares", {
+        message: `Number of shares must be between 1 and ${maxShares.toLocaleString()}`,
+      });
+    }
+    if (data.minimumValuation && company.fullyDilutedShares && impliedValuation < data.minimumValuation) {
+      return form.setError("pricePerShare", {
+        message: `Price per share must be at least ${formatMoney(
+          new Decimal(data.minimumValuation.toString()).div(company.fullyDilutedShares),
+        )}`,
+      });
+    }
+    mutation.mutate({
+      companyId: company.id,
+      tenderOfferId,
+      shareClass: values.shareClass,
+      numberOfShares: values.numberOfShares,
+      sharePriceCents: Math.round(values.pricePerShare * 100),
+    });
+  });
+
+  return (
+    <>
+      <DialogHeader>
+        <DialogTitle>Place a bid</DialogTitle>
+        <DialogDescription>Submit an offer to sell your shares in this buyback event.</DialogDescription>
+      </DialogHeader>
+
+      <Form {...form}>
+        <form
+          onSubmit={(e) => void handleSubmit(e)}
+          className="flex flex-1 flex-col space-y-4 overflow-y-auto px-1 py-1"
+        >
+          <FormField
+            control={form.control}
+            name="shareClass"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>Share class</FormLabel>
+                <FormControl>
+                  <ComboBox
+                    {...field}
+                    placeholder="Select..."
+                    options={holdings.map((holding) => ({
+                      value: holding.className,
+                      label: `${holding.className} (${holding.count.toLocaleString()} shares)`,
+                    }))}
+                  />
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+
+          <div className="grid grid-cols-1 items-start gap-3 sm:grid-cols-2">
+            <FormField
+              control={form.control}
+              name="numberOfShares"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Number of shares</FormLabel>
+                  <FormControl>
+                    <NumberInput {...field} placeholder="0" />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+
+            <FormField
+              control={form.control}
+              name="pricePerShare"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Price per share</FormLabel>
+                  <FormControl>
+                    <NumberInput {...field} decimal prefix="$" placeholder="$ 0" />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+          </div>
+
+          <div className="mt-4 space-y-2">
+            <div className="flex justify-between text-sm">
+              <span className="font-medium">Implied company valuation</span>
+              <span>{formatMoney(impliedValuation)}</span>
+            </div>
+            <div className="flex justify-between text-sm">
+              <span className="font-medium">Total amount</span>
+              <span>{formatMoney(totalAmount)}</span>
+            </div>
+          </div>
+        </form>
+      </Form>
+
+      <DialogFooter className="mt-4 flex shrink-0 flex-col-reverse gap-2 sm:flex-row sm:justify-end sm:gap-2">
+        <Button variant="outline" onClick={onBack} className="w-full sm:w-24">
+          Back
+        </Button>
+        <MutationStatusButton
+          onClick={() => void handleSubmit()}
+          mutation={mutation}
+          className="w-full sm:w-auto"
+          disabled={!form.formState.isValid || !numberOfShares || !pricePerShare}
+        >
+          Submit bid
+        </MutationStatusButton>
+      </DialogFooter>
+    </>
+  );
+};
+
+export default PlaceTenderOfferBidModal;

--- a/frontend/components/ui/dialog.tsx
+++ b/frontend/components/ui/dialog.tsx
@@ -93,6 +93,83 @@ function DialogDescription({ className, ...props }: React.ComponentProps<typeof 
     <DialogPrimitive.Description data-slot="dialog-description" className={cn("text-base", className)} {...props} />
   );
 }
+type LayerConfig = {
+  scaleX: number;
+  offsetY: number;
+};
+
+type DialogStackContentProps = {
+  step: number;
+  children: React.ReactNode;
+} & React.ComponentProps<typeof DialogPrimitive.Content>;
+
+function DialogStackContent({ step, children, className, ...props }: DialogStackContentProps) {
+  const childrenArray = React.Children.toArray(children);
+  const totalSteps = childrenArray.length;
+
+  // Generate stack layers dynamically based on totalSteps
+  // Last layer: { scaleX: BASE_SCALE, offsetY: BASE_OFFSET }
+  // Each previous layer: reduce scaleX by SCALE_STEP, increase offsetY by OFFSET_STEP
+  const BASE_SCALE = 0.95;
+  const SCALE_STEP = 0.05;
+  const BASE_OFFSET = 20;
+  const OFFSET_STEP = 20;
+  const stackLayers: LayerConfig[] = Array.from({ length: totalSteps - 1 }, (_, i) => ({
+    scaleX: BASE_SCALE - (totalSteps - 2 - i) * SCALE_STEP,
+    offsetY: BASE_OFFSET + (totalSteps - 2 - i) * OFFSET_STEP,
+  }));
+
+  const layersToShow = stackLayers.slice(step);
+
+  return (
+    <DialogPrimitive.Portal data-slot="dialog-portal">
+      <DialogPrimitive.Overlay data-slot="dialog-overlay" className="fixed inset-0 z-40 overflow-auto bg-black/80">
+        <div className="mt-16 mb-10 flex w-full justify-center px-4">
+          <div className="relative w-full max-w-lg">
+            {layersToShow.map((layer, i) => (
+              <div
+                key={i}
+                className={cn(
+                  "bg-background absolute inset-0 rounded-lg shadow-[0_6px_24px_rgba(0,0,0,0.10),_0_9px_48px_rgba(0,0,0,0.08)] transition-transform duration-300",
+                )}
+                style={{
+                  transform: `translateY(-${layer.offsetY}px) scaleX(${layer.scaleX})`,
+                  zIndex: 10 + i,
+                }}
+              />
+            ))}
+
+            <DialogPrimitive.Content
+              data-slot="dialog-content"
+              className={cn(
+                "bg-background data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 relative z-50 w-full content-start rounded-lg p-8 shadow-[0_6px_24px_rgba(0,0,0,0.10),_0_9px_48px_rgba(0,0,0,0.08)] duration-200",
+                className,
+              )}
+              {...props}
+            >
+              {childrenArray.map((child, index) => (
+                <div
+                  key={index}
+                  className={cn("grid gap-4", index === step ? "grid" : "hidden")}
+                  data-slot="dialog-section"
+                >
+                  {child}
+                </div>
+              ))}
+              <DialogPrimitive.Close
+                data-slot="dialog-close"
+                className="ring-offset-background focus:ring-ring data-[state=open]:bg-accent data-[state=open]:text-muted-foreground absolute top-4 right-4 rounded-xs opacity-70 transition-opacity hover:opacity-100 focus:ring-2 focus:ring-offset-2 focus:outline-hidden disabled:pointer-events-none [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4"
+              >
+                <XIcon />
+                <span className="sr-only">Close</span>
+              </DialogPrimitive.Close>
+            </DialogPrimitive.Content>
+          </div>
+        </div>
+      </DialogPrimitive.Overlay>
+    </DialogPrimitive.Portal>
+  );
+}
 export {
   Dialog,
   DialogClose,
@@ -102,6 +179,7 @@ export {
   DialogHeader,
   DialogOverlay,
   DialogPortal,
+  DialogStackContent,
   DialogTitle,
   DialogTrigger,
 };


### PR DESCRIPTION
In part for https://github.com/antiwork/flexile/issues/96, allows investors participate in buybacks by placing a bid via a modal, rather than the current clogged up page

#### e2e

<img width="1283" height="190" alt="image" src="https://github.com/user-attachments/assets/39b4a53f-f55d-46f3-9ace-650655b9cc7f" />

#### before

https://github.com/user-attachments/assets/6795df38-3708-4434-9efb-43870a539ee2

#### after

https://github.com/user-attachments/assets/e934f41f-b7c9-4939-8b15-e5e0e4c8f85d

