### PR TITLE
Fix incorrect padding for verify bank banner

### DIFF
--- a/frontend/app/settings/administrator/StripeMicrodepositVerification.tsx
+++ b/frontend/app/settings/administrator/StripeMicrodepositVerification.tsx
@@ -78,7 +78,9 @@ const StripeMicrodepositVerification = () => {
         <AlertTitle>Verify your bank account to enable contractor payments</AlertTitle>
         <AlertDescription>
           <p>To ensure seamless payments to your contractors, we need to confirm your bank account details.</p>
-          <Button onClick={() => setShowVerificationModal(true)}>Verify bank account</Button>
+          <p>
+            <Button onClick={() => setShowVerificationModal(true)}>Verify bank account</Button>
+          </p>
         </AlertDescription>
       </Alert>
 

--- a/frontend/app/settings/administrator/StripeMicrodepositVerification.tsx
+++ b/frontend/app/settings/administrator/StripeMicrodepositVerification.tsx
@@ -74,7 +74,7 @@ const StripeMicrodepositVerification = () => {
 
   return !microdepositVerificationDetails || microdepositVerification.isSuccess ? null : (
     <>
-      <Alert>
+      <Alert className="mx-4">
         <AlertTitle>Verify your bank account to enable contractor payments</AlertTitle>
         <AlertDescription>
           <p>To ensure seamless payments to your contractors, we need to confirm your bank account details.</p>


### PR DESCRIPTION
Before:
<img width="1951" height="454" alt="image" src="https://github.com/user-attachments/assets/b38e0fcc-65e2-49d9-9d56-c8536ca76cf7" />

After:
<img width="2058" height="550" alt="image" src="https://github.com/user-attachments/assets/963249a9-7835-43db-8053-71db71f85984" />

Closes #989

Also @slavingia I'm not sure if this is official yet, but I saw on X you want AI disclosures. AI was used in this PR to quickly find the correct component, make the change, and set up a temporary mock so that the banner would display in my testing environment when it otherwise would not.