### PR TITLE
Fix microdeposit verification modal spacing and text formatting

### DIFF
--- a/frontend/app/settings/administrator/StripeMicrodepositVerification.tsx
+++ b/frontend/app/settings/administrator/StripeMicrodepositVerification.tsx
@@ -95,7 +95,7 @@ const StripeMicrodepositVerification = () => {
             </p>
           ) : (
             <p>
-              Check your {microdepositVerificationDetails.bank_account_number || ""} bank account for
+              Check your {microdepositVerificationDetails.bank_account_number || ""} bank account for{" "}
               <strong>two deposits</strong> from Stripe on {arrivalDate}. The transactions' description will read
               "ACCTVERIFY".
             </p>
@@ -150,7 +150,7 @@ const StripeMicrodepositVerification = () => {
                 </div>
               )}
 
-              <DialogFooter>
+              <DialogFooter className="mt-6">
                 <MutationStatusButton type="submit" loadingText="Submitting..." mutation={microdepositVerification}>
                   Submit
                 </MutationStatusButton>


### PR DESCRIPTION
Closes #990

Before:
<img width="585" height="536" alt="Screenshot 2025-08-21 at 2 09 34 PM" src="https://github.com/user-attachments/assets/7b5e5376-1ff9-4364-a30b-fbf2b4a8cf05" />

After:
<img width="668" height="549" alt="Screenshot 2025-08-21 at 2 17 26 PM" src="https://github.com/user-attachments/assets/410ab8ff-4a2a-4b31-bdac-5ff85648f4b6" />

Repeating what I said in #992:
AI was used in this PR to quickly find the correct component, make the change, and set up a temporary mock so that the banner and modal would display in my testing environment when it otherwise would not.
