### PR TITLE
Fix microdeposit modal inconsistent spacing form pattern

### DIFF
--- a/frontend/app/settings/administrator/StripeMicrodepositVerification.tsx
+++ b/frontend/app/settings/administrator/StripeMicrodepositVerification.tsx
@@ -105,7 +105,7 @@ const StripeMicrodepositVerification = () => {
           <p>If {isDescriptorCode ? "it's" : "they're"} not visible yet, please check in 1-2 days.</p>
 
           <Form {...form}>
-            <form onSubmit={(e) => void submit(e)}>
+            <form onSubmit={(e) => void submit(e)} className="space-y-4">
               {isDescriptorCode ? (
                 <FormField
                   control={form.control}
@@ -151,7 +151,7 @@ const StripeMicrodepositVerification = () => {
                 </div>
               )}
 
-              <DialogFooter className="mt-6">
+              <DialogFooter>
                 <MutationStatusButton type="submit" loadingText="Submitting..." mutation={microdepositVerification}>
                   Submit
                 </MutationStatusButton>


### PR DESCRIPTION
[DialogContent](https://github.com/antiwork/flexile/blob/main/frontend/components/ui/dialog.tsx#L46C232-L46C238) already has `gap-4` but it applies to direct children only. In this case, the footer is inside a form so we lose the consistency.

This makes the form more consistent with the rest of the codebase and shadcn defaults.

Before:
<img width="626" height="512" alt="before-screenshot" src="https://github.com/user-attachments/assets/ae328dfd-f608-4183-baf1-adab6ad4d4f8" />

After:
<img width="768" height="557" alt="after-screenshot" src="https://github.com/user-attachments/assets/75dbd88a-52bd-4620-a019-7ac1d8cd0b39" />
