### PR TITLE
Migrate QuickBooks integration from Inngest to Sidekiq background jobs

### DIFF
--- a/backend/app/controllers/internal/companies/administrator/quickbooks_controller.rb
+++ b/backend/app/controllers/internal/companies/administrator/quickbooks_controller.rb
@@ -62,6 +62,9 @@ class Internal::Companies::Administrator::QuickbooksController < Internal::Compa
       company.attributes = company_params[:company]
     end
     if @quickbooks_integration.update(quickbooks_integration_params) && company.save
+      # Trigger QuickBooks integration sync via Sidekiq
+      QuickbooksIntegrationSyncScheduleJob.perform_async(company.id)
+
       render json: { success: true, quickbooks_integration: @quickbooks_integration.as_json }
     else
       render json: { success: false }

--- a/backend/spec/sidekiq/quickbooks_data_sync_job_spec.rb
+++ b/backend/spec/sidekiq/quickbooks_data_sync_job_spec.rb
@@ -1,0 +1,108 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe QuickbooksDataSyncJob, type: :job do
+  describe "#perform" do
+    let(:company) { create(:company) }
+    let(:company_id) { company.id }
+    let!(:integration) { create(:quickbooks_integration, company:) }
+    let(:contractor) { create(:company_worker, company:) }
+
+    before do
+      allow(IntegrationApi::Quickbooks).to receive(:new).and_return(double(sync_data_for: true))
+    end
+
+    context "with CompanyContractor object type" do
+      it "converts CompanyContractor to CompanyWorker and syncs" do
+        integration_api = instance_double(IntegrationApi::Quickbooks)
+        expect(IntegrationApi::Quickbooks).to receive(:new).with(company_id:).and_return(integration_api)
+        expect(integration_api).to receive(:sync_data_for).with(object: contractor)
+
+        described_class.new.perform(company_id, "CompanyContractor", contractor.id)
+      end
+    end
+
+    context "with CompanyWorker object type" do
+      it "syncs the contractor directly" do
+        integration_api = instance_double(IntegrationApi::Quickbooks)
+        expect(IntegrationApi::Quickbooks).to receive(:new).with(company_id:).and_return(integration_api)
+        expect(integration_api).to receive(:sync_data_for).with(object: contractor)
+
+        described_class.new.perform(company_id, "CompanyWorker", contractor.id)
+      end
+    end
+
+    context "with Invoice object type" do
+      let(:invoice) { create(:invoice, company:, user: contractor.user) }
+
+      it "syncs the invoice" do
+        integration_api = instance_double(IntegrationApi::Quickbooks)
+        expect(IntegrationApi::Quickbooks).to receive(:new).with(company_id:).and_return(integration_api)
+        expect(integration_api).to receive(:sync_data_for).with(object: invoice)
+
+        described_class.new.perform(company_id, "Invoice", invoice.id)
+      end
+    end
+
+    context "with Payment object type" do
+      let(:invoice) { create(:invoice, company:, user: contractor.user) }
+      let(:payment) { create(:payment, invoice:) }
+
+      it "syncs the payment" do
+        integration_api = instance_double(IntegrationApi::Quickbooks)
+        expect(IntegrationApi::Quickbooks).to receive(:new).with(company_id:).and_return(integration_api)
+        expect(integration_api).to receive(:sync_data_for).with(object: payment)
+
+        described_class.new.perform(company_id, "Payment", payment.id)
+      end
+    end
+
+    context "with ConsolidatedInvoice object type" do
+      let(:invoice) { create(:invoice, company:, user: contractor.user) }
+      let(:consolidated_invoice) { create(:consolidated_invoice, company:, invoices: [invoice]) }
+
+      it "syncs the consolidated invoice" do
+        integration_api = instance_double(IntegrationApi::Quickbooks)
+        expect(IntegrationApi::Quickbooks).to receive(:new).with(company_id:).and_return(integration_api)
+        expect(integration_api).to receive(:sync_data_for).with(object: consolidated_invoice)
+
+        described_class.new.perform(company_id, "ConsolidatedInvoice", consolidated_invoice.id)
+      end
+    end
+
+    context "with ConsolidatedPayment object type" do
+      let(:invoice) { create(:invoice, company:, user: contractor.user) }
+      let(:consolidated_invoice) { create(:consolidated_invoice, company:, invoices: [invoice]) }
+      let(:consolidated_payment) { create(:consolidated_payment, consolidated_invoice:) }
+
+      it "syncs the consolidated payment" do
+        integration_api = instance_double(IntegrationApi::Quickbooks)
+        expect(IntegrationApi::Quickbooks).to receive(:new).with(company_id:).and_return(integration_api)
+        expect(integration_api).to receive(:sync_data_for).with(object: consolidated_payment)
+
+        described_class.new.perform(company_id, "ConsolidatedPayment", consolidated_payment.id)
+      end
+    end
+
+    context "when object does not exist" do
+      it "raises ActiveRecord::RecordNotFound" do
+        expect do
+          described_class.new.perform(company_id, "CompanyWorker", 999999)
+        end.to raise_error(ActiveRecord::RecordNotFound)
+      end
+    end
+
+    context "when IntegrationApi::Quickbooks raises an error" do
+      it "allows the error to bubble up for Sidekiq retry handling" do
+        integration_api = instance_double(IntegrationApi::Quickbooks)
+        expect(IntegrationApi::Quickbooks).to receive(:new).with(company_id:).and_return(integration_api)
+        expect(integration_api).to receive(:sync_data_for).and_raise(StandardError, "QuickBooks API error")
+
+        expect do
+          described_class.new.perform(company_id, "CompanyWorker", contractor.id)
+        end.to raise_error(StandardError, "QuickBooks API error")
+      end
+    end
+  end
+end

--- a/backend/spec/sidekiq/quickbooks_integration_sync_schedule_job_spec.rb
+++ b/backend/spec/sidekiq/quickbooks_integration_sync_schedule_job_spec.rb
@@ -1,0 +1,95 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe QuickbooksIntegrationSyncScheduleJob, type: :job do
+  describe "#perform" do
+    let(:company) { create(:company) }
+    let(:company_id) { company.id }
+
+    context "when integration is nil" do
+      it "returns early without scheduling any jobs" do
+        expect(QuickbooksDataSyncJob).not_to receive(:perform_bulk)
+        described_class.new.perform(company_id)
+      end
+    end
+
+    context "when integration is deleted" do
+      let!(:integration) { create(:quickbooks_integration, :deleted, company:) }
+
+      it "returns early without scheduling any jobs" do
+        expect(QuickbooksDataSyncJob).not_to receive(:perform_bulk)
+        described_class.new.perform(company_id)
+      end
+    end
+
+    context "when integration exists and is active" do
+      let!(:integration) { create(:quickbooks_integration, company:) }
+
+      context "when there are no active contractors" do
+        it "returns early without scheduling any jobs" do
+          expect(QuickbooksDataSyncJob).not_to receive(:perform_bulk)
+          described_class.new.perform(company_id)
+        end
+      end
+
+      context "when there are active contractors" do
+        let!(:contractor_1) { create(:company_worker, company:) }
+        let!(:contractor_2) { create(:company_worker, company:) }
+        let!(:ended_contractor) { create(:company_worker, company:, ended_at: 1.day.ago) }
+
+        it "sets integration status to active" do
+          expect do
+            described_class.new.perform(company_id)
+          end.to change { integration.reload.status }.to("active")
+        end
+
+        it "schedules QuickbooksDataSyncJob for all active contractors" do
+          expected_args = [
+            [company_id, "CompanyWorker", contractor_1.id],
+            [company_id, "CompanyWorker", contractor_2.id]
+          ]
+
+          expect(QuickbooksDataSyncJob).to receive(:perform_bulk).with(expected_args)
+          described_class.new.perform(company_id)
+        end
+
+        it "does not schedule jobs for ended contractors" do
+          expected_args = [
+            [company_id, "CompanyWorker", contractor_1.id],
+            [company_id, "CompanyWorker", contractor_2.id]
+          ]
+
+          expect(QuickbooksDataSyncJob).to receive(:perform_bulk).with(expected_args)
+          described_class.new.perform(company_id)
+
+          # Verify ended contractor is not in the expected args
+          contractor_ids = expected_args.map { |args| args[2] }
+          expect(contractor_ids).to include(contractor_1.id, contractor_2.id)
+          expect(contractor_ids).not_to include(ended_contractor.id)
+        end
+      end
+
+      context "when integration status is initialized" do
+        let!(:integration) { create(:quickbooks_integration, :with_incomplete_setup, company:) }
+        let!(:contractor) { create(:company_worker, company:) }
+
+        it "raises validation error due to incomplete setup" do
+          expect do
+            described_class.new.perform(company_id)
+          end.to raise_error(ActiveRecord::RecordInvalid)
+        end
+      end
+    end
+
+    context "when company does not exist" do
+      let(:company_id) { 999999 }
+
+      it "raises ActiveRecord::RecordNotFound" do
+        expect do
+          described_class.new.perform(company_id)
+        end.to raise_error(ActiveRecord::RecordNotFound)
+      end
+    end
+  end
+end

--- a/docs/quickbooks.md
+++ b/docs/quickbooks.md
@@ -217,7 +217,7 @@ QuickbooksDataSyncJob.perform_async(contractor_id, 'CompanyContractor')
 - Creates new Vendor in QBO if not found
 - Updates existing Vendor sync token if found
 - Creates or updates `integration_record` to link Flexile `CompanyContractor` with QBO `Vendor`
-- Triggers `quickbooks/sync-workers` Inngest event for batch processing
+- Triggers Sidekiq jobs for batch processing via `QuickbooksIntegrationSyncScheduleJob` to processes additional contractors in the same company
 
 ### Syncing Invoices as Bills
 
@@ -344,13 +344,12 @@ puts integration.sync_error if integration.sync_error.present?
 3. Review Audit Log in QBO for specific transactions
 4. Compare data between Flexile and QuickBooks
 
-### Check Inngest Dashboard
+### Check Sidekiq Jobs
 
-Monitor function status for:
+Monitor background job status for:
 
-- `quickbooks/sync-integration`
-- `quickbooks/sync-workers`
-- `quickbooks/sync-financial-report`
+- `QuickbooksIntegrationSyncScheduleJob`
+- `QuickbooksDataSyncJob`
 
 ### Manual Resync
 

--- a/frontend/trpc/routes/quickbooks.ts
+++ b/frontend/trpc/routes/quickbooks.ts
@@ -3,7 +3,6 @@ import { and, eq, isNull } from "drizzle-orm";
 import { z } from "zod";
 import { db } from "@/db";
 import { integrations } from "@/db/schema";
-import { inngest } from "@/inngest/client";
 import {
   CLEARANCE_BANK_ACCOUNT_NAME,
   getQuickbooksAuthUrl,
@@ -196,9 +195,31 @@ export const quickbooksRouter = createRouter({
         })
         .where(eq(integrations.id, integration.id));
 
-      await inngest.send({
-        name: "quickbooks/sync-integration",
-        data: { companyId: String(ctx.company.id) },
-      });
+      try {
+        const response = await fetch(
+          `/internal/companies/${ctx.company.id}/administrator/quickbooks/${integration.id}`,
+          {
+            method: "PUT",
+            headers: {
+              "Content-Type": "application/json",
+              Accept: "application/json",
+            },
+            body: JSON.stringify({
+              quickbooks_integration: {
+                consulting_services_expense_account_id: input.consultingServicesExpenseAccountId,
+                flexile_fees_expense_account_id: input.flexileFeesExpenseAccountId,
+                equity_compensation_expense_account_id: input.equityCompensationExpenseAccountId,
+                default_bank_account_id: input.defaultBankAccountId,
+              },
+            }),
+          },
+        );
+
+        if (!response.ok) {
+          throw new TRPCError({ code: "INTERNAL_SERVER_ERROR", message: "Failed to update QuickBooks configuration" });
+        }
+      } catch (_error) {
+        throw new TRPCError({ code: "INTERNAL_SERVER_ERROR", message: "Failed to call Rails API for QuickBooks sync" });
+      }
     }),
 });


### PR DESCRIPTION
This PR migrates the QuickBooks integration from Inngest functions to Rails Sidekiq background jobs,

## Changes Made

**Frontend Migration:**
- Updated `frontend/trpc/routes/quickbooks.ts` to use Rails API endpoint instead of Inngest events
- Replaced `inngest.send()` calls with direct `fetch()` requests to `/internal/companies/.../administrator/quickbooks`

**Backend Integration:**
- Enhanced QuickBooks controller to trigger `QuickbooksIntegrationSyncScheduleJob.perform_async()` after configuration updates
- Leverages existing Sidekiq job infrastructure for reliable background processing

**Test Coverage:**
- Added comprehensive test suite for `QuickbooksDataSyncJob` 
- Added full test coverage for `QuickbooksIntegrationSyncScheduleJob` 
- Tests cover all object types, error handling, and edge cases
- Ensures proper migration from event-driven to job-based processing

**Documentation Updates:**
- Updated QuickBooks documentation to reference Sidekiq jobs instead of Inngest functions
- Replaced monitoring instructions to use Sidekiq instead of Inngest dashboard

## Benefits

- **Simplified Architecture:** Removes dependency on external Inngest service
- **Better Error Handling:** Leverages Sidekiq's built-in retry mechanisms
- **Improved Reliability:** Uses Rails' native background job processing
- **Easier Debugging:** Sidekiq provides better monitoring and introspection tools

All existing QuickBooks functionality remains unchanged from a user perspective. The migration maintains backward compatibility while modernizing the underlying infrastructure.