### PR TITLE
migrate option_exercising flag to dedicated column & improve UI

### DIFF
--- a/backend/app/policies/equity_grant_exercise_policy.rb
+++ b/backend/app/policies/equity_grant_exercise_policy.rb
@@ -2,26 +2,26 @@
 
 class EquityGrantExercisePolicy < ApplicationPolicy
   def new?
-    return false unless company.json_flag?("option_exercising")
+    return false unless company.option_exercising_enabled?
 
     (company_investor.present? && company_worker.present?) || company_administrator?
   end
 
   def create?
-    return false unless company.json_flag?("option_exercising")
+    return false unless company.option_exercising_enabled?
 
     company_investor.present? && company_worker.present?
   end
 
   def resend?
-    return false unless company.json_flag?("option_exercising")
+    return false unless company.option_exercising_enabled?
 
     company_investor.present? && company_worker.present? &&
       record.status == EquityGrantExercise::SIGNED
   end
 
   def process?
-    return false unless company.json_flag?("option_exercising")
+    return false unless company.option_exercising_enabled?
 
     company_administrator.present?
   end

--- a/backend/app/presenters/user_presenter.rb
+++ b/backend/app/presenters/user_presenter.rb
@@ -62,7 +62,7 @@ class UserPresenter
         flags = []
         flags.push("equity") if company.equity_enabled?
         flags.push("company_updates") if company.company_investors.exists?
-        flags.push("option_exercising") if company.json_flag?("option_exercising")
+        flags.push("option_exercising") if company.option_exercising_enabled?
         can_view_financial_data = user.company_administrator_for?(company) || user.company_investor_for?(company)
         {
           **company_navigation_props(
@@ -78,6 +78,7 @@ class UserPresenter
           },
           flags:,
           equityEnabled: company.equity_enabled,
+          optionExercisingEnabled: company.option_exercising_enabled,
           requiredInvoiceApprovals: company.required_invoice_approval_count,
           paymentProcessingDays: company.contractor_payment_processing_time_in_days,
           createdAt: company.created_at.iso8601,

--- a/backend/db/migrate/20250821170846_replace_json_data_with_option_exercising_enabled.rb
+++ b/backend/db/migrate/20250821170846_replace_json_data_with_option_exercising_enabled.rb
@@ -1,0 +1,12 @@
+class ReplaceJsonDataWithOptionExercisingEnabled < ActiveRecord::Migration[8.0]
+  def change
+    add_column :companies, :option_exercising_enabled, :boolean, default: false, null: false
+
+    # Set option_exercising_enabled to true for companies that had the option_exercising flag
+    execute <<-SQL
+      UPDATE companies
+      SET option_exercising_enabled = true
+      WHERE json_data->'flags' ? 'option_exercising'
+    SQL
+  end
+end

--- a/backend/db/schema.rb
+++ b/backend/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_08_21_091952) do
+ActiveRecord::Schema[8.0].define(version: 2025_08_21_170846) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -107,6 +107,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_08_21_091952) do
     t.boolean "equity_enabled", default: false, null: false
     t.text "exercise_notice"
     t.string "invite_link"
+    t.boolean "option_exercising_enabled", default: false, null: false
     t.index ["external_id"], name: "index_companies_on_external_id", unique: true
     t.index ["invite_link"], name: "index_companies_on_invite_link", unique: true
   end

--- a/frontend/app/(dashboard)/equity/grants/DetailsModal.tsx
+++ b/frontend/app/(dashboard)/equity/grants/DetailsModal.tsx
@@ -139,7 +139,7 @@ const DetailsModal = ({
             </>
           ) : null}
         </div>
-        {company.flags.includes("option_exercising") &&
+        {company.optionExercisingEnabled &&
         equityGrant.vestedShares > 0 &&
         isFuture(equityGrant.expiresAt) &&
         canExercise ? (

--- a/frontend/app/(dashboard)/equity/grants/page.tsx
+++ b/frontend/app/(dashboard)/equity/grants/page.tsx
@@ -102,7 +102,18 @@ export default function GrantsPage() {
         }
       />
 
-      {exerciseData && !exerciseData.exercise_notice ? (
+      {!company.optionExercisingEnabled ? (
+        <Alert className="mx-4">
+          <Info />
+          <AlertDescription>
+            <span className="font-bold">Option exercises are currently unavailable.</span> Investors can't submit new
+            exercise requests.{" "}
+            <Link href="/settings/administrator/equity" className={linkClasses}>
+              Manage in settings
+            </Link>
+          </AlertDescription>
+        </Alert>
+      ) : exerciseData && !exerciseData.exercise_notice ? (
         <Alert className="mx-4">
           <Info />
           <AlertDescription>

--- a/frontend/app/(dashboard)/equity/options/index.ts
+++ b/frontend/app/(dashboard)/equity/options/index.ts
@@ -16,6 +16,6 @@ export const useExerciseDataConfig = () => {
       });
       return z.object({ exercise_notice: z.string().nullable() }).parse(await response.json());
     },
-    enabled: company.flags.includes("option_exercising"),
+    enabled: company.optionExercisingEnabled,
   } as const;
 };

--- a/frontend/app/(dashboard)/equity/options/page.tsx
+++ b/frontend/app/(dashboard)/equity/options/page.tsx
@@ -114,7 +114,15 @@ export default function OptionsPage() {
         </div>
       ) : (
         <>
-          {company.flags.includes("option_exercising") && exerciseData?.exercise_notice ? (
+          {!company.optionExercisingEnabled ? (
+            <Alert className="mx-4 mb-4">
+              <Info />
+              <AlertDescription>
+                <span className="font-bold">Option exercises are currently unavailable.</span> The company has paused
+                exercises, which may be due to a distribution in progress or other administrative settings.
+              </AlertDescription>
+            </Alert>
+          ) : exerciseData?.exercise_notice ? (
             <>
               {totalUnexercisedVestedShares > 0 && !exerciseInProgress && (
                 <Alert className="mx-4 mb-4">

--- a/frontend/app/settings/administrator/equity/page.tsx
+++ b/frontend/app/settings/administrator/equity/page.tsx
@@ -26,10 +26,19 @@ export default function Equity() {
   const utils = trpc.useUtils();
   const queryClient = useQueryClient();
   const [localEquityEnabled, setLocalEquityEnabled] = useState(company.equityEnabled);
+  const [localOptionExercisingEnabled, setLocalOptionExercisingEnabled] = useState(company.optionExercisingEnabled);
   const { data: exerciseData } = useQuery(useExerciseDataConfig());
 
-  // Separate mutation for the toggle
+  // Separate mutation for the equity toggle
   const updateEquityEnabled = trpc.companies.update.useMutation({
+    onSuccess: async () => {
+      await utils.companies.settings.invalidate();
+      await queryClient.invalidateQueries({ queryKey: ["currentUser"] });
+    },
+  });
+
+  // Separate mutation for the option exercising toggle
+  const updateOptionExercisingEnabled = trpc.companies.update.useMutation({
     onSuccess: async () => {
       await utils.companies.settings.invalidate();
       await queryClient.invalidateQueries({ queryKey: ["currentUser"] });
@@ -45,11 +54,19 @@ export default function Equity() {
     },
   });
 
-  const handleToggle = async (checked: boolean) => {
+  const handleEquityToggle = async (checked: boolean) => {
     setLocalEquityEnabled(checked);
     await updateEquityEnabled.mutateAsync({
       companyId: company.id,
       equityEnabled: checked,
+    });
+  };
+
+  const handleOptionExercisingToggle = async (checked: boolean) => {
+    setLocalOptionExercisingEnabled(checked);
+    await updateOptionExercisingEnabled.mutateAsync({
+      companyId: company.id,
+      optionExercisingEnabled: checked,
     });
   };
 
@@ -74,106 +91,143 @@ export default function Equity() {
   );
 
   return (
-    <div className="grid gap-8">
+    <div className="max-w-4xl space-y-8">
       <hgroup>
         <h2 className="mb-1 text-3xl font-bold">Equity</h2>
         <p className="text-muted-foreground text-base">
           Manage your company ownership, including cap table, option pools, and grants.
         </p>
       </hgroup>
-      <div className="bg-card border-input rounded-lg border p-4">
-        <div className="flex items-center justify-between">
-          <div>
-            <div className="font-semibold">Enable equity</div>
-            <div className="text-muted-foreground text-sm">
-              Unlock cap table, grants, and pools across your workspace.
+
+      {/* Settings Section */}
+      <div className="space-y-6">
+        <div>
+          <h2 className="text-lg font-semibold">Settings</h2>
+          <div className="bg-border mt-2 h-px"></div>
+        </div>
+
+        <div className="space-y-6">
+          {/* Enable Equity Setting */}
+          <div className="flex items-center justify-between">
+            <div className="space-y-1">
+              <div className="font-medium">Enable equity</div>
+              <div className="text-muted-foreground text-sm">
+                Unlock cap table, grants, and pools across your workspace.
+              </div>
             </div>
+            <Switch
+              checked={localEquityEnabled}
+              onCheckedChange={(checked) => {
+                void handleEquityToggle(checked);
+              }}
+              aria-label="Enable equity"
+              disabled={updateEquityEnabled.isPending}
+            />
           </div>
-          <Switch
-            checked={localEquityEnabled}
-            onCheckedChange={(checked) => {
-              void handleToggle(checked);
-            }}
-            aria-label="Enable equity"
-            disabled={updateEquityEnabled.isPending}
-          />
+
+          {/* Option Exercising Setting - Always visible, toggle only when equity enabled */}
+          <div className="flex items-center justify-between">
+            <div className="space-y-1">
+              <div className="font-medium">Exercise requests</div>
+              <div className="text-muted-foreground text-sm">Allow investors to exercise their vested options.</div>
+            </div>
+            {localEquityEnabled ? (
+              <Switch
+                checked={localOptionExercisingEnabled}
+                onCheckedChange={(checked) => {
+                  void handleOptionExercisingToggle(checked);
+                }}
+                aria-label="Enable option exercising"
+                disabled={updateOptionExercisingEnabled.isPending}
+              />
+            ) : null}
+          </div>
         </div>
       </div>
+
+      {/* Equity Value Section - Only shown when equity is enabled */}
       {localEquityEnabled ? (
-        <Form {...form}>
-          <form className="grid gap-8" onSubmit={(e) => void submit(e)}>
-            <hgroup>
-              <h2 className="mb-1 font-bold">Equity value</h2>
-              <p className="text-muted-foreground text-base">
-                These details will be used for equity-related calculations and reporting.
-              </p>
-            </hgroup>
-            <div className="grid gap-4">
-              <FormField
-                control={form.control}
-                name="sharePriceInUsd"
-                render={({ field }) => (
-                  <FormItem>
-                    <FormLabel>Current share price (USD)</FormLabel>
-                    <FormControl>
-                      <NumberInput {...field} decimal minimumFractionDigits={2} prefix="$" />
-                    </FormControl>
-                    <FormMessage />
-                  </FormItem>
-                )}
-              />
-              <FormField
-                control={form.control}
-                name="fmvPerShareInUsd"
-                render={({ field }) => (
-                  <FormItem>
-                    <FormLabel>Current 409A valuation (USD per share)</FormLabel>
-                    <FormControl>
-                      <NumberInput {...field} decimal minimumFractionDigits={2} prefix="$" />
-                    </FormControl>
-                    <FormMessage />
-                  </FormItem>
-                )}
-              />
-              <FormField
-                control={form.control}
-                name="conversionSharePriceUsd"
-                render={({ field }) => (
-                  <FormItem>
-                    <FormLabel>Conversion share price (USD)</FormLabel>
-                    <FormControl>
-                      <NumberInput {...field} decimal minimumFractionDigits={2} prefix="$" />
-                    </FormControl>
-                    <FormMessage />
-                  </FormItem>
-                )}
-              />
-              {exerciseData ? (
-                <FormField
-                  control={form.control}
-                  name="exerciseNotice"
-                  render={({ field }) => (
-                    <FormItem>
-                      <FormLabel>Exercise notice</FormLabel>
-                      <FormControl>
-                        <RichTextEditor {...field} />
-                      </FormControl>
-                    </FormItem>
-                  )}
-                />
-              ) : null}
-              <MutationStatusButton
-                type="submit"
-                className="w-fit"
-                mutation={updateSettings}
-                loadingText="Saving..."
-                successText="Changes saved"
-              >
-                Save changes
-              </MutationStatusButton>
-            </div>
-          </form>
-        </Form>
+        <div className="space-y-6">
+          <hgroup>
+            <h2 className="text-lg font-semibold">Equity value</h2>
+            <div className="bg-border mt-2 h-px"></div>
+          </hgroup>
+
+          <div>
+            <p className="text-muted-foreground mb-6 text-sm">
+              These details will be used for equity-related calculations and reporting.
+            </p>
+
+            <Form {...form}>
+              <form className="grid gap-8" onSubmit={(e) => void submit(e)}>
+                <div className="grid gap-4">
+                  <FormField
+                    control={form.control}
+                    name="sharePriceInUsd"
+                    render={({ field }) => (
+                      <FormItem>
+                        <FormLabel>Current share price (USD)</FormLabel>
+                        <FormControl>
+                          <NumberInput {...field} decimal minimumFractionDigits={2} prefix="$" />
+                        </FormControl>
+                        <FormMessage />
+                      </FormItem>
+                    )}
+                  />
+                  <FormField
+                    control={form.control}
+                    name="fmvPerShareInUsd"
+                    render={({ field }) => (
+                      <FormItem>
+                        <FormLabel>Current 409A valuation (USD per share)</FormLabel>
+                        <FormControl>
+                          <NumberInput {...field} decimal minimumFractionDigits={2} prefix="$" />
+                        </FormControl>
+                        <FormMessage />
+                      </FormItem>
+                    )}
+                  />
+                  <FormField
+                    control={form.control}
+                    name="conversionSharePriceUsd"
+                    render={({ field }) => (
+                      <FormItem>
+                        <FormLabel>Conversion share price (USD)</FormLabel>
+                        <FormControl>
+                          <NumberInput {...field} decimal minimumFractionDigits={2} prefix="$" />
+                        </FormControl>
+                        <FormMessage />
+                      </FormItem>
+                    )}
+                  />
+                  {exerciseData ? (
+                    <FormField
+                      control={form.control}
+                      name="exerciseNotice"
+                      render={({ field }) => (
+                        <FormItem>
+                          <FormLabel>Exercise notice</FormLabel>
+                          <FormControl>
+                            <RichTextEditor {...field} />
+                          </FormControl>
+                        </FormItem>
+                      )}
+                    />
+                  ) : null}
+                  <MutationStatusButton
+                    type="submit"
+                    className="w-fit"
+                    mutation={updateSettings}
+                    loadingText="Saving..."
+                    successText="Changes saved"
+                  >
+                    Save changes
+                  </MutationStatusButton>
+                </div>
+              </form>
+            </Form>
+          </div>
+        </div>
       ) : null}
     </div>
   );

--- a/frontend/db/schema.ts
+++ b/frontend/db/schema.ts
@@ -1620,6 +1620,7 @@ export const companies = pgTable(
     conversionSharePriceUsd: numeric("conversion_share_price_usd"),
     jsonData: jsonb("json_data").notNull().$type<{ flags: string[] }>().default({ flags: [] }),
     inviteLink: varchar("invite_link"),
+    optionExercisingEnabled: boolean("option_exercising_enabled").notNull().default(false),
     exerciseNotice: text("exercise_notice"),
   },
   (table) => [

--- a/frontend/models/user.ts
+++ b/frontend/models/user.ts
@@ -19,6 +19,7 @@ const companySchema = z.object({
   routes: z.array(navLinkSchema.extend({ subLinks: z.array(navLinkSchema).optional() })),
   requiredInvoiceApprovals: z.number(),
   equityEnabled: z.boolean(),
+  optionExercisingEnabled: z.boolean(),
   completedPaymentMethodSetup: z.boolean(),
   paymentProcessingDays: z.number(),
   createdAt: z.string(),

--- a/frontend/trpc/routes/companies.ts
+++ b/frontend/trpc/routes/companies.ts
@@ -64,17 +64,21 @@ export const companiesRouter = createRouter({
           conversionSharePriceUsd: true,
           exerciseNotice: true,
         })
-        .extend({ logoKey: z.string().optional(), equityEnabled: z.boolean().optional() }),
+        .extend({
+          logoKey: z.string().optional(),
+          equityEnabled: z.boolean().optional(),
+          optionExercisingEnabled: z.boolean().optional(),
+        }),
     )
     .mutation(async ({ ctx, input }) => {
       if (!ctx.companyAdministrator) throw new TRPCError({ code: "FORBIDDEN" });
 
-      const { equityEnabled, ...rest } = input;
+      const { equityEnabled, optionExercisingEnabled, ...rest } = input;
       await db.transaction(async (tx) => {
-        if (equityEnabled !== undefined) {
+        if (equityEnabled !== undefined || optionExercisingEnabled !== undefined) {
           await tx
             .update(companies)
-            .set({ ...rest, equityEnabled })
+            .set({ ...rest, equityEnabled, optionExercisingEnabled })
             .where(eq(companies.id, ctx.company.id));
         } else {
           await tx.update(companies).set(rest).where(eq(companies.id, ctx.company.id));


### PR DESCRIPTION
- add `option_exercising_enabled` boolean column on companies
- backfill values from json_data.flags in migration

- add administrator toggle in Equity Settings
- update e2e tests for exercising disabled flow and toggle behavior


<img width="2940" height="1912" alt="image" src="https://github.com/user-attachments/assets/a3590ac1-aafb-4fe6-9ae6-739959bdfbb2" />

<img width="2940" height="1912" alt="image" src="https://github.com/user-attachments/assets/ce9f986e-02bb-4ff2-91e6-428f4afa097e" />
