### PR TITLE
fix: enable decimal input for microdeposit verification amounts

### DIFF
--- a/frontend/app/settings/administrator/StripeMicrodepositVerification.tsx
+++ b/frontend/app/settings/administrator/StripeMicrodepositVerification.tsx
@@ -18,8 +18,8 @@ import { formatDate } from "@/utils/time";
 
 const formSchema = z.object({ verificationCode: z.string().length(6, "Please enter a 6-digit code.") }).or(
   z.object({
-    firstAmount: z.number().min(1, "Please enter an amount."),
-    secondAmount: z.number().min(1, "Please enter an amount."),
+    firstAmount: z.number().min(0.01, "Please enter an amount (minimum $0.01)."),
+    secondAmount: z.number().min(0.01, "Please enter an amount (minimum $0.01)."),
   }),
 );
 
@@ -129,7 +129,7 @@ const StripeMicrodepositVerification = () => {
                       <FormItem>
                         <FormLabel>Amount 1</FormLabel>
                         <FormControl>
-                          <NumberInput {...field} prefix="$" />
+                          <NumberInput {...field} prefix="$" decimal maximumFractionDigits={2} />
                         </FormControl>
                         <FormMessage />
                       </FormItem>
@@ -142,7 +142,7 @@ const StripeMicrodepositVerification = () => {
                       <FormItem>
                         <FormLabel>Amount 2</FormLabel>
                         <FormControl>
-                          <NumberInput {...field} prefix="$" />
+                          <NumberInput {...field} prefix="$" decimal maximumFractionDigits={2} />
                         </FormControl>
                         <FormMessage />
                       </FormItem>


### PR DESCRIPTION
## Fix: Enable decimal input for microdeposit verification amounts #1010

### Problem
Users were unable to enter decimal amounts (e.g., `$0.32`, `$0.45`) in the microdeposit verification modal, causing validation errors and preventing successful bank account verification. The NumberInput components were configured to only accept whole dollar amounts, but Stripe microdeposits are typically small cent amounts.

### Solution
- ✅ Added `decimal` prop to NumberInput components in `StripeMicrodepositVerification`
- ✅ Set `maximumFractionDigits={2}` to allow cents precision
- ✅ Updated validation schema minimum from `$1.00` to `$0.01` for proper microdeposit amounts

### Testing
- [x] Manual testing: Users can now enter decimal amounts like `0.32` in verification modal
- [x] Validation works correctly with amounts as low as `$0.01`

### Files Changed
- `frontend/app/settings/administrator/StripeMicrodepositVerification.tsx`
- `e2e/tests/settings/administrator/payment-details.spec.ts`

### Screenshots/Demo

https://github.com/user-attachments/assets/12765a0f-fa43-4eaf-b592-b089c1bb978f
