### PR TITLE
Fix: make dialog close (X) show pointer cursor on hover across app

### DIFF
--- a/frontend/components/ui/dialog.tsx
+++ b/frontend/components/ui/dialog.tsx
@@ -55,7 +55,7 @@ function DialogContent({
         {showCloseButton && !isMobile ? (
           <DialogPrimitive.Close
             data-slot="dialog-close"
-            className="ring-offset-background focus:ring-ring data-[state=open]:bg-accent data-[state=open]:text-muted-foreground absolute top-[26px] right-5 mt-2 mr-2 rounded-xs opacity-70 transition-opacity hover:opacity-100 focus:ring-2 focus:ring-offset-2 focus:outline-hidden disabled:pointer-events-none [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4"
+            className="ring-offset-background focus:ring-ring data-[state=open]:bg-accent data-[state=open]:text-muted-foreground absolute top-[26px] right-5 mt-2 mr-2 cursor-pointer rounded-xs opacity-70 transition-opacity hover:opacity-100 focus:ring-2 focus:ring-offset-2 focus:outline-hidden disabled:pointer-events-none [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4"
           >
             <XIcon />
             <span className="sr-only">Close</span>


### PR DESCRIPTION
Under #911 
## PR description
### Summary
- Adds cursor-pointer to the reusable dialog close button in `frontend/components/ui/dialog.tsx` so the cursor changes to a hand on hover, matching expected affordance.
- Applies globally to all dialogs (e.g., Settings → Payouts → Add bank account modal, equity/grants modals, etc.).
- The close (X) button didn’t show a pointer cursor on hover, reducing clarity of interactivity and hurting UX consistency.

### Before

https://github.com/user-attachments/assets/612d59e6-a17b-402c-afc4-1dd7036af0c9

### After


https://github.com/user-attachments/assets/c6423f05-9d47-48ca-a164-730a52fc68f8


#### AI Disclosure 
No AI was used to generate this code.
