### PR TITLE
Fix decimal input in bank verification microdeposit amounts

### DIFF
--- a/e2e/tests/settings/administrator/payment-details.spec.ts
+++ b/e2e/tests/settings/administrator/payment-details.spec.ts
@@ -71,31 +71,69 @@ test.describe("Company administrator settings - payment details", () => {
     await login(page, adminUser);
     await page.getByRole("link", { name: "Settings" }).click();
     await page.getByRole("link", { name: "Billing" }).click();
-    await page.getByRole("button", { name: "Link your bank account" }).click();
-
-    const stripeFrame = page.frameLocator("[src^='https://js.stripe.com/v3/elements-inner-payment']");
-    await stripeFrame.getByRole("button", { name: /Enter bank details manually/u }).click();
-
-    const bankFrame = page.frameLocator("[src^='https://js.stripe.com/v3/linked-accounts-inner']");
-    await bankFrame.getByLabel("Routing number").fill("110000000");
-    await bankFrame.getByTestId("manualEntry-accountNumber-input").fill("000123456789");
-    await bankFrame.getByTestId("manualEntry-confirmAccountNumber-input").fill("000123456789");
-    await bankFrame.getByRole("button", { name: "Submit" }).click();
 
     await expect(
-      bankFrame.getByText(
-        "Next, finish up on Flexile to initiate micro-deposits. You can expect an email with instructions within 1-2 business days.",
-      ),
+      page.getByText("We'll use this account to debit contractor payments and our monthly fee"),
     ).toBeVisible();
 
-    await bankFrame.getByRole("button", { name: "Back to Flexile" }).click();
+    await page.getByRole("button", { name: "Link your bank account" }).click();
+
+    const stripePaymentFrame = page.frameLocator("iframe[src*='js.stripe.com/v3/elements-inner-payment']").first();
+    await stripePaymentFrame.getByRole("button", { name: /Enter bank details manually/iu }).click();
+
+    const stripeBankFrame = page.frameLocator("iframe[src*='js.stripe.com/v3/linked-accounts-inner']").first();
+    await stripeBankFrame.getByLabel("Routing number").waitFor({ state: "visible" });
+    await stripeBankFrame.getByLabel("Routing number").fill("110000000");
+    await stripeBankFrame.getByTestId("manualEntry-accountNumber-input").fill("000123456789");
+    await stripeBankFrame.getByTestId("manualEntry-confirmAccountNumber-input").fill("000123456789");
+
+    await stripeBankFrame.getByRole("button", { name: "Submit" }).click();
+
+    const bankFrame = page.frameLocator("iframe[src*='js.stripe.com/v3/linked-accounts-inner']");
+    const linkNotNowButton = bankFrame.getByTestId("link-not-now-button");
+    const completionText = bankFrame.getByText(/Next, finish up on/iu);
+
+    await Promise.race([
+      linkNotNowButton.waitFor({ state: "visible" }).catch(() => undefined),
+      completionText.waitFor({ state: "visible" }).catch(() => undefined),
+    ]);
+
+    if (await linkNotNowButton.isVisible().catch(() => false)) {
+      await linkNotNowButton.click();
+    }
+
+    await bankFrame.getByRole("button", { name: /Back to/iu }).click();
+
     await expect(page.getByRole("dialog")).not.toBeVisible();
 
-    await expect(page.getByText("Verify your bank account to enable contractor payments")).toBeVisible();
+    const bannerLocator = page.getByText("Verify your bank account to enable contractor payments");
+    await expect(bannerLocator).toBeVisible();
 
     const companyStripeAccount = await db.query.companyStripeAccounts
       .findFirst({ where: eq(companyStripeAccounts.companyId, company.id) })
       .then(takeOrThrow);
     expect(companyStripeAccount.status).toBe("processing");
+
+    await page.getByRole("button", { name: "Verify bank account" }).click();
+    await expect(page.getByRole("dialog")).toBeVisible();
+
+    const amount1Input = page.getByLabel("Amount 1");
+    await amount1Input.fill("0.32");
+    await expect(amount1Input).toHaveValue("0.32");
+
+    const amount2Input = page.getByLabel("Amount 2");
+    await amount2Input.fill("0.45");
+    await expect(amount2Input).toHaveValue("0.45");
+
+    await page.getByRole("button", { name: "Submit" }).click();
+
+    await expect(page.getByRole("dialog")).not.toBeVisible();
+
+    const updatedStripeAccount = await db.query.companyStripeAccounts
+      .findFirst({ where: eq(companyStripeAccounts.companyId, company.id) })
+      .then(takeOrThrow);
+
+    expect(updatedStripeAccount.setupIntentId).toBeTruthy();
+    expect(updatedStripeAccount.bankAccountLastFour).toBe("6789");
   });
 });

--- a/frontend/app/settings/administrator/StripeMicrodepositVerification.tsx
+++ b/frontend/app/settings/administrator/StripeMicrodepositVerification.tsx
@@ -18,8 +18,8 @@ import { formatDate } from "@/utils/time";
 
 const formSchema = z.object({ verificationCode: z.string().length(6, "Please enter a 6-digit code.") }).or(
   z.object({
-    firstAmount: z.number().min(1, "Please enter an amount."),
-    secondAmount: z.number().min(1, "Please enter an amount."),
+    firstAmount: z.number().min(0.01, "Please enter an amount."),
+    secondAmount: z.number().min(0.01, "Please enter an amount."),
   }),
 );
 
@@ -129,7 +129,7 @@ const StripeMicrodepositVerification = () => {
                       <FormItem>
                         <FormLabel>Amount 1</FormLabel>
                         <FormControl>
-                          <NumberInput {...field} prefix="$" />
+                          <NumberInput {...field} prefix="$" decimal maximumFractionDigits={2} />
                         </FormControl>
                         <FormMessage />
                       </FormItem>
@@ -142,7 +142,7 @@ const StripeMicrodepositVerification = () => {
                       <FormItem>
                         <FormLabel>Amount 2</FormLabel>
                         <FormControl>
-                          <NumberInput {...field} prefix="$" />
+                          <NumberInput {...field} prefix="$" decimal maximumFractionDigits={2} />
                         </FormControl>
                         <FormMessage />
                       </FormItem>


### PR DESCRIPTION
Closes #1010

## Before
<img width="841" height="827" alt="before-decimals" src="https://github.com/user-attachments/assets/ee944515-daf3-4975-b922-b99f43d7ba6a" />

## After
<img width="1436" height="1100" alt="image" src="https://github.com/user-attachments/assets/9a29a184-e5e3-4ad2-869f-54243ff2bd09" />


## Demo Video
[demo.webm](https://github.com/user-attachments/assets/d0129c5c-5850-4ae8-8f2d-e81f98e4fe92)


## AI Disclosure

AI was used for an initial draft of this PR, and I had to manually go step by step to get the test to work correctly. 

## Self review

I reviewed the code in this PR (with one comment) and locally by verifying the changes through my e2e test.

## Tests

The updated test passes without issue
<img width="2636" height="206" alt="image" src="https://github.com/user-attachments/assets/d8205efe-660a-4986-836e-e2c404d9f7f1" />

See [this comment](https://github.com/antiwork/flexile/pull/1039#discussion_r2298414250) on changes I would need to make to get the other payment test to pass for all contributors

I did run all tests, and there are quite a few failing. This is a minimal change so I don't believe any tests are failing as a result of these changes
<img width="3084" height="1150" alt="image" src="https://github.com/user-attachments/assets/c0803787-f995-4bdc-956f-32d821ef10c6" />
