### PR TITLE
Use request's protocol when querying backend API

### DIFF
--- a/frontend/lib/getRedirectUrl.ts
+++ b/frontend/lib/getRedirectUrl.ts
@@ -5,7 +5,9 @@ import { internal_current_user_data_url } from "@/utils/routes";
 
 export const getRedirectUrl = async (req: Request) => {
   const host = assertDefined(req.headers.get("Host"));
-  const response = await fetch(internal_current_user_data_url({ host }), {
+  const url = new URL(req.url);
+  const protocol = url.protocol.slice(0, -1); // "http" or "https"
+  const response = await fetch(internal_current_user_data_url({ protocol, host }), {
     headers: {
       cookie: req.headers.get("cookie") ?? "",
       "User-Agent": req.headers.get("User-Agent") ?? "",


### PR DESCRIPTION
Otherwise, it queries `http://api.flexile.com` (due to [this change](https://github.com/antiwork/flexile/pull/1017/files#diff-f45ae02c8384c47d5a549fe8541fcaaf3ba76f0598da8315dc44868c3b72553d)) and cookies won't be shared.