### PR TITLE
fixed bin/dev and port on next config.ts

### DIFF
--- a/bin/dev
+++ b/bin/dev
@@ -3,7 +3,7 @@
 set -e
 
 if [ -f ".vercel/project.json" ]; then
-    pnpx vercel env pull .env
+    echo "Skipping \`vercel env pull\` to avoid overriding .env"
 elif [ ! -f ".env" ]; then
     echo ".env file not found. Please run bin/setup first."
     exit 1

--- a/frontend/next.config.ts
+++ b/frontend/next.config.ts
@@ -26,7 +26,7 @@ const nextConfig: NextConfig = {
   },
 };
 if (process.env.NODE_ENV === "development") {
-  nextConfig.images.remotePatterns.push({ protocol: "http", hostname: "localhost", port: "3001" });
+  nextConfig.images.remotePatterns.push({ protocol: "http", hostname: "localhost", port: "3000" });
 }
 
 const withBundleAnalyzer = NextBundleAnalyzer({


### PR DESCRIPTION
bin/dev automatically pulls from vercel env variables which automatically overrides the `.env` file.
fixed it to just echo.

and 

was getting un-configured host after the updates from #1017 
the port should be 3000 not 3001. 