### PR TITLE
Fix: heading overflow issue by adjusting responsive font sizes

### DIFF
--- a/frontend/app/(marketing)/page.tsx
+++ b/frontend/app/(marketing)/page.tsx
@@ -55,7 +55,7 @@ export default async function HomePage() {
 
       <main className="min-h-screen bg-white pt-20">
         <Section className="bg-blue-600 py-8 md:py-16">
-          <h1 className="text-6xl leading-[0.9] font-medium tracking-tight sm:text-8xl md:text-[12rem]">
+          <h1 className="text-6xl leading-[0.9] font-medium tracking-tight sm:text-8xl md:text-[9rem] lg:text-[12rem]">
             Contractor payments
           </h1>
           <div className="flex">


### PR DESCRIPTION
What Changed:

- Adjusted the h1 heading in the hero section for sm, md, and lg breakpoints
- Prevents text overflow on medium screens
- Improves responsive scaling across all devices

Before:

<img width="1912" height="979" alt="image" src="https://github.com/user-attachments/assets/04077c42-e58f-4467-ae49-ba08c5cd436d" />

After:

<img width="1919" height="933" alt="image" src="https://github.com/user-attachments/assets/78b8ad5a-a304-44ad-9646-c9338d7db8e8" />


- Tested & verified across all medium screens
- No AI was used to generate any of this code.
