### PR TITLE
feat: add status details for invoice

### DIFF
--- a/frontend/app/(dashboard)/invoices/[id]/page.tsx
+++ b/frontend/app/(dashboard)/invoices/[id]/page.tsx
@@ -30,6 +30,7 @@ import {
   EDITABLE_INVOICE_STATES,
   LegacyAddress,
   RejectModal,
+  StatusDetails,
   taxRequirementsMet,
   useIsActionable,
   useIsDeletable,
@@ -289,10 +290,7 @@ export default function InvoicePage() {
         </Alert>
       )}
 
-      <div className="mx-4 mb-4 print:hidden">
-        <div className="text-sm text-gray-500">Status</div>
-        <div className="font-medium">{getInvoiceStatusText(invoice, company)}</div>
-      </div>
+      <StatusDetails invoice={invoice} className="m-4 print:hidden" />
 
       {payRateInSubunits && invoice.lineItems.some((lineItem) => lineItem.payRateInSubunits > payRateInSubunits) ? (
         <Alert className="mx-4 print:hidden" variant="warning">

--- a/frontend/app/(dashboard)/invoices/index.tsx
+++ b/frontend/app/(dashboard)/invoices/index.tsx
@@ -1,7 +1,9 @@
 import { CurrencyDollarIcon } from "@heroicons/react/20/solid";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { addDays, isWeekend, nextMonday } from "date-fns";
 import React, { useState } from "react";
 import MutationButton from "@/components/MutationButton";
+import { Alert, AlertDescription } from "@/components/ui/alert";
 import { Button } from "@/components/ui/button";
 import { Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle } from "@/components/ui/dialog";
 import { Label } from "@/components/ui/label";
@@ -9,8 +11,10 @@ import { Textarea } from "@/components/ui/textarea";
 import { useCurrentCompany, useCurrentUser } from "@/global";
 import type { RouterOutput } from "@/trpc";
 import { trpc } from "@/trpc/client";
+import { cn } from "@/utils";
 import { request } from "@/utils/request";
 import { approve_company_invoices_path, company_invoice_path, reject_company_invoices_path } from "@/utils/routes";
+import { formatDate } from "@/utils/time";
 
 type Invoice = RouterOutput["invoices"]["list"][number] | RouterOutput["invoices"]["get"];
 export const EDITABLE_INVOICE_STATES: Invoice["status"][] = ["received", "rejected"];
@@ -300,3 +304,54 @@ export const DeleteModal = ({
     </Dialog>
   );
 };
+
+export function StatusDetails({ invoice, className }: { invoice: Invoice; className?: string }) {
+  const user = useCurrentUser();
+  const company = useCurrentCompany();
+  const [{ invoice: consolidatedInvoice }] = trpc.consolidatedInvoices.last.useSuspenseQuery({ companyId: company.id });
+
+  const getDetails = () => {
+    let details = null;
+    switch (invoice.status) {
+      case "approved":
+        if (invoice.approvals.length > 0) {
+          details = (
+            <ul className="list-disc pl-5">
+              {invoice.approvals.map((approval, index) => (
+                <li key={index}>
+                  Approved by {approval.approver.id === user.id ? "you" : approval.approver.name} on{" "}
+                  {formatDate(approval.approvedAt, { time: true })}
+                </li>
+              ))}
+            </ul>
+          );
+        }
+        break;
+      case "rejected":
+        details = "Rejected";
+        if (invoice.rejector) details += ` by ${invoice.rejector.name}`;
+        if (invoice.rejectedAt) details += ` on ${formatDate(invoice.rejectedAt)}`;
+        if (invoice.rejectionReason) details += `: "${invoice.rejectionReason}"`;
+        break;
+      case "payment_pending":
+      case "processing":
+        if (consolidatedInvoice) {
+          let paymentExpectedBy = addDays(consolidatedInvoice.createdAt, company.paymentProcessingDays);
+          if (isWeekend(paymentExpectedBy)) paymentExpectedBy = nextMonday(paymentExpectedBy);
+          details = `Your payment should arrive by ${formatDate(paymentExpectedBy)}`;
+        }
+        break;
+      default:
+        break;
+    }
+    return details;
+  };
+
+  const statusDetails = getDetails();
+
+  return statusDetails ? (
+    <Alert className={cn(className)} {...(invoice.status === "rejected" && { variant: "destructive" })}>
+      <AlertDescription>{statusDetails}</AlertDescription>
+    </Alert>
+  ) : null;
+}

--- a/frontend/app/(dashboard)/invoices/page.tsx
+++ b/frontend/app/(dashboard)/invoices/page.tsx
@@ -29,6 +29,7 @@ import {
   DeleteModal,
   EDITABLE_INVOICE_STATES,
   RejectModal,
+  StatusDetails,
   useApproveInvoices,
   useIsActionable,
   useIsDeletable,
@@ -684,10 +685,7 @@ const TasksModal = ({
           </DialogTitle>
         </DialogHeader>
         <section>
-          <div className="mb-4">
-            <div className="text-sm text-gray-500">Status</div>
-            <div className="font-medium">{getInvoiceStatusText(invoice, company)}</div>
-          </div>
+          <StatusDetails invoice={invoice} className="mb-4" />
           {payRateInSubunits &&
           invoiceData.lineItems.some((lineItem) => lineItem.payRateInSubunits > payRateInSubunits) ? (
             <Alert className="max-md:mb-4" variant="warning">


### PR DESCRIPTION
### Description:

Add status details for invoices. This helps display clear status messages, such as explaining why an invoice was rejected. The details message existed earlier but was removed along with the status icon in #1059 .

Part of #911 

### Before / After: Contractor

#### Before:

<img width="1432" height="804" alt="Screenshot 2025-08-31 at 1 28 35 PM" src="https://github.com/user-attachments/assets/2375ce40-f738-495e-96cb-407c2ab66a37" />

#### After:

 <table>
 <tr><th>Desktop</th><th>Mobile</th></tr>
 <tr>
 <td> 
 <img width="1436" height="809" alt="Screenshot 2025-08-31 at 2 13 15 PM" src="https://github.com/user-attachments/assets/4e24394e-ee40-4561-b8e0-9128f50285dc" />
 </td>
 <td>
 <img width="430" height="931" alt="Screenshot 2025-08-31 at 2 13 00 PM" src="https://github.com/user-attachments/assets/da4b1393-0cb0-48b0-9a35-52478d35920f" />
 </td>
 </tr>
 </table>

### Before / After: Admin

#### Before:

<img width="1431" height="819" alt="Screenshot 2025-08-31 at 1 28 01 PM" src="https://github.com/user-attachments/assets/ce2feeae-9dcf-44cf-b5b1-f35d352a1ff3" />

#### After:

 <table>
 <tr><th>Desktop</th><th>Mobile</th></tr>
 <tr>
 <td> 
<img width="1431" height="811" alt="Screenshot 2025-08-31 at 2 13 39 PM" src="https://github.com/user-attachments/assets/1c113e05-4e45-4a55-9975-a0abd093cdb8" />
 </td>
 <td>
<img width="426" height="930" alt="Screenshot 2025-08-31 at 2 12 07 PM" src="https://github.com/user-attachments/assets/068896e2-1670-43eb-99fb-087d664d3478" />
 </td>
 </tr>
 </table>

### Test Suite / Related tests:

<img width="500" height="642" alt="Screenshot 2025-08-31 at 3 44 15 PM" src="https://github.com/user-attachments/assets/18e0c60d-4913-492a-9f88-abf31eede95a" />

> [!Note]
> AI Disclosure: No AI was used to generate any of this code.