### PR TITLE
ci: enable workflows to run on forks

### DIFF
--- a/.github/workflows/autofix.yml
+++ b/.github/workflows/autofix.yml
@@ -13,7 +13,7 @@ permissions:
 
 jobs:
   autofix:
-    runs-on: ubicloud-standard-2
+    runs-on: ${{ github.repository == 'antiwork/flexile' && 'ubicloud-standard-2' || 'ubuntu-latest' }}
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -20,7 +20,7 @@ env:
 
 jobs:
   rspec:
-    runs-on: ubicloud-standard-2
+    runs-on: ${{ github.repository == 'antiwork/flexile' && 'ubicloud-standard-2' || 'ubuntu-latest' }}
 
     services:
       postgres:
@@ -59,7 +59,7 @@ jobs:
 
   playwright:
     name: playwright
-    runs-on: ubicloud-standard-8
+    runs-on: ${{ github.repository == 'antiwork/flexile' && 'ubicloud-standard-8' || 'ubuntu-latest' }}
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## Closes https://github.com/antiwork/flexile/issues/1025

Referencing comment from the issue below

> ### Why?
> 1. Enables OSS contributors to draft PRs on their fork with workflows to guide them through.
> 2. Encourages OSS contributors to use tooling of their choice on their fork eg:- coderabbit, codeant or any other app they want to use to bring a PR to a mergeable state
> 3. Frees up local machine from running the test suite
> 4. Allows linking tests runs from forks in PRs

### Test Link - https://github.com/sm17p/flexile/pull/8

<img width="1394" height="812" alt="#8" src="https://github.com/user-attachments/assets/fc0dd208-1bd6-4b6d-a6c2-4095a883aff3" />

### AI Disclosure
No usage
