### PR TITLE
tests: add e2e tests for placing bids

### DIFF
--- a/e2e/builders/tenderOfferScenarios.ts
+++ b/e2e/builders/tenderOfferScenarios.ts
@@ -1,0 +1,168 @@
+import { db } from "@test/db";
+import { companiesFactory } from "@test/factories/companies";
+import { companyInvestorsFactory } from "@test/factories/companyInvestors";
+import { shareClassesFactory } from "@test/factories/shareClasses";
+import { shareHoldingsFactory } from "@test/factories/shareHoldings";
+import { tenderOfferBidsFactory } from "@test/factories/tenderOfferBids";
+import { tenderOffersFactory } from "@test/factories/tenderOffers";
+import { usersFactory } from "@test/factories/users";
+import type { companies, tenderOffers, users } from "@/db/schema";
+import { assertDefined } from "@/utils/assert";
+
+export interface TenderOfferScenario {
+  company: typeof companies.$inferSelect;
+  adminUser: typeof users.$inferSelect;
+  investorUsers: (typeof users.$inferSelect)[];
+  tenderOffer: typeof tenderOffers.$inferSelect;
+}
+
+export const tenderOfferScenarioBuilder = {
+  createBasicScenario: async (): Promise<TenderOfferScenario> => {
+    const { company, adminUser } = await companiesFactory.createCompletedOnboarding({
+      equityEnabled: true,
+    });
+
+    const { tenderOffer } = await tenderOffersFactory.createActive({
+      companyId: company.id,
+      minimumValuation: 10000000n,
+    });
+
+    const investorUsers: (typeof users.$inferSelect)[] = [];
+
+    for (let i = 0; i < 3; i++) {
+      const { user } = await usersFactory.create();
+      const { companyInvestor } = await companyInvestorsFactory.create({
+        companyId: company.id,
+        userId: user.id,
+      });
+
+      await shareHoldingsFactory.create({
+        companyInvestorId: companyInvestor.id,
+        shareClassId: (await shareClassesFactory.create({ companyId: company.id, name: "Common" })).shareClass.id,
+        numberOfShares: 1000 * (i + 1),
+      });
+
+      investorUsers.push(user);
+    }
+
+    return { company, adminUser, investorUsers, tenderOffer };
+  },
+
+  createScenarioWithExistingBids: async () => {
+    const scenario = await tenderOfferScenarioBuilder.createBasicScenario();
+
+    for (let i = 0; i < scenario.investorUsers.length; i++) {
+      const investor = await db.query.companyInvestors.findFirst({
+        where: (ci, { and, eq }) =>
+          and(eq(ci.companyId, scenario.company.id), eq(ci.userId, assertDefined(scenario.investorUsers[i]).id)),
+      });
+
+      if (investor) {
+        await tenderOfferBidsFactory.create({
+          tenderOfferId: scenario.tenderOffer.id,
+          companyInvestorId: investor.id,
+          numberOfShares: String(100 * (i + 1)),
+          sharePriceCents: 5000 - i * 500,
+        });
+      }
+    }
+
+    return scenario;
+  },
+
+  createScenarioWithMultipleShareClasses: async () => {
+    const { company, adminUser } = await companiesFactory.createCompletedOnboarding({
+      equityEnabled: true,
+    });
+
+    const commonShareClass = await shareClassesFactory.create({
+      companyId: company.id,
+      name: "Common",
+    });
+
+    const preferredShareClass = await shareClassesFactory.create({
+      companyId: company.id,
+      name: "Preferred",
+    });
+
+    const { tenderOffer } = await tenderOffersFactory.createActive({
+      companyId: company.id,
+    });
+
+    const investorUsers: (typeof users.$inferSelect)[] = [];
+    const shareClasses = [commonShareClass.shareClass, preferredShareClass.shareClass];
+
+    for (let i = 0; i < 4; i++) {
+      const { user } = await usersFactory.create();
+      const { companyInvestor } = await companyInvestorsFactory.create({
+        companyId: company.id,
+        userId: user.id,
+      });
+
+      await shareHoldingsFactory.create({
+        companyInvestorId: companyInvestor.id,
+        shareClassId: assertDefined(shareClasses[i % 2]).id,
+        numberOfShares: 1000 * (i + 1),
+      });
+
+      investorUsers.push(user);
+    }
+
+    return { company, adminUser, investorUsers, tenderOffer };
+  },
+
+  createExpiredTenderOfferScenario: async () => {
+    const { company, adminUser } = await companiesFactory.createCompletedOnboarding({
+      equityEnabled: true,
+    });
+
+    const { tenderOffer } = await tenderOffersFactory.createExpired({
+      companyId: company.id,
+    });
+
+    const { user: investorUser } = await usersFactory.create();
+    const { companyInvestor } = await companyInvestorsFactory.create({
+      companyId: company.id,
+      userId: investorUser.id,
+    });
+
+    await shareHoldingsFactory.create({
+      companyInvestorId: companyInvestor.id,
+      shareClassId: (await shareClassesFactory.create({ companyId: company.id, name: "Common" })).shareClass.id,
+      numberOfShares: 1000,
+    });
+
+    return { company, adminUser, investorUsers: [investorUser], tenderOffer };
+  },
+
+  createCompletedTenderOfferScenario: async () => {
+    const scenario = await tenderOfferScenarioBuilder.createBasicScenario();
+
+    const { tenderOffer } = await tenderOffersFactory.createExpired({
+      companyId: scenario.company.id,
+      acceptedPriceCents: 4500,
+      numberOfShares: 500n,
+      numberOfShareholders: 2,
+      totalAmountInCents: 2250000n,
+    });
+
+    for (let i = 0; i < 2; i++) {
+      const investor = await db.query.companyInvestors.findFirst({
+        where: (ci, { and, eq }) =>
+          and(eq(ci.companyId, scenario.company.id), eq(ci.userId, assertDefined(scenario.investorUsers[i]).id)),
+      });
+
+      if (investor) {
+        await tenderOfferBidsFactory.createAccepted({
+          tenderOfferId: tenderOffer.id,
+          companyInvestorId: investor.id,
+          numberOfShares: String(250),
+          sharePriceCents: 4500,
+          acceptedShares: String(250),
+        });
+      }
+    }
+
+    return { ...scenario, tenderOffer };
+  },
+};

--- a/e2e/factories/tenderOfferBids.ts
+++ b/e2e/factories/tenderOfferBids.ts
@@ -1,0 +1,71 @@
+import { db } from "@test/db";
+import { companyInvestorsFactory } from "@test/factories/companyInvestors";
+import { tenderOffersFactory } from "@test/factories/tenderOffers";
+import { tenderOfferBids } from "@/db/schema";
+import { assert } from "@/utils/assert";
+
+export const tenderOfferBidsFactory = {
+  create: async (overrides: Partial<typeof tenderOfferBids.$inferInsert> = {}) => {
+    const tenderOfferId = overrides.tenderOfferId || (await tenderOffersFactory.createActive()).tenderOffer.id;
+    const companyInvestorId =
+      overrides.companyInvestorId || (await companyInvestorsFactory.create()).companyInvestor.id;
+
+    const [createdBid] = await db
+      .insert(tenderOfferBids)
+      .values({
+        tenderOfferId,
+        companyInvestorId,
+        numberOfShares: "100",
+        sharePriceCents: 5000,
+        shareClass: "Common",
+        acceptedShares: "0",
+        ...overrides,
+      })
+      .returning();
+    assert(createdBid !== undefined);
+
+    return { bid: createdBid };
+  },
+
+  createAccepted: async (overrides: Partial<typeof tenderOfferBids.$inferInsert> = {}) => {
+    const acceptedShares = overrides.numberOfShares || "100";
+    return tenderOfferBidsFactory.create({
+      acceptedShares,
+      ...overrides,
+    });
+  },
+
+  createPartiallyAccepted: async (overrides: Partial<typeof tenderOfferBids.$inferInsert> = {}) => {
+    const numberOfShares = overrides.numberOfShares || "100";
+    const acceptedShares = String(Math.floor(Number(numberOfShares) / 2));
+    return tenderOfferBidsFactory.create({
+      numberOfShares,
+      acceptedShares,
+      ...overrides,
+    });
+  },
+
+  createRejected: async (overrides: Partial<typeof tenderOfferBids.$inferInsert> = {}) =>
+    tenderOfferBidsFactory.create({
+      acceptedShares: "0",
+      ...overrides,
+    }),
+
+  createMultiple: async (
+    count: number,
+    tenderOfferId: bigint,
+    overrides: Partial<typeof tenderOfferBids.$inferInsert> = {},
+  ) => {
+    const bids = [];
+    for (let i = 0; i < count; i++) {
+      const bid = await tenderOfferBidsFactory.create({
+        tenderOfferId,
+        numberOfShares: String(100 + i * 50),
+        sharePriceCents: 5000 - i * 100,
+        ...overrides,
+      });
+      bids.push(bid);
+    }
+    return bids;
+  },
+};

--- a/e2e/factories/tenderOffers.ts
+++ b/e2e/factories/tenderOffers.ts
@@ -1,0 +1,79 @@
+import { faker } from "@faker-js/faker";
+import { db } from "@test/db";
+import { companiesFactory } from "@test/factories/companies";
+import { addDays, subDays } from "date-fns";
+import { activeStorageAttachments, activeStorageBlobs, tenderOffers } from "@/db/schema";
+import { assert } from "@/utils/assert";
+
+export const tenderOffersFactory = {
+  create: async (overrides: Partial<typeof tenderOffers.$inferInsert> = {}) => {
+    const companyId = overrides.companyId || (await companiesFactory.create()).company.id;
+
+    const startsAt = overrides.startsAt || subDays(new Date(), 5);
+    const endsAt = overrides.endsAt || addDays(new Date(), 1);
+
+    const [createdTenderOffer] = await db
+      .insert(tenderOffers)
+      .values({
+        companyId,
+        startsAt,
+        endsAt,
+        minimumValuation: 100000n,
+        letterOfTransmittal: overrides.letterOfTransmittal || faker.lorem.paragraph(),
+        ...overrides,
+      })
+      .returning();
+    assert(createdTenderOffer !== undefined);
+
+    const [blob] = await db
+      .insert(activeStorageBlobs)
+      .values({
+        key: `${createdTenderOffer.externalId}-tender-offer-attachment`,
+        filename: "attachment.zip",
+        serviceName: "test",
+        byteSize: 100n,
+        contentType: "application/zip",
+      })
+      .returning();
+    assert(blob !== undefined);
+
+    await db.insert(activeStorageAttachments).values({
+      recordId: createdTenderOffer.id,
+      recordType: "TenderOffer",
+      blobId: blob.id,
+      name: "attachment",
+    });
+
+    return { tenderOffer: createdTenderOffer };
+  },
+
+  createActive: async (overrides: Partial<typeof tenderOffers.$inferInsert> = {}) =>
+    tenderOffersFactory.create({
+      startsAt: subDays(new Date(), 1),
+      endsAt: addDays(new Date(), 7),
+      ...overrides,
+    }),
+
+  createExpired: async (overrides: Partial<typeof tenderOffers.$inferInsert> = {}) =>
+    tenderOffersFactory.create({
+      startsAt: subDays(new Date(), 30),
+      endsAt: subDays(new Date(), 1),
+      ...overrides,
+    }),
+
+  createUpcoming: async (overrides: Partial<typeof tenderOffers.$inferInsert> = {}) =>
+    tenderOffersFactory.create({
+      startsAt: addDays(new Date(), 1),
+      endsAt: addDays(new Date(), 30),
+      ...overrides,
+    }),
+
+  createWithAcceptedPrice: async (overrides: Partial<typeof tenderOffers.$inferInsert> = {}) =>
+    tenderOffersFactory.create({
+      acceptedPriceCents: 4500,
+      numberOfShares: 10000n,
+      numberOfShareholders: 5,
+      totalAmountInCents: 45000000n,
+      ...overrides,
+    }),
+};

--- a/e2e/helpers/tenderOffers.ts
+++ b/e2e/helpers/tenderOffers.ts
@@ -1,0 +1,12 @@
+import type { Page } from "@playwright/test";
+
+export const navigateToTenderOffers = async (page: Page) => {
+  await page.getByRole("button", { name: "Equity" }).click();
+  await page.getByRole("link", { name: "Buybacks" }).click();
+  await page.waitForURL(/\/equity\/tender_offers/u);
+};
+
+export const openTenderOfferDetails = async (page: Page, tenderOfferId: string) => {
+  await page.locator(`a[href="/equity/tender_offers/${tenderOfferId}"]`).click();
+  await page.waitForURL(/\/equity\/tender_offers\/[a-zA-Z0-9]+/u);
+};

--- a/e2e/tests/company/tender-offers/place-bid.spec.ts
+++ b/e2e/tests/company/tender-offers/place-bid.spec.ts
@@ -1,0 +1,99 @@
+import { tenderOfferScenarioBuilder } from "@test/builders/tenderOfferScenarios";
+import { db, takeOrThrow } from "@test/db";
+import { login } from "@test/helpers/auth";
+import { navigateToTenderOffers, openTenderOfferDetails } from "@test/helpers/tenderOffers";
+import { expect, test } from "@test/index";
+import { assertDefined } from "@/utils/assert";
+
+test.describe.configure({ mode: "serial" });
+test.describe("Tender Offer Bid Placement", () => {
+  test("investor can place a bid on an active tender offer", async ({ page }) => {
+    const scenario = await tenderOfferScenarioBuilder.createBasicScenario();
+    const investorUser = assertDefined(scenario.investorUsers[0]);
+
+    await login(page, investorUser);
+    await navigateToTenderOffers(page);
+    await openTenderOfferDetails(page, scenario.tenderOffer.externalId);
+
+    await page.getByRole("button", { name: "Add your signature" }).click();
+
+    await page.getByLabel("Share class").click();
+    await page.getByRole("option").first().click();
+    await page.getByLabel("Number of shares").fill("100");
+    await page.getByLabel("Price per share").fill("45");
+
+    await expect(page.getByText("Total amount: $4,500")).toBeVisible();
+
+    await page.getByRole("button", { name: "Submit bid" }).click();
+
+    await expect(page.getByRole("cell", { name: "100" })).toBeVisible();
+    await expect(page.getByRole("cell", { name: "$45" })).toBeVisible();
+  });
+
+  test("investor cannot place bid on expired tender offer", async ({ page }) => {
+    const scenario = await tenderOfferScenarioBuilder.createExpiredTenderOfferScenario();
+    const investorUser = assertDefined(scenario.investorUsers[0]);
+
+    await login(page, investorUser);
+    await navigateToTenderOffers(page);
+
+    await openTenderOfferDetails(page, scenario.tenderOffer.externalId);
+
+    await expect(page.getByRole("button", { name: "Submit bid" })).not.toBeVisible();
+  });
+
+  test("investor can view existing bids", async ({ page }) => {
+    const scenario = await tenderOfferScenarioBuilder.createScenarioWithExistingBids();
+    const investorUser = assertDefined(scenario.investorUsers[0]);
+
+    await login(page, investorUser);
+    await navigateToTenderOffers(page);
+    await openTenderOfferDetails(page, scenario.tenderOffer.externalId);
+
+    const investor = await db.query.companyInvestors
+      .findFirst({
+        where: (ci, { and, eq }) => and(eq(ci.companyId, scenario.company.id), eq(ci.userId, investorUser.id)),
+      })
+      .then(takeOrThrow);
+
+    const bid = await db.query.tenderOfferBids
+      .findFirst({
+        where: (tob, { and, eq }) =>
+          and(eq(tob.tenderOfferId, scenario.tenderOffer.id), eq(tob.companyInvestorId, investor.id)),
+      })
+      .then(takeOrThrow);
+
+    await expect(page.getByRole("cell", { name: bid.numberOfShares.toString() })).toBeVisible();
+    await expect(page.getByRole("cell", { name: `$${bid.sharePriceCents / 100}` })).toBeVisible();
+  });
+
+  test("investor cannot exceed available shares", async ({ page }) => {
+    const scenario = await tenderOfferScenarioBuilder.createBasicScenario();
+    const investorUser = assertDefined(scenario.investorUsers[0]);
+
+    const investor = await db.query.companyInvestors
+      .findFirst({
+        where: (ci, { and, eq }) => and(eq(ci.companyId, scenario.company.id), eq(ci.userId, investorUser.id)),
+      })
+      .then(takeOrThrow);
+
+    const holdings = await db.query.shareHoldings.findFirst({
+      where: (sh, { eq }) => eq(sh.companyInvestorId, investor.id),
+    });
+
+    await login(page, investorUser);
+    await navigateToTenderOffers(page);
+    await openTenderOfferDetails(page, scenario.tenderOffer.externalId);
+
+    await page.getByRole("button", { name: "Add your signature" }).click();
+
+    await page.getByLabel("Share class").click();
+    await page.getByRole("option").first().click();
+    const excessiveShares = String(Number(holdings?.numberOfShares || 0) + 1000);
+    await page.getByLabel("Number of shares").fill(excessiveShares);
+    await page.getByLabel("Price per share").fill("45");
+
+    await page.getByRole("button", { name: "Submit bid" }).click();
+    await expect(page.getByText(/Number of shares must be between/iu)).toBeVisible();
+  });
+});


### PR DESCRIPTION
Part of https://github.com/antiwork/flexile/issues/96

This PR adds E2E tests for participate in buybacks by placing a bid. There is no change in UI or business logic.

In a follow up PR I would refactor the bidding page to modal after this PR with E2E tests are merged as mentioned by @slavingia .

Screenshot of E2E tests passing locally

![Screenshot 2025-09-04 at 7 48 11 PM](https://github.com/user-attachments/assets/2cfeab31-f5fb-4ab7-9927-60b49edc2db8)

### AI Disclosure
I have used Claude Code in planning phase
