### PR TITLE
feat(equity-settings): require company name before enabling equity

### DIFF
--- a/frontend/app/settings/administrator/equity/page.tsx
+++ b/frontend/app/settings/administrator/equity/page.tsx
@@ -2,13 +2,17 @@
 
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { Info } from "lucide-react";
+import Link from "next/link";
 import { useState } from "react";
 import { useForm } from "react-hook-form";
 import { z } from "zod";
 import { useExerciseDataConfig } from "@/app/(dashboard)/equity/options";
+import { linkClasses } from "@/components/Link";
 import { MutationStatusButton } from "@/components/MutationButton";
 import NumberInput from "@/components/NumberInput";
 import { Editor as RichTextEditor } from "@/components/RichText";
+import { Alert, AlertDescription } from "@/components/ui/alert";
 import { Form, FormControl, FormField, FormItem, FormLabel, FormMessage } from "@/components/ui/form";
 import { Switch } from "@/components/ui/switch";
 import { useCurrentCompany } from "@/global";
@@ -23,10 +27,12 @@ const formSchema = z.object({
 
 export default function Equity() {
   const company = useCurrentCompany();
+  const [settings] = trpc.companies.settings.useSuspenseQuery({ companyId: company.id });
   const utils = trpc.useUtils();
   const queryClient = useQueryClient();
   const [localEquityEnabled, setLocalEquityEnabled] = useState(company.equityEnabled);
   const { data: exerciseData } = useQuery(useExerciseDataConfig());
+  const requiresCompanyName = !settings.name || settings.name.trim().length === 0;
 
   // Separate mutation for the toggle
   const updateEquityEnabled = trpc.companies.update.useMutation({
@@ -61,6 +67,7 @@ export default function Equity() {
       conversionSharePriceUsd: Number(company.conversionSharePriceUsd),
       exerciseNotice: exerciseData?.exercise_notice ?? null,
     },
+    disabled: requiresCompanyName,
   });
 
   const submit = form.handleSubmit((values) =>
@@ -81,7 +88,19 @@ export default function Equity() {
           Manage your company ownership, including cap table, option pools, and grants.
         </p>
       </hgroup>
-      <div className="bg-card border-input rounded-lg border p-4">
+      {requiresCompanyName ? (
+        <Alert>
+          <Info className="my-auto size-4" />
+          <AlertDescription>
+            Please{" "}
+            <Link href="/settings/administrator/details" className={linkClasses}>
+              add your company name
+            </Link>{" "}
+            in order to manage equity settings.
+          </AlertDescription>
+        </Alert>
+      ) : null}
+      <div className={`bg-card border-input rounded-lg border p-4 ${requiresCompanyName ? "opacity-50" : ""}`}>
         <div className="flex items-center justify-between">
           <div>
             <div className="font-semibold">Enable equity</div>
@@ -95,13 +114,13 @@ export default function Equity() {
               void handleToggle(checked);
             }}
             aria-label="Enable equity"
-            disabled={updateEquityEnabled.isPending}
+            disabled={updateEquityEnabled.isPending || requiresCompanyName}
           />
         </div>
       </div>
       {localEquityEnabled ? (
         <Form {...form}>
-          <form className="grid gap-8" onSubmit={(e) => void submit(e)}>
+          <form className={`grid gap-8 ${requiresCompanyName ? "opacity-50" : ""}`} onSubmit={(e) => void submit(e)}>
             <hgroup>
               <h2 className="mb-1 font-bold">Equity value</h2>
               <p className="text-muted-foreground text-base">


### PR DESCRIPTION
ref #911 

<img width="2940" height="1912" alt="image" src="https://github.com/user-attachments/assets/892e69c4-acf5-483d-bdf0-eb242bb876a8" />






| Before | After |
|--------|-------|
| <img width="375" height="812" alt="image" src="https://github.com/user-attachments/assets/fcc570cc-2273-487c-a541-84a9cc36163b" />  | <img width="375" height="812" alt="image" src="https://github.com/user-attachments/assets/970aac1c-6a65-489d-a273-c3b109672777" />

# Before
 <img width="1470" height="835" alt="image" src="https://github.com/user-attachments/assets/1bd2c16a-7360-442d-a8b0-073a591d894e" /> 

# After
 <img width="1470" height="835" alt="image" src="https://github.com/user-attachments/assets/e67a2b70-0d8d-42c8-95cf-3fe0b39d5c4e" />





* Several backend equity flows assume `company.name` is present:

  * `EquityGrantCreation#next_grant_name` uses `company.name.first(3)` when generating grant names.
  * `EquityExercisingService#next_share_name` uses `company.name.first(1)` for share holdings.
  * `GenerateTaxFormService` embeds `company.name.parameterize` into document filenames.
  
* Triggering these flows without a company name would cause runtime errors.
* The guardrail ensures admins cannot proceed until the required company metadata is set.
* Matches the existing **fade + disable UX** used (e.g., invoice creation without legal details).



> [!NOTE]
> AI assistance was used in preparing this PR:
> - **Cursor Pro (GPT-5)**: for code scaffolding and refactoring suggestions  
> - **Claude Sonnet 4**: for explanation drafts and wording improvements
