### PR TITLE
Update GitHub Actions workflows to conditionally use specific runners based on repository name

### DIFF
--- a/.github/workflows/autofix.yml
+++ b/.github/workflows/autofix.yml
@@ -13,7 +13,7 @@ permissions:
 
 jobs:
   autofix:
-    runs-on: ubicloud-standard-2
+    runs-on: ${{ github.repository == 'antiwork/flexile' && 'ubicloud-standard-2' || 'ubuntu-latest' }}
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -20,7 +20,7 @@ env:
 
 jobs:
   rspec:
-    runs-on: ubicloud-standard-2
+    runs-on: ${{ github.repository == 'antiwork/flexile' && 'ubicloud-standard-2' || 'ubuntu-latest' }}
 
     services:
       postgres:
@@ -59,7 +59,7 @@ jobs:
 
   playwright:
     name: playwright
-    runs-on: ubicloud-standard-8
+    runs-on: ${{ github.repository == 'antiwork/flexile' && 'ubicloud-standard-8' || 'ubuntu-latest' }}
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Fixes #1025 (thanks, @sm17p)

The `runs-on` attribute for both `autofix` and `tests` jobs now checks if the repository is 'antiwork/flexile' to select the appropriate runner, defaulting to 'ubuntu-latest' otherwise.