### PR TITLE
fix: text on payouts page

### DIFF
--- a/frontend/app/settings/payouts/page.tsx
+++ b/frontend/app/settings/payouts/page.tsx
@@ -29,6 +29,9 @@ import {
 } from "@/utils/routes";
 import BankAccountModal, { type BankAccount, bankAccountSchema } from "./BankAccountModal";
 
+const getPayRateDisplayText = (payRateType: "hourly" | "project_based"): string =>
+  payRateType === "project_based" ? "project" : "hourly";
+
 export default function PayoutsPage() {
   const user = useCurrentUser();
   const company = useCurrentCompany();
@@ -105,7 +108,7 @@ const EquitySection = () => {
                 <div>Cash amount</div>
                 <div>
                   {formatMoneyFromCents(((100 - equityPercentage) * payRateInSubunits) / 100)}{" "}
-                  <span className="text-gray-500">/ {worker.payRateType}</span>
+                  <span className="text-gray-500">/ {getPayRateDisplayText(worker.payRateType)}</span>
                 </div>
               </div>
               <Separator />
@@ -113,7 +116,7 @@ const EquitySection = () => {
                 <div>Equity value</div>
                 <div>
                   {formatMoneyFromCents((equityPercentage * payRateInSubunits) / 100)}{" "}
-                  <span className="text-gray-500">/ {worker.payRateType}</span>
+                  <span className="text-gray-500">/ {getPayRateDisplayText(worker.payRateType)}</span>
                 </div>
               </div>
               <Separator />
@@ -121,7 +124,7 @@ const EquitySection = () => {
                 <div>Total amount</div>
                 <div>
                   {formatMoneyFromCents(payRateInSubunits)}{" "}
-                  <span className="text-gray-500">/ {worker.payRateType}</span>
+                  <span className="text-gray-500">/ {getPayRateDisplayText(worker.payRateType)}</span>
                 </div>
               </div>
             </div>


### PR DESCRIPTION
Ref:- https://github.com/antiwork/flexile/issues/911

Text on https://flexile.com/settings/payouts for a contractor displays `project_based`  instead of "project"

Before:-
![Screenshot 2025-09-06 at 2 17 26 AM](https://github.com/user-attachments/assets/2d7519f5-b402-43d1-8438-d6a5f89fa92c)

After:-
![Screenshot 2025-09-06 at 2 22 45 AM](https://github.com/user-attachments/assets/c4d07c36-f9b1-41bc-b11b-2ede4636a9b3)


### AI Disclosure:-
I have not used any AI assistance in this PR
