### PR TITLE
fix: dialog close button on small screens

### DIFF
--- a/frontend/components/ui/dialog.tsx
+++ b/frontend/components/ui/dialog.tsx
@@ -1,5 +1,6 @@
 import * as DialogPrimitive from "@radix-ui/react-dialog";
 import { XIcon } from "lucide-react";
+import { usePathname } from "next/navigation";
 import * as React from "react";
 import { cn } from "@/utils";
 import { useIsMobile } from "@/utils/use-mobile";
@@ -36,6 +37,8 @@ function DialogContent({
   showCloseButton?: boolean;
 }) {
   const isMobile = useIsMobile();
+  const pathname = usePathname();
+  const hideCloseButton = isMobile && pathname === "/invoices";
 
   return (
     <DialogPortal data-slot="dialog-portal">
@@ -52,7 +55,7 @@ function DialogContent({
         {...props}
       >
         {children}
-        {showCloseButton && !isMobile ? (
+        {showCloseButton && !hideCloseButton ? (
           <DialogPrimitive.Close
             data-slot="dialog-close"
             className="ring-offset-background focus:ring-ring data-[state=open]:bg-accent data-[state=open]:text-muted-foreground absolute top-[26px] right-5 mt-2 mr-2 cursor-pointer rounded-xs opacity-70 transition-opacity hover:opacity-100 focus:ring-2 focus:ring-offset-2 focus:outline-hidden disabled:pointer-events-none [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4"


### PR DESCRIPTION
Ref:- https://github.com/antiwork/flexile/issues/911

## Description 

- Updated DialogContent component to conditionally hide the close button 
  only on the /invoices page when rendered on mobile devices.

- Previously, the dialog close button was hidden on all mobile pages, which 
caused usability issues outside of /invoices.  
- Now the button remains visible everywhere else and only hides where intended.

### Screenshots 
before: 

<img width="508" height="897" alt="Screenshot from 2025-09-06 14-01-46" src="https://github.com/user-attachments/assets/ef831065-9445-4e64-b664-c22b632da5c6" />

<img width="508" height="897" alt="Screenshot from 2025-09-06 14-04-03" src="https://github.com/user-attachments/assets/d99930cc-2626-4b9d-abf8-4ecf600a1e22" />

after:

<img width="508" height="897" alt="image" src="https://github.com/user-attachments/assets/38af1580-161f-41b2-bf76-d067c9463c0d" />

<img width="508" height="897" alt="image" src="https://github.com/user-attachments/assets/9f8cab12-acd2-4cac-afcc-f7402dd0c520" />


this remains the same : 

<img width="508" height="897" alt="image" src="https://github.com/user-attachments/assets/c74bc9ee-71ee-4494-bb8f-b5718eaad388" />


#### AI Disclosure:-
I have not used any AI assistance in this PR