### PR TITLE
Fix Tax ID and Date of Birth alignment

### DIFF
--- a/frontend/app/settings/tax/page.tsx
+++ b/frontend/app/settings/tax/page.tsx
@@ -353,7 +353,7 @@ export default function TaxPage() {
               )}
             />
 
-            <div className="grid items-start gap-3 md:grid-cols-2">
+            <div className="grid items-start gap-3 lg:grid-cols-2">
               <FormField
                 control={form.control}
                 name="tax_id"


### PR DESCRIPTION
Ref #911 
## What Changed
- Switched the **Tax ID + Date of Birth** container from `md:grid-cols-2` → `lg:grid-cols-2`.
- This keeps the fields stacked until larger screens, avoiding mid-width collisions when the **VERIFIED / INVALID / VERIFYING** badge appears.

## Why
- Between ~**770–860px**, the status badge next to the **Tax ID** label was increasing row width and forcing the grid to wrap, causing the **DOB** field to jump below.
- Deferring the two-column layout to `lg` (≥1024px) ensures consistent alignment and prevents awkward wraps at medium widths.

## Testing
- Verified at common breakpoints: **360, 414, 768, 820, 912, 1024, 1280** px.
- Checked all Tax ID states: **VERIFIED / INVALID / VERIFYING**, and entity modes: **Individual/Business**, **Foreign/US**.
- Confirmed fields: stay stacked <1024px, side-by-side ≥1024px, with no overlap/misalignment.
- Form validation and submission behavior unchanged.


## Screenshots / Video (before & after)
Before

https://github.com/user-attachments/assets/a85f5232-693b-4cdf-ae13-1d738a7e9e56



After


https://github.com/user-attachments/assets/61ee0822-15dc-4034-a652-880312696efe


## AI Assistance
No AI was used to generate any of this code or description.  
