### PR TITLE
fix leave workspace success handling

### DIFF
--- a/e2e/tests/settings/leave-company.spec.ts
+++ b/e2e/tests/settings/leave-company.spec.ts
@@ -36,7 +36,7 @@ test.describe("Leave company", () => {
     await expect(page.getByText("Leave this workspace?")).toBeVisible();
     await page.getByRole("button", { name: "Leave" }).click();
 
-    await expect(page).toHaveURL("/invoices");
+    await expect(page).toHaveURL("/login");
 
     const contractor = await db.query.companyContractors.findFirst({
       where: and(eq(companyContractors.companyId, company.id), eq(companyContractors.userId, user.id)),
@@ -61,7 +61,7 @@ test.describe("Leave company", () => {
     await expect(page.getByText("Leave this workspace?")).toBeVisible();
     await page.getByRole("button", { name: "Leave" }).click();
 
-    await expect(page).toHaveURL("/equity/dividends");
+    await expect(page).toHaveURL("/login");
 
     const investor = await db.query.companyInvestors.findFirst({
       where: and(eq(companyInvestors.companyId, company.id), eq(companyInvestors.userId, user.id)),
@@ -86,7 +86,7 @@ test.describe("Leave company", () => {
     await expect(page.getByText("Leave this workspace?")).toBeVisible();
     await page.getByRole("button", { name: "Leave" }).click();
 
-    await expect(page).toHaveURL("/documents");
+    await expect(page).toHaveURL("/login");
 
     const lawyer = await db.query.companyLawyers.findFirst({
       where: and(eq(companyLawyers.companyId, company.id), eq(companyLawyers.userId, user.id)),
@@ -116,7 +116,7 @@ test.describe("Leave company", () => {
     await expect(page.getByText("Leave this workspace?")).toBeVisible();
     await page.getByRole("button", { name: "Leave" }).click();
 
-    await expect(page).toHaveURL("/invoices");
+    await expect(page).toHaveURL("/login");
 
     const contractor = await db.query.companyContractors.findFirst({
       where: and(eq(companyContractors.companyId, company.id), eq(companyContractors.userId, user.id)),

--- a/e2e/tests/settings/leave-company.spec.ts
+++ b/e2e/tests/settings/leave-company.spec.ts
@@ -177,7 +177,6 @@ test.describe("Leave company", () => {
     await expect(page.getByText("Leave this workspace?")).toBeVisible();
     await page.getByRole("button", { name: "Leave" }).click();
 
-    await expect(page.getByText("Success!")).toBeVisible();
     await expect(page.getByRole("button", { name: "Company A" })).toBeVisible();
 
     const investor = await db.query.companyInvestors.findFirst({

--- a/frontend/app/settings/page.tsx
+++ b/frontend/app/settings/page.tsx
@@ -139,9 +139,8 @@ const LeaveWorkspaceSection = () => {
     },
     onSuccess: async () => {
       await queryClient.invalidateQueries({ queryKey: ["currentUser"] });
-      document.cookie = `${user.id}_selected_company=; path=/; max-age=0`;
 
-      if (Object.keys(user.companies).length > 1) {
+      if (user.companies.length > 1) {
         router.push("/dashboard");
       } else {
         await signOut({ redirect: false }).then(logout);

--- a/frontend/app/settings/page.tsx
+++ b/frontend/app/settings/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
-import { useMutation, useQueryClient } from "@tanstack/react-query";
-import { useRouter } from "next/navigation";
+import { useMutation } from "@tanstack/react-query";
+import { signOut } from "next-auth/react";
 import React, { useState } from "react";
 import { useForm } from "react-hook-form";
 import { z } from "zod";
@@ -21,7 +21,7 @@ import { Button } from "@/components/ui/button";
 import { Card, CardAction, CardHeader } from "@/components/ui/card";
 import { Form, FormControl, FormField, FormItem, FormLabel, FormMessage } from "@/components/ui/form";
 import { Input } from "@/components/ui/input";
-import { useCurrentCompany, useCurrentUser } from "@/global";
+import { useCurrentCompany, useCurrentUser, useUserStore } from "@/global";
 import defaultLogo from "@/images/default-company-logo.svg";
 import { MAX_PREFERRED_NAME_LENGTH, MIN_EMAIL_LENGTH } from "@/models";
 import { request } from "@/utils/request";
@@ -109,9 +109,8 @@ const DetailsSection = () => {
 
 const LeaveWorkspaceSection = () => {
   const user = useCurrentUser();
+  const { logout } = useUserStore();
   const company = useCurrentCompany();
-  const router = useRouter();
-  const queryClient = useQueryClient();
   const [isModalOpen, setIsModalOpen] = useState(false);
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
 
@@ -136,11 +135,8 @@ const LeaveWorkspaceSection = () => {
       return data;
     },
     onSuccess: async () => {
-      await queryClient.invalidateQueries({ queryKey: ["currentUser"] });
-      setTimeout(() => {
-        setIsModalOpen(false);
-        router.push("/dashboard");
-      }, 1000);
+      await signOut({ redirect: false }).then(logout);
+      window.location.href = "/login";
     },
     onError: (error: Error) => {
       setErrorMessage(error.message);


### PR DESCRIPTION
AI Disclosure
No AI was used

This PR handles the leave workspace success scenario. Instead of redirecting the user to various pages, it now logs them out, allowing them to start a fresh session. This approach prevents the unintended creation of a new company when a user isn't associated with one, reducing confusion for users who don't wish to continue. Those who do want to continue can simply log back in and will be redirected to an existing or new company.

Demo

https://github.com/user-attachments/assets/0f0d89ba-63db-48e1-b0ba-cc0f178fd06c


E2E
<img width="704" height="349" alt="Screenshot 2025-09-12 at 12 17 22 AM" src="https://github.com/user-attachments/assets/5b0e4c08-f232-4b60-b72b-662ce2aad84e" />

Part of #911 and https://github.com/antiwork/flexile/issues/1132