### PR TITLE
fix + improvement: correct loading state usage and add error & empty state handling

### DIFF
--- a/frontend/app/settings/administrator/billing/page.tsx
+++ b/frontend/app/settings/administrator/billing/page.tsx
@@ -111,7 +111,12 @@ const stripePromise = loadStripe(env.NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY);
 export default function Billing() {
   const company = useCurrentCompany();
   const [addingBankAccount, setAddingBankAccount] = useState(false);
-  const { data: stripeData } = useQuery({
+  const {
+    data: stripeData,
+    isLoading: isStripeDataLoading,
+    refetch: refetchStripeData,
+    error: stripeDataError,
+  } = useQuery({
     queryKey: ["administratorBankAccount", company.id],
     queryFn: async () => {
       const response = await request({
@@ -169,8 +174,24 @@ export default function Billing() {
             <AddBankAccount open={addingBankAccount} onOpenChange={setAddingBankAccount} />
           </Elements>
         </>
-      ) : (
+      ) : isStripeDataLoading ? (
         <BankAccountCardSkeleton />
+      ) : stripeDataError ? (
+        <Placeholder icon={CircleDollarSign}>
+          <p>Unable to load payment method information.</p>
+          <Button variant="outline" onClick={() => refetchStripeData()}>
+            <RefreshCw className="size-4" />
+            Try again
+          </Button>
+        </Placeholder>
+      ) : (
+        <Placeholder icon={CircleDollarSign}>
+          <p>No payment method found.</p>
+          <Button variant="outline" onClick={() => refetchStripeData()}>
+            <RefreshCw className="size-4" />
+            Try again
+          </Button>
+        </Placeholder>
       )}
       <StripeMicrodepositVerification />
       <h3 className="mt-4 text-base font-medium">Billing history</h3>


### PR DESCRIPTION
### problem:

1. for payout method component, we use loading state of `trpc.consolidatedInvoices` query, instead of stripeData's query.
2. we weren't handling empty and loading state. (in both of those cases we were just loading skeleton

# Before:
https://github.com/user-attachments/assets/c3e87f08-1b78-4c39-a91a-95176916eb7d

# After:
https://github.com/user-attachments/assets/2e59e459-a8d9-404c-830d-92edd6c50e06

ref #911 