### PR TITLE
fix: considers the invoice year when calculating equity test and complete flow

### DIFF
--- a/e2e/helpers/index.ts
+++ b/e2e/helpers/index.ts
@@ -1,5 +1,4 @@
-import type { Locator, Page } from "@playwright/test";
-import { expect } from "@test/index";
+import { expect, type Locator, type Page } from "@playwright/test";
 
 export const selectComboboxOption = async (page: Page, name: string, option: string) => {
   await page.getByRole("combobox", { name }).click();
@@ -14,3 +13,26 @@ export const fillDatePicker = async (page: Page, name: string, value: string) =>
 
 export const findRichTextEditor = (page: Locator | Page, name: string) =>
   page.locator(`xpath=.//*[@contenteditable="true" and (./@id = //label[contains(., ${JSON.stringify(name)})]/@for)]`);
+
+export type FillByLabelOptions = {
+  index?: number;
+  exact?: boolean;
+  blur?: boolean;
+};
+
+export const fillByLabelSafe = async (page: Page, name: string, value: string, options: FillByLabelOptions = {}) => {
+  const { index, exact, blur = true } = options;
+  let field = page.getByLabel(name, { exact: Boolean(exact) });
+  if (typeof index === "number") {
+    field = field.nth(index);
+  }
+
+  await expect(field).toBeVisible();
+  await expect(field).toBeEditable();
+
+  await field.fill(value);
+
+  if (blur) {
+    await field.blur();
+  }
+};

--- a/e2e/helpers/index.ts
+++ b/e2e/helpers/index.ts
@@ -6,7 +6,7 @@ export const selectComboboxOption = async (page: Page, name: string, option: str
 };
 
 export const fillDatePicker = async (page: Page, name: string, value: string) =>
-  page.getByRole("spinbutton", { name }).first().pressSequentially(value, { delay: 50 });
+  page.getByRole("spinbutton", { name }).first().pressSequentially(value, { delay: 100 });
 
 export const findRichTextEditor = (page: Locator | Page, name: string) =>
   page.locator(`xpath=.//*[@contenteditable="true" and (./@id = //label[contains(., ${JSON.stringify(name)})]/@for)]`);

--- a/e2e/helpers/index.ts
+++ b/e2e/helpers/index.ts
@@ -1,12 +1,16 @@
 import type { Locator, Page } from "@playwright/test";
+import { expect } from "@test/index";
 
 export const selectComboboxOption = async (page: Page, name: string, option: string) => {
   await page.getByRole("combobox", { name }).click();
   await page.getByRole("option", { name: option, exact: true }).first().click();
 };
 
-export const fillDatePicker = async (page: Page, name: string, value: string) =>
-  page.getByRole("spinbutton", { name }).first().pressSequentially(value, { delay: 100 });
+export const fillDatePicker = async (page: Page, name: string, value: string) => {
+  const date = page.getByRole("spinbutton", { name }).first();
+  await expect(date).toBeEditable();
+  return date.pressSequentially(value, { delay: 100 });
+};
 
 export const findRichTextEditor = (page: Locator | Page, name: string) =>
   page.locator(`xpath=.//*[@contenteditable="true" and (./@id = //label[contains(., ${JSON.stringify(name)})]/@for)]`);

--- a/e2e/tests/company/invoices/create.spec.ts
+++ b/e2e/tests/company/invoices/create.spec.ts
@@ -67,7 +67,13 @@ test.describe("invoice creation", () => {
     await expect(page.getByText("Swapped for equity (not paid in cash)$0")).toBeVisible();
     await expect(page.getByText("Net amount in cash$60")).toBeVisible();
 
+    const date = page.getByRole("spinbutton", { name: "Date" }).first();
+    await expect(date).toBeEditable();
     await fillDatePicker(page, "Date", "08/08/2021");
+    const hoursQty = page.getByLabel("Hours / Qty");
+    await expect(hoursQty).toHaveValue("03:25");
+    await expect(hoursQty).toBeEditable();
+    await hoursQty.clear();
     await page.getByLabel("Hours / Qty").fill("100:00");
     await page.getByPlaceholder("Description").fill("I worked on invoices");
 


### PR DESCRIPTION
This PR fixes flakiness in many e2e tests like "considers the invoice year when calculating equity test" and "allows contractor to submit/delete invoices and admin to approve/reject them" and all the other invoice related test.

AI Disclosure:
No AI assitance was used in this PR

Before:-

considers the invoice year when calculating equity test
![Screenshot 2025-09-14 at 2 00 24 AM](https://github.com/user-attachments/assets/45986816-2a76-40fa-8fe8-fd9fbc6efb2f)

I was able to reproduce the flakiness locally 
![Screenshot 2025-09-14 at 1 42 08 AM](https://github.com/user-attachments/assets/291687a8-9507-4845-94ba-1d8be560f7bc)



After:- 
I ran these test 5+ times locally and confirmed no flakiness in the test after my changes
![Screenshot 2025-09-14 at 1 59 57 AM](https://github.com/user-attachments/assets/c2db8d8b-b0d8-4507-a0a2-eb8cb3e2a7eb)

![Screenshot 2025-09-14 at 1 59 57 AM](https://github.com/user-attachments/assets/8e173918-394b-4ac3-8507-f34d840a9147)
