### PR TITLE
fix(validation): Disallow whitespace-only input for required fields

### DIFF
--- a/frontend/app/(dashboard)/documents/FinishOnboarding.tsx
+++ b/frontend/app/(dashboard)/documents/FinishOnboarding.tsx
@@ -30,7 +30,7 @@ const WorkerOnboardingModal = ({ open, onClose, onNext }: OnboardingStepProps) =
         startedAt: z.instanceof(CalendarDate),
         payRateInSubunits: z.number(),
         payRateType: z.nativeEnum(PayRateType),
-        role: z.string().min(1),
+        role: z.string().trim().min(1),
       }),
     ),
     defaultValues: {

--- a/frontend/app/(dashboard)/equity/grants/NewEquityGrantModal.tsx
+++ b/frontend/app/(dashboard)/equity/grants/NewEquityGrantModal.tsx
@@ -31,8 +31,8 @@ import { company_administrator_equity_grants_path } from "@/utils/routes";
 const MAX_VESTING_DURATION_IN_MONTHS = 120;
 
 const formSchema = documentSchema.extend({
-  userId: z.string().min(1, "Must be present."),
-  optionPoolId: z.string().min(1, "Must be present."),
+  userId: z.string().trim().min(1, "Must be present."),
+  optionPoolId: z.string().trim().min(1, "Must be present."),
   numberOfShares: z.number().gt(0),
   issueDateRelationship: z.enum(optionGrantIssueDateRelationships),
   optionGrantType: z.enum(optionGrantTypes),

--- a/frontend/app/(dashboard)/equity/investors/add/page.tsx
+++ b/frontend/app/(dashboard)/equity/investors/add/page.tsx
@@ -27,7 +27,7 @@ const investorSchema = z.object({
   investors: z
     .array(
       z.object({
-        userId: z.string().min(1, "Please select an investor"),
+        userId: z.string().trim().min(1, "Please select an investor"),
         shares: z.number().min(1, "Please enter shares greater than 0"),
         searchTerm: z.string().optional(),
       }),

--- a/frontend/app/(dashboard)/equity/tender_offers/NewBuyBack.tsx
+++ b/frontend/app/(dashboard)/equity/tender_offers/NewBuyBack.tsx
@@ -23,7 +23,7 @@ const formSchema = z.object({
   endDate: z.instanceof(CalendarDate, { message: "This field is required." }),
   minimumValuation: z.number(),
   attachment: z.instanceof(File, { message: "This field is required." }),
-  letterOfTransmittal: z.string().min(1, "This field is required."),
+  letterOfTransmittal: z.string().trim().min(1, "This field is required."),
 });
 
 type NewBuybackFormProps = {

--- a/frontend/app/(dashboard)/equity/tender_offers/[id]/page.tsx
+++ b/frontend/app/(dashboard)/equity/tender_offers/[id]/page.tsx
@@ -31,7 +31,7 @@ import { VESTED_SHARES_CLASS } from "..";
 type Bid = RouterOutput["tenderOffers"]["bids"]["list"][number];
 
 const formSchema = z.object({
-  shareClass: z.string().min(1, "This field is required"),
+  shareClass: z.string().trim().min(1, "This field is required"),
   numberOfShares: z.number().min(1),
   pricePerShare: z.number().min(0),
 });

--- a/frontend/app/(dashboard)/people/[id]/page.tsx
+++ b/frontend/app/(dashboard)/people/[id]/page.tsx
@@ -55,7 +55,7 @@ import FormFields, { schema as formSchema } from "../FormFields";
 
 const issuePaymentSchema = z.object({
   amountInCents: z.number().min(0),
-  description: z.string().min(1, "This field is required"),
+  description: z.string().trim().min(1, "This field is required"),
   equityType: z.enum(["fixed", "range"]),
   equityPercentage: z.number().min(MINIMUM_EQUITY_PERCENTAGE).max(MAXIMUM_EQUITY_PERCENTAGE),
   equityRange: z.tuple([z.number().min(MINIMUM_EQUITY_PERCENTAGE), z.number().max(MAXIMUM_EQUITY_PERCENTAGE)]),

--- a/frontend/app/settings/administrator/details/page.tsx
+++ b/frontend/app/settings/administrator/details/page.tsx
@@ -13,7 +13,7 @@ import { usStates } from "@/models";
 import { trpc } from "@/trpc/client";
 
 const formSchema = z.object({
-  name: z.string().min(1, "This field is required."),
+  name: z.string().trim().min(1, "This field is required."),
   taxId: z.string().superRefine((val, ctx) => {
     const taxIdDigits = val.replace(/\D/gu, "");
     if (taxIdDigits.length !== 9)
@@ -25,10 +25,10 @@ const formSchema = z.object({
     .string()
     .min(1, "This field is required.")
     .refine((val) => val.replace(/\D/gu, "").length === 10, "Please enter a valid U.S. phone number."),
-  streetAddress: z.string().min(1, "This field is required."),
-  city: z.string().min(1, "This field is required."),
-  state: z.string().min(1, "This field is required."),
-  zipCode: z.string().min(1, "This field is required."),
+  streetAddress: z.string().trim().min(1, "This field is required."),
+  city: z.string().trim().min(1, "This field is required."),
+  state: z.string().trim().min(1, "This field is required."),
+  zipCode: z.string().trim().min(1, "This field is required."),
 });
 
 export default function Details() {

--- a/frontend/app/settings/administrator/details/page.tsx
+++ b/frontend/app/settings/administrator/details/page.tsx
@@ -67,7 +67,7 @@ export default function Details() {
   };
 
   const formatTaxId = (value: string) => {
-    const digits = value.replace(/\D/gu, "");
+    const digits = value.replace(/\D/gu, "").slice(0, 9);
     if (digits.length < 3) return digits;
     return `${digits.slice(0, 2)}-${digits.slice(2)}`;
   };

--- a/frontend/app/settings/tax/page.tsx
+++ b/frontend/app/settings/tax/page.tsx
@@ -57,10 +57,10 @@ const formValuesSchema = z.object({
   business_type: z.nativeEnum(BusinessType).nullable(),
   tax_classification: z.nativeEnum(TaxClassification).nullable(),
   country_code: z.string(),
-  tax_id: z.string().min(1, "This field is required."),
+  tax_id: z.string().trim().min(1, "This field is required."),
   birth_date: z.instanceof(CalendarDate).nullable(),
-  street_address: z.string().min(1, "Please add your residential address."),
-  city: z.string().min(1, "Please add your city or town."),
+  street_address: z.string().trim().min(1, "Please add your residential address."),
+  city: z.string().trim().min(1, "Please add your city or town."),
   state: z.string(),
   zip_code: z.string().regex(/\d/u, "Please add a valid postal code (must contain at least one number)."),
 });


### PR DESCRIPTION
### Problem:
- at multiple places whitespaces was considered as valid input for *required* fields like company name, zip code, city name, 

### AI Disclosure:
- No AI Used

- one form is shown below as demo, otherwise updated zod schema across project for required string fields.

## Before: (whitespaces are considered as valid strings for required fields)
https://github.com/user-attachments/assets/9e5b022f-e727-47ac-8baa-3c57a02394ec

## After: (whitespaces are not considered as valid)
https://github.com/user-attachments/assets/734cbecc-2925-4d42-bcb0-9efcb66802de

ref #911 