### PR TITLE
fix: correct request payload structure for updating user profile

### DIFF
--- a/frontend/app/settings/page.tsx
+++ b/frontend/app/settings/page.tsx
@@ -51,7 +51,7 @@ const DetailsSection = () => {
         url: settings_path(),
         method: "PATCH",
         accept: "json",
-        jsonData: { settings: { email: values.email, preferred_name: values.preferredName } },
+        jsonData: { email: values.email, preferred_name: values.preferredName },
       });
       if (!response.ok)
         throw new Error(z.object({ error_message: z.string() }).parse(await response.json()).error_message);


### PR DESCRIPTION
### Explanation of Change
fixes an issue where updating the preferred name in the user profile settings was not being saved

### Screenshots/Videos
Before

https://github.com/user-attachments/assets/71a4e701-9db6-4a15-bd4d-1ea77699e3b0

After

https://github.com/user-attachments/assets/ed7d7b72-12ba-4af7-b580-c702f00271df

### AI Disclosure
No AI tools used