### PR TITLE
fix: hide billing entity name field for individual entities

### DIFF
--- a/frontend/app/(dashboard)/people/[id]/page.tsx
+++ b/frontend/app/(dashboard)/people/[id]/page.tsx
@@ -587,7 +587,7 @@ const DetailsTab = ({
               </FormItem>
             )}
           />
-          <div className="grid gap-3 md:grid-cols-2">
+          <div className={user.businessName ? "grid gap-3 md:grid-cols-2" : ""}>
             <FormField
               control={personalInfoForm.control}
               name="preferredName"
@@ -601,19 +601,21 @@ const DetailsTab = ({
                 </FormItem>
               )}
             />
-            <FormField
-              control={personalInfoForm.control}
-              name="businessName"
-              render={({ field }) => (
-                <FormItem>
-                  <FormLabel>Billing entity name</FormLabel>
-                  <FormControl>
-                    <Input {...field} />
-                  </FormControl>
-                  <FormMessage />
-                </FormItem>
-              )}
-            />
+            {user.businessName ? (
+              <FormField
+                control={personalInfoForm.control}
+                name="businessName"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Billing entity name</FormLabel>
+                    <FormControl>
+                      <Input {...field} />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+            ) : null}
           </div>
           <FormField
             control={personalInfoForm.control}


### PR DESCRIPTION
### Explanation of Change
Ensures the billing entity name field is only shown for business entities, not individual users

### Screenshots/Videos
Before
Individual:
<img width="1412" height="746" alt="Screenshot 2025-09-15 at 10 23 40" src="https://github.com/user-attachments/assets/80753ddb-8fea-4ea7-8e84-6174729d76e8" />

Business:
<img width="1413" height="747" alt="image" src="https://github.com/user-attachments/assets/5381b88e-2477-41d7-b951-da67ed23f134" />


After
Individual:
<img width="1412" height="746" alt="Screenshot 2025-09-15 at 10 21 29" src="https://github.com/user-attachments/assets/a8914889-4158-4e37-98e9-1442dcc4c71c" />

Business:
<img width="1411" height="746" alt="image" src="https://github.com/user-attachments/assets/ea8a17d6-cf7c-4f73-8145-67336f1680bc" />


### AI Disclosure
No AI tools used