### PR TITLE
fix(documents): add download button to mobile view

### DIFF
--- a/frontend/app/(dashboard)/documents/page.tsx
+++ b/frontend/app/(dashboard)/documents/page.tsx
@@ -174,19 +174,29 @@ export default function DocumentsPage() {
       [
         columnHelper.display({
           id: "documentNameSigner",
-          cell: (info) => (
-            <div className="flex flex-col gap-1">
-              <div className="text-base font-medium">{info.row.original.name}</div>
-              {isCompanyRepresentative ? (
-                <div className="text-sm font-normal">
-                  {
-                    info.row.original.signatories.find((signatory) => signatory.title !== "Company Representative")
-                      ?.name
-                  }
-                </div>
-              ) : null}
-            </div>
-          ),
+          cell: (info) => {
+            const document = info.row.original;
+            return (
+              <div className="flex flex-col gap-1">
+                <div className="text-base font-medium">{document.name}</div>
+                {isCompanyRepresentative ? (
+                  <div className="text-sm font-normal">
+                    {document.signatories.find((signatory) => signatory.title !== "Company Representative")?.name}
+                  </div>
+                ) : null}
+                {document.attachment ? (
+                  <div>
+                    <Button variant="outline" size="small" asChild>
+                      <Link href={`/download/${document.attachment.key}/${document.attachment.filename}`} download>
+                        <Download className="mr-2 size-4" />
+                        Download
+                      </Link>
+                    </Button>
+                  </div>
+                ) : null}
+              </div>
+            );
+          },
           meta: {
             cellClassName: "w-full",
           },


### PR DESCRIPTION
### Explanation of Change
Fixes an issue where the download button was missing from the documents list on mobile devices. This prevented users from downloading their signed documents directly from mobile.

### Screenshots/Videos
Before
<img width="384" height="676" alt="image" src="https://github.com/user-attachments/assets/7b3f40e9-2765-49d8-a206-4304bc2ff56a" />


After
<img width="378" height="668" alt="image" src="https://github.com/user-attachments/assets/424b9773-d9f4-46f2-a952-f9bf2b62e67e" />


### AI Disclosure
No AI tools used