### PR TITLE
fix: show missing status text for updates mobile view

### DIFF
--- a/frontend/app/(dashboard)/updates/company/page.tsx
+++ b/frontend/app/(dashboard)/updates/company/page.tsx
@@ -165,8 +165,8 @@ const AdminList = ({ onEditUpdate }: { onEditUpdate: (update: UpdateListItem) =>
 
           return (
             <div className="flex h-full flex-col items-end justify-between">
-              <div className="flex h-5 w-4 items-center justify-center">
-                <Status variant={update.sentAt ? "success" : undefined} />
+              <div className="flex h-5 items-center justify-center">
+                <Status variant={update.sentAt ? "success" : undefined}>{update.sentAt ? "Sent" : "Draft"}</Status>
               </div>
               <div className="text-gray-600">{update.sentAt ? formatDate(update.sentAt) : "-"}</div>
             </div>


### PR DESCRIPTION
### Description:

For admin mobile view, updates doesn't shows status text (Draft, Sent). 

Part of #911    

### Before / After:

 <table>
 <tr><th>Before</th><th>After</th></tr>
 <tr>
 <td> 
<img width="330" height="714" alt="Screenshot 2025-09-15 at 3 21 23 PM" src="https://github.com/user-attachments/assets/ea1cc343-baf9-472c-968a-02d3c02cebb3" />
 </td>
 <td>
<img width="330" height="716" alt="Screenshot 2025-09-15 at 3 29 03 PM" src="https://github.com/user-attachments/assets/562369aa-2e62-4c02-9642-8c8222de8b35" />
 </td>
 </tr>
 </table>

For reference: status text shown in desktop view
 <table>
 <tr>
 <td> 
<img width="1433" height="791" alt="Screenshot 2025-09-15 at 3 21 35 PM" src="https://github.com/user-attachments/assets/3beb09fb-a37d-45cb-a6c3-2cf96957bc4a" />
 </td>
 </tr>
 </table>

### Test Suite / Related tests:
 <table>
 <tr>
 <td> 
<img width="578" height="676" alt="Screenshot 2025-09-15 at 3 36 14 PM" src="https://github.com/user-attachments/assets/1b62340e-32b6-4cba-b05f-d0b93d617b46" />
 </td>
 </tr>
 </table>

> [!Note]
> AI Disclosure: No AI was used to generate any of this code.
>Self-review: All changes are intuitive, so no additional comments are needed.

