### PR TITLE
fix: extra close icon on selected dialog on mobile screens

### DIFF
--- a/frontend/app/(dashboard)/invoices/page.tsx
+++ b/frontend/app/(dashboard)/invoices/page.tsx
@@ -784,7 +784,7 @@ const InvoiceBulkActionsBar = ({
             className="border-muted flex h-9 items-center gap-2 rounded-lg border border-dashed text-sm font-medium hover:bg-white"
             onClick={onClose}
           >
-            <span className="tabular-nums">{rowsSelected}</span> selecteddfssfs
+            <span className="tabular-nums">{rowsSelected}</span> selected
             <X className="size-4" />
           </Button>
           {rejectAction ? (

--- a/frontend/app/(dashboard)/invoices/page.tsx
+++ b/frontend/app/(dashboard)/invoices/page.tsx
@@ -771,7 +771,10 @@ const InvoiceBulkActionsBar = ({
 
   return (
     <Dialog open={selectedInvoices.length > 0} modal={false}>
-      <DialogContent className="border-border fixed right-auto bottom-16 left-1/2 w-auto -translate-x-1/2 transform rounded-xl border p-0">
+      <DialogContent
+        showCloseButton={false}
+        className="border-border fixed right-auto bottom-16 left-1/2 w-auto -translate-x-1/2 transform rounded-xl border p-0"
+      >
         <DialogHeader className="sr-only">
           <DialogTitle>Selected invoices</DialogTitle>
         </DialogHeader>
@@ -781,7 +784,7 @@ const InvoiceBulkActionsBar = ({
             className="border-muted flex h-9 items-center gap-2 rounded-lg border border-dashed text-sm font-medium hover:bg-white"
             onClick={onClose}
           >
-            <span className="tabular-nums">{rowsSelected}</span> selected
+            <span className="tabular-nums">{rowsSelected}</span> selecteddfssfs
             <X className="size-4" />
           </Button>
           {rejectAction ? (


### PR DESCRIPTION
Part of #911 

- Fix double close icon on mobile bulk action bar on invoices page

### Before 

<img width="437" height="457" alt="Screenshot From 2025-09-15 21-11-19" src="https://github.com/user-attachments/assets/729302fb-9479-4146-9e8e-3d4b0fa34890" />

### After 

<img width="437" height="457" alt="Screenshot From 2025-09-15 21-29-09" src="https://github.com/user-attachments/assets/6c402469-f0cb-48bf-9a45-eaba0c9a4436" />

## AI Disclosure
No AI usage
