### PR TITLE
fix: settings profile update payload 

### DIFF
--- a/frontend/app/settings/page.tsx
+++ b/frontend/app/settings/page.tsx
@@ -37,6 +37,7 @@ export default function SettingsPage() {
 }
 
 const DetailsSection = () => {
+  const queryClient = useQueryClient();
   const user = useCurrentUser();
   const form = useForm({
     defaultValues: {
@@ -51,10 +52,12 @@ const DetailsSection = () => {
         url: settings_path(),
         method: "PATCH",
         accept: "json",
-        jsonData: { settings: { email: values.email, preferred_name: values.preferredName } },
+        jsonData: { email: values.email, preferred_name: values.preferredName },
       });
       if (!response.ok)
         throw new Error(z.object({ error_message: z.string() }).parse(await response.json()).error_message);
+
+      await queryClient.invalidateQueries({ queryKey: ["currentUser"] });
     },
     onSuccess: () => setTimeout(() => saveMutation.reset(), 2000),
   });


### PR DESCRIPTION
Ref:- https://github.com/antiwork/flexile/issues/911


## Description 

- previously, the settings form was sending user data inside a nested settings object
- the backend controller only permits params (email, preferred_name).
- causing, updates to profile information (like email and preferred name) were not being saved.

### Before

[Screencast from 2025-09-16 00-24-28.webm](https://github.com/user-attachments/assets/a703a9c8-863c-4c56-b130-c9d31e0ff6de)

### After

[Screencast from 2025-09-16 00-25-01.webm](https://github.com/user-attachments/assets/96112462-6057-4638-a6c7-6e792cc3baa3)



#### AI Disclosure:-
I have not used any AI assistance in this PR