### PR TITLE
fix(flaky tests): stabilise tax settings test by ordering userComplianceInfos by createdAt

### DIFF
--- a/e2e/tests/settings/tax.spec.ts
+++ b/e2e/tests/settings/tax.spec.ts
@@ -9,9 +9,9 @@ import { usersFactory } from "@test/factories/users";
 import { fillDatePicker, selectComboboxOption } from "@test/helpers";
 import { login } from "@test/helpers/auth";
 import { expect, test } from "@test/index";
-import { eq } from "drizzle-orm";
+import { desc, eq } from "drizzle-orm";
 import { BusinessType, TaxClassification } from "@/db/enums";
-import { companies, users } from "@/db/schema";
+import { companies, userComplianceInfos, users } from "@/db/schema";
 
 test.describe("Tax settings", () => {
   let company: typeof companies.$inferSelect;
@@ -152,10 +152,13 @@ test.describe("Tax settings", () => {
         .findFirst({
           where: eq(users.id, user.id),
           with: {
-            userComplianceInfos: true,
+            userComplianceInfos: {
+              orderBy: [desc(userComplianceInfos.createdAt)],
+            },
           },
         })
         .then(takeOrThrow);
+
       expect(updatedUser.userComplianceInfos).toHaveLength(2);
 
       expect(updatedUser.userComplianceInfos[0]?.deletedAt).not.toBeNull();


### PR DESCRIPTION

### Root Cause:
- The test queried userComplianceInfos without an explicit order, so the “latest” record wasn’t guaranteed—leading to flaky assertions.

### Solution:
Added orderBy: [desc(userComplianceInfos.createdAt)] to always fetch the newest record first. so in assertions we always get latest record at `0th` index.

### AI Disclosure:
- no AI used

### CI Failure Link:
https://github.com/antiwork/flexile/actions/runs/17728605580/job/50374743417?pr=1173#step:12:433
<img width="1506" height="847" alt="Screenshot 2025-09-16 at 9 36 13 AM" src="https://github.com/user-attachments/assets/047e15a0-7cdc-4863-b653-fd344540b259" />

### After:
<img width="1086" height="249" alt="Screenshot 2025-09-16 at 4 11 47 PM" src="https://github.com/user-attachments/assets/29eb2e9f-e9d8-4803-afd9-7248c2f898e4" />



