### PR TITLE
fix(flaky test): displays correct ownership percentages for investors

### DIFF
--- a/e2e/tests/company/equity/investors.spec.ts
+++ b/e2e/tests/company/equity/investors.spec.ts
@@ -49,7 +49,7 @@ test.describe("Investors", () => {
       .where(eq(companyInvestors.id, companyInvestor2.id));
 
     await login(page, adminUser, "/equity/investors");
-    await expect(page.getByText("Investors")).toBeVisible();
+    await expect(page.getByRole("heading", { name: "Investors" })).toBeVisible();
     await expect(page.getByText("Alice Investor")).toBeVisible();
     await expect(page.getByText("Bob Investor")).toBeVisible();
 


### PR DESCRIPTION
### Ref 
- #1132 
- #1184

### Flaky Test Addressed from [#1184's run](https://github.com/antiwork/flexile/actions/runs/17765006252/job/50486204153?pr=1184)
1. e2e/tests/company/equity/investors.spec.ts:15:3 › Investors › displays correct ownership percentages for investors
<img width="1099" height="570" alt="flaky" src="https://github.com/user-attachments/assets/19de4ad9-c9b4-4757-8025-d25e29a6097f" />

### AI Usage
None