### PR TITLE
fix(calendar): prevent popover position jumps when navigating months

### DIFF
--- a/frontend/components/DatePicker.tsx
+++ b/frontend/components/DatePicker.tsx
@@ -31,11 +31,16 @@ export default function DatePicker({ label, className, ...props }: DatePickerPro
         </RacButton>
       </div>
       <RacPopover
-        placement="bottom end"
-        className="bg-background border-input text-popover-foreground data-entering:animate-in data-exiting:animate-out data-[entering]:fade-in-0 data-[exiting]:fade-out-0 data-[entering]:zoom-in-95 data-[exiting]:zoom-out-95 data-[placement=bottom]:slide-in-from-top-2 data-[placement=left]:slide-in-from-right-2 data-[placement=right]:slide-in-from-left-2 data-[placement=top]:slide-in-from-bottom-2 pointer-events-auto rounded-md border shadow-lg outline-hidden"
+        placement="bottom start"
+        offset={8}
+        crossOffset={0}
+        shouldFlip
+        shouldUpdatePosition
+        containerPadding={12}
+        className="bg-background border-input text-popover-foreground data-entering:animate-in data-exiting:animate-out data-[entering]:fade-in-0 data-[exiting]:fade-out-0 data-[entering]:zoom-in-95 data-[exiting]:zoom-out-95 data-[placement=bottom]:slide-in-from-top-2 data-[placement=left]:slide-in-from-right-2 data-[placement=right]:slide-in-from-left-2 data-[placement=top]:slide-in-from-bottom-2 pointer-events-auto z-50 rounded-md border shadow-lg outline-hidden"
       >
-        <RacDialog className="max-h-[inherit] overflow-auto p-2">
-          <Calendar />
+        <RacDialog className="max-h-[inherit] overflow-auto p-3">
+          <Calendar className="w-[260px]" />
         </RacDialog>
       </RacPopover>
     </RacDatePicker>

--- a/frontend/components/ui/calendar.tsx
+++ b/frontend/components/ui/calendar.tsx
@@ -49,7 +49,7 @@ function CalendarGridComponent({ isRange = false }: { isRange?: boolean }) {
   const now = today(getLocalTimeZone());
 
   return (
-    <CalendarGridRac>
+    <CalendarGridRac className="w-full">
       <CalendarGridHeaderRac>
         {(day) => (
           <CalendarHeaderCellRac className="text-muted-foreground/80 size-9 rounded-md p-0 text-xs font-medium">
@@ -57,7 +57,7 @@ function CalendarGridComponent({ isRange = false }: { isRange?: boolean }) {
           </CalendarHeaderCellRac>
         )}
       </CalendarGridHeaderRac>
-      <CalendarGridBodyRac className="[&_td]:px-0 [&_td]:py-px">
+      <CalendarGridBodyRac className="[&_td]:px-0 [&_td]:py-px [&_tr]:h-[32px]">
         {(date) => (
           <CalendarCellRac
             date={date}
@@ -86,7 +86,9 @@ function Calendar({ className, ...props }: CalendarProps) {
   return (
     <CalendarRac {...props} className={composeRenderProps(className, (className) => cn("w-fit", className))}>
       <CalendarHeader />
-      <CalendarGridComponent />
+      <div className="flex h-[220px] flex-col">
+        <CalendarGridComponent />
+      </div>
     </CalendarRac>
   );
 }


### PR DESCRIPTION
ref #911 
## Problem
The calendar popover in DatePicker was jumping/moving position when users clicked the navigation arrows to change months, creating a jarring user experience.

Fixes the positioning instability issue in the date picker component.

## before


https://github.com/user-attachments/assets/a71b3a97-d85f-4f44-b864-1e2986deb1f2



## after



https://github.com/user-attachments/assets/95d5dc98-f32e-499c-946d-fd0731e6b078



## AI Usage
No AI was used to generate any of this code.

## Self-Review
I have self-reviewed all the code that I have written.