### PR TITLE
fix(flaky tests): add contractor flows with pre-existing contractors

### DIFF
--- a/e2e/index.ts
+++ b/e2e/index.ts
@@ -63,3 +63,25 @@ export const withinModal = async (
   await callback(modal);
   if (assertClosed) await expect(modal).not.toBeVisible();
 };
+
+export const withinCombobox = async (
+  callback: (searchField: Locator, combobox: Locator) => Promise<void>,
+  {
+    assertClosed = true,
+    name,
+    page,
+    popoverName,
+    searchPlaceholder = "Search...",
+  }: { assertClosed?: boolean; name: string; page: Page; popoverName?: string; searchPlaceholder?: string },
+) => {
+  const combobox = page.getByRole("combobox", { name, exact: true });
+  await combobox.click();
+  const popover = page.getByRole("listbox", { name: popoverName ?? `${name} options` });
+  await expect(popover).toBeVisible();
+  const searchField = popover.getByPlaceholder(searchPlaceholder);
+  await expect(searchField).toBeVisible();
+  await callback(searchField, combobox);
+  if (assertClosed) {
+    await expect(popover).not.toBeVisible();
+  }
+};

--- a/e2e/tests/company/administrator/edit-contractor.spec.ts
+++ b/e2e/tests/company/administrator/edit-contractor.spec.ts
@@ -4,7 +4,7 @@ import { companyAdministratorsFactory } from "@test/factories/companyAdministrat
 import { companyContractorsFactory } from "@test/factories/companyContractors";
 import { usersFactory } from "@test/factories/users";
 import { login } from "@test/helpers/auth";
-import { expect, test } from "@test/index";
+import { expect, test, withinCombobox } from "@test/index";
 import { eq } from "drizzle-orm";
 import { PayRateType } from "@/db/enums";
 import { users } from "@/db/schema";
@@ -67,11 +67,17 @@ test.describe("Edit contractor", () => {
     await page.getByRole("link", { name: contractor.preferredName }).click();
 
     await page.getByRole("heading", { name: contractor.preferredName }).click();
-    await expect(page.getByLabel("Role")).toHaveValue(assertDefined(companyContractor.role));
     await expect(page.getByLabel("Legal name")).toHaveValue(contractor.legalName);
     await expect(page.getByLabel("Legal name")).toBeDisabled();
 
-    await page.getByLabel("Role").fill("Stuff-doer");
+    await withinCombobox(
+      async (searchField, combobox) => {
+        await expect(combobox).toHaveText(assertDefined(companyContractor.role));
+        await searchField.fill("Stuff-doer");
+        await searchField.press("Enter");
+      },
+      { page, name: "Role", searchPlaceholder: "Select or type a role..." },
+    );
     await page.getByLabel("Rate").fill("107");
     await page.getByRole("button", { name: "Save changes" }).click();
     await expect(page.getByRole("button", { name: "Save changes" })).not.toBeDisabled();
@@ -104,7 +110,13 @@ test.describe("Edit contractor", () => {
     await page.getByRole("link", { name: user.preferredName }).click();
     await page.getByRole("heading", { name: user.preferredName }).click();
 
-    await page.getByLabel("Role").fill("Stuff-doer");
+    await withinCombobox(
+      async (searchField) => {
+        await searchField.fill("Stuff-doer");
+        await searchField.press("Enter");
+      },
+      { page, name: "Role", searchPlaceholder: "Select or type a role..." },
+    );
     await page.getByRole("radio", { name: "Custom" }).click({ force: true });
     await page.getByLabel("Rate").fill("2000");
     await page.getByRole("button", { name: "Save changes" }).click();

--- a/e2e/tests/company/administrator/edit-contractor.spec.ts
+++ b/e2e/tests/company/administrator/edit-contractor.spec.ts
@@ -76,7 +76,7 @@ test.describe("Edit contractor", () => {
         await searchField.fill("Stuff-doer");
         await searchField.press("Enter");
       },
-      { page, name: "Role", searchPlaceholder: "Select or type a role..." },
+      { page, name: "Role", searchPlaceholder: "Search or enter a role..." },
     );
     await page.getByLabel("Rate").fill("107");
     await page.getByRole("button", { name: "Save changes" }).click();
@@ -115,7 +115,7 @@ test.describe("Edit contractor", () => {
         await searchField.fill("Stuff-doer");
         await searchField.press("Enter");
       },
-      { page, name: "Role", searchPlaceholder: "Select or type a role..." },
+      { page, name: "Role", searchPlaceholder: "Search or enter a role..." },
     );
     await page.getByRole("radio", { name: "Custom" }).click({ force: true });
     await page.getByLabel("Rate").fill("2000");

--- a/e2e/tests/company/administrator/new-contract.spec.ts
+++ b/e2e/tests/company/administrator/new-contract.spec.ts
@@ -6,7 +6,7 @@ import { companyContractorsFactory } from "@test/factories/companyContractors";
 import { usersFactory } from "@test/factories/users";
 import { fillDatePicker, findRichTextEditor } from "@test/helpers";
 import { login, logout } from "@test/helpers/auth";
-import { expect, type Page, test } from "@test/index";
+import { expect, type Page, test, withinCombobox } from "@test/index";
 import { addMonths, format } from "date-fns";
 import { eq } from "drizzle-orm";
 import { PayRateType } from "@/db/enums";
@@ -51,7 +51,13 @@ test.describe("New Contractor", () => {
 
   test("allows inviting a contractor", async ({ page }) => {
     const { email } = await fillForm(page);
-    await page.getByLabel("Role").fill("Hourly Role 1");
+    await withinCombobox(
+      async (searchField) => {
+        await searchField.fill("Hourly Role 1");
+        await searchField.press("Enter");
+      },
+      { page, name: "Role", searchPlaceholder: "Select or type a role..." },
+    );
     await page.getByLabel("Rate").fill("99");
     await page.getByRole("button", { name: "Continue" }).click();
     await page.getByRole("tab", { name: "Write" }).click();
@@ -77,7 +83,13 @@ test.describe("New Contractor", () => {
 
   test("allows inviting a project-based contractor", async ({ page }) => {
     const { email } = await fillForm(page);
-    await page.getByLabel("Role").fill("Project-based Role");
+    await withinCombobox(
+      async (searchField) => {
+        await searchField.fill("Project-based Role");
+        await searchField.press("Enter");
+      },
+      { page, name: "Role", searchPlaceholder: "Select or type a role..." },
+    );
     await page.getByRole("radio", { name: "Custom" }).click({ force: true });
     await page.getByLabel("Rate").fill("1000");
     await page.getByRole("button", { name: "Continue" }).click();
@@ -112,7 +124,7 @@ test.describe("New Contractor", () => {
     });
     await login(page, user, "/people");
     await page.getByRole("button", { name: "Add contractor" }).click();
-    await expect(page.getByLabel("Role")).toHaveValue("Hourly Role 1");
+    await expect(page.getByRole("combobox", { name: "Role", exact: true })).toHaveText("Hourly Role 1");
     await expect(page.getByLabel("Rate")).toHaveValue("100");
     await page.getByRole("button", { name: "Continue" }).click();
     await expect(page.getByLabel("Already signed contract elsewhere")).toBeChecked();

--- a/e2e/tests/company/administrator/new-contract.spec.ts
+++ b/e2e/tests/company/administrator/new-contract.spec.ts
@@ -56,7 +56,7 @@ test.describe("New Contractor", () => {
         await searchField.fill("Hourly Role 1");
         await searchField.press("Enter");
       },
-      { page, name: "Role", searchPlaceholder: "Select or type a role..." },
+      { page, name: "Role", searchPlaceholder: "Search or enter a role..." },
     );
     await page.getByLabel("Rate").fill("99");
     await page.getByRole("button", { name: "Continue" }).click();
@@ -88,7 +88,7 @@ test.describe("New Contractor", () => {
         await searchField.fill("Project-based Role");
         await searchField.press("Enter");
       },
-      { page, name: "Role", searchPlaceholder: "Select or type a role..." },
+      { page, name: "Role", searchPlaceholder: "Search or enter a role..." },
     );
     await page.getByRole("radio", { name: "Custom" }).click({ force: true });
     await page.getByLabel("Rate").fill("1000");

--- a/e2e/tests/company/administrator/role-autocomplete.spec.ts
+++ b/e2e/tests/company/administrator/role-autocomplete.spec.ts
@@ -57,7 +57,7 @@ test.describe("Role autocomplete", () => {
         await searchField.press("Enter");
         await expect(combobox).toHaveText(role1);
       },
-      { page, name: "Role", searchPlaceholder: "Select or type a role..." },
+      { page, name: "Role", searchPlaceholder: "Search or enter a role..." },
     );
   };
 

--- a/e2e/tests/company/administrator/role-autocomplete.spec.ts
+++ b/e2e/tests/company/administrator/role-autocomplete.spec.ts
@@ -3,7 +3,7 @@ import { companyAdministratorsFactory } from "@test/factories/companyAdministrat
 import { companyContractorsFactory } from "@test/factories/companyContractors";
 import { usersFactory } from "@test/factories/users";
 import { login } from "@test/helpers/auth";
-import { expect, type Page, test } from "@test/index";
+import { expect, type Page, test, withinCombobox } from "@test/index";
 import { assertDefined } from "@/utils/assert";
 
 test.describe("Role autocomplete", () => {
@@ -43,26 +43,22 @@ test.describe("Role autocomplete", () => {
   };
 
   const testAutofill = async (page: Page) => {
-    const roleField = page.getByLabel("Role");
-    await roleField.click();
-    await expect(page.getByRole("option", { name: role1 })).not.toBeVisible();
-    await expect(page.getByRole("option", { name: role2 })).not.toBeVisible();
-    await expect(page.getByRole("option", { name: role3 })).toBeVisible();
-    await expect(page.getByRole("option", { name: "Alumni Role" })).not.toBeVisible();
+    await withinCombobox(
+      async (searchField, combobox) => {
+        await expect(page.getByRole("option", { name: role1 })).toBeVisible();
+        await expect(page.getByRole("option", { name: role2 })).toBeVisible();
+        await expect(page.getByRole("option", { name: role3 })).toBeVisible();
+        await expect(page.getByRole("option", { name: "Alumni Role" })).not.toBeVisible();
 
-    await roleField.clear();
-    await expect(page.getByRole("option", { name: role1 })).toBeVisible();
-    await expect(page.getByRole("option", { name: role2 })).toBeVisible();
-    await expect(page.getByRole("option", { name: role3 })).toBeVisible();
-    await expect(page.getByRole("option", { name: "Alumni Role" })).not.toBeVisible();
-
-    await roleField.fill("de");
-    await expect(page.getByRole("option", { name: role1 })).toBeVisible();
-    await expect(page.getByRole("option", { name: role2 })).toBeVisible();
-    await expect(page.getByRole("option", { name: role3 })).not.toBeVisible();
-    await roleField.press("Enter");
-    await expect(roleField).toHaveValue(role1);
-    await expect(page.getByRole("option")).not.toBeVisible();
+        await searchField.fill("de");
+        await expect(page.getByRole("option", { name: role1 })).toBeVisible();
+        await expect(page.getByRole("option", { name: role2 })).toBeVisible();
+        await expect(page.getByRole("option", { name: role3 })).not.toBeVisible();
+        await searchField.press("Enter");
+        await expect(combobox).toHaveText(role1);
+      },
+      { page, name: "Role", searchPlaceholder: "Select or type a role..." },
+    );
   };
 
   test("suggests existing roles when inviting a new contractor", async ({ page }) => {
@@ -85,7 +81,7 @@ test.describe("Role autocomplete", () => {
     await login(page, admin);
     await page.getByRole("link", { name: "People" }).click();
     await page.getByRole("link", { name: user.preferredName ?? "" }).click();
-    await expect(page.getByLabel("Role")).toHaveValue(assertDefined(contractor.role));
+    await expect(page.getByRole("combobox", { name: "Role", exact: true })).toHaveText(assertDefined(contractor.role));
     await testAutofill(page);
   });
 });

--- a/e2e/tests/company/contractor/contractor-invite-link.spec.ts
+++ b/e2e/tests/company/contractor/contractor-invite-link.spec.ts
@@ -2,7 +2,7 @@ import { faker } from "@faker-js/faker";
 import { db, takeOrThrow } from "@test/db";
 import { companiesFactory } from "@test/factories/companies";
 import { externalProviderMock, fillOtp, login } from "@test/helpers/auth";
-import { expect, test } from "@test/index";
+import { expect, test, withinCombobox } from "@test/index";
 import { and, eq } from "drizzle-orm";
 import { SignInMethod } from "@/db/enums";
 import { companyContractors } from "@/db/schema";
@@ -69,7 +69,13 @@ test.describe("Contractor Invite Link Joining flow", () => {
 
     await expect(page.getByLabel("Role")).not.toBeValid();
 
-    await page.getByLabel("Role").fill("Hourly Role 1");
+    await withinCombobox(
+      async (searchField) => {
+        await searchField.fill("Hourly Role 1");
+        await searchField.press("Enter");
+      },
+      { page, name: "Role", searchPlaceholder: "Select or type a role..." },
+    );
     await page.getByLabel("Rate").fill("99");
     await page.getByRole("button", { name: "Continue" }).click();
 

--- a/e2e/tests/company/contractor/contractor-invite-link.spec.ts
+++ b/e2e/tests/company/contractor/contractor-invite-link.spec.ts
@@ -74,7 +74,7 @@ test.describe("Contractor Invite Link Joining flow", () => {
         await searchField.fill("Hourly Role 1");
         await searchField.press("Enter");
       },
-      { page, name: "Role", searchPlaceholder: "Select or type a role..." },
+      { page, name: "Role", searchPlaceholder: "Search or enter a role..." },
     );
     await page.getByLabel("Rate").fill("99");
     await page.getByRole("button", { name: "Continue" }).click();

--- a/e2e/tests/company/contractor/multiple-companies.spec.ts
+++ b/e2e/tests/company/contractor/multiple-companies.spec.ts
@@ -31,7 +31,7 @@ test.describe("Contractor for multiple companies", () => {
         await searchField.fill("Role");
         await searchField.press("Enter");
       },
-      { page, name: "Role", searchPlaceholder: "Select or type a role..." },
+      { page, name: "Role", searchPlaceholder: "Search or enter a role..." },
     );
     await page.getByRole("button", { name: "Continue" }).click();
     await page.getByRole("tab", { name: "Write" }).click();

--- a/e2e/tests/company/contractor/multiple-companies.spec.ts
+++ b/e2e/tests/company/contractor/multiple-companies.spec.ts
@@ -4,7 +4,7 @@ import { companyContractorsFactory } from "@test/factories/companyContractors";
 import { usersFactory } from "@test/factories/users";
 import { fillDatePicker, findRichTextEditor } from "@test/helpers";
 import { login, logout } from "@test/helpers/auth";
-import { expect, test } from "@test/index";
+import { expect, test, withinCombobox } from "@test/index";
 import { assertDefined } from "@/utils/assert";
 
 test.describe("Contractor for multiple companies", () => {
@@ -26,7 +26,13 @@ test.describe("Contractor for multiple companies", () => {
 
     await page.getByLabel("Email").fill(contractorUser.email);
     await fillDatePicker(page, "Start date", "08/08/2025");
-    await page.getByLabel("Role").fill("Role");
+    await withinCombobox(
+      async (searchField) => {
+        await searchField.fill("Role");
+        await searchField.press("Enter");
+      },
+      { page, name: "Role", searchPlaceholder: "Select or type a role..." },
+    );
     await page.getByRole("button", { name: "Continue" }).click();
     await page.getByRole("tab", { name: "Write" }).click();
     await findRichTextEditor(page, "Contract").fill("This is a contract you must sign");

--- a/frontend/app/(dashboard)/people/FormFields.tsx
+++ b/frontend/app/(dashboard)/people/FormFields.tsx
@@ -1,15 +1,17 @@
 import { skipToken } from "@tanstack/react-query";
+import { Check, ChevronDown } from "lucide-react";
 import React, { useState } from "react";
 import { useFormContext } from "react-hook-form";
 import { z } from "zod";
 import NumberInput from "@/components/NumberInput";
 import RadioButtons from "@/components/RadioButtons";
-import { Command, CommandGroup, CommandItem, CommandList } from "@/components/ui/command";
+import { Button } from "@/components/ui/button";
+import { Command, CommandGroup, CommandInput, CommandItem, CommandList } from "@/components/ui/command";
 import { FormControl, FormField, FormItem, FormLabel, FormMessage } from "@/components/ui/form";
-import { Input } from "@/components/ui/input";
-import { Popover, PopoverAnchor, PopoverContent } from "@/components/ui/popover";
+import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
 import { useUserStore } from "@/global";
 import { PayRateType, trpc } from "@/trpc/client";
+import { cn } from "@/utils";
 
 export const schema = z.object({
   payRateType: z.nativeEnum(PayRateType),
@@ -26,64 +28,102 @@ export default function FormFields() {
   const { data: workers } = trpc.contractors.list.useQuery(companyId ? { companyId, excludeAlumni: true } : skipToken);
 
   const [rolePopoverOpen, setRolePopoverOpen] = useState(false);
-  const roleRegex = new RegExp(form.watch("role"), "iu");
-  const filteredRoles = workers
-    ? [...new Set(workers.map((worker) => worker.role))].sort().filter((value) => roleRegex.test(value))
-    : defaultRoles;
+  const [searchQuery, setSearchQuery] = useState("");
+  const trimmedQuery = searchQuery.trim();
+  const roleValue = form.getValues("role");
+  const availableRoles = [...new Set([...(workers?.map((worker) => worker.role) ?? []), ...defaultRoles])].sort(
+    (a: string, b: string) => a.toLowerCase().localeCompare(b.toLowerCase()),
+  );
+  const filteredRoles = availableRoles.filter((role) => role.toLowerCase().includes(trimmedQuery.toLowerCase()));
+
+  const suggestions: string[] = [];
+  if (trimmedQuery && !availableRoles.some((role) => role.toLowerCase() === trimmedQuery.toLowerCase()))
+    suggestions.push(trimmedQuery);
+  if (roleValue !== trimmedQuery && !availableRoles.some((role) => role.toLowerCase() === roleValue.toLowerCase()))
+    suggestions.push(roleValue);
+
+  const handleSelect = (selectedRole: string) => {
+    form.setValue("role", selectedRole);
+    setRolePopoverOpen(false);
+    setSearchQuery("");
+  };
 
   return (
     <>
       <FormField
         control={form.control}
         name="role"
-        render={({ field }) => (
-          <FormItem>
-            <FormLabel>Role</FormLabel>
-            <Command shouldFilter={false} className="overflow-visible">
-              <Popover open={!!rolePopoverOpen && filteredRoles.length > 0}>
-                <PopoverAnchor asChild>
+        render={({ field }) => {
+          const popoverId = `${field.name}-popover`;
+          return (
+            <FormItem>
+              <FormLabel>Role</FormLabel>
+              <Popover open={rolePopoverOpen} onOpenChange={setRolePopoverOpen}>
+                <PopoverTrigger asChild>
                   <FormControl>
-                    <Input
+                    <Button
                       {...field}
-                      type="text"
-                      autoComplete="off"
-                      className="focus-visible:ring-ring focus-visible:border-border focus-visible:ring-2"
-                      onFocus={() => setRolePopoverOpen(true)}
-                      onBlur={() => setRolePopoverOpen(false)}
-                      onChange={(e) => {
-                        field.onChange(e);
-                        setRolePopoverOpen(true);
-                      }}
-                    />
+                      aria-controls={rolePopoverOpen ? popoverId : undefined}
+                      aria-expanded={rolePopoverOpen}
+                      aria-haspopup="listbox"
+                      className="border-input focus-visible:ring-ring focus-visible:border-border aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive h-9 w-full min-w-0 justify-between outline-none focus-visible:ring-2 focus-visible:outline-hidden dark:bg-transparent"
+                      role="combobox"
+                      size="small"
+                      variant="outline"
+                    >
+                      <div className="truncate">{field.value || "Select or type a role..."}</div>
+                      <ChevronDown className="ml-2 size-4 shrink-0 opacity-50" />
+                    </Button>
                   </FormControl>
-                </PopoverAnchor>
+                </PopoverTrigger>
                 <PopoverContent
-                  onOpenAutoFocus={(e) => e.preventDefault()}
+                  aria-label={`${field.name} options`}
+                  id={popoverId}
                   className="p-0"
                   style={{ width: "var(--radix-popover-trigger-width)" }}
+                  role="listbox"
                 >
-                  <CommandList>
-                    <CommandGroup>
-                      {filteredRoles.map((option) => (
-                        <CommandItem
-                          key={option}
-                          value={option}
-                          onSelect={(e) => {
-                            field.onChange(e);
-                            setRolePopoverOpen(false);
-                          }}
-                        >
-                          {option}
-                        </CommandItem>
-                      ))}
-                    </CommandGroup>
-                  </CommandList>
+                  <Command value={field.value}>
+                    <CommandInput
+                      placeholder="Select or type a role..."
+                      value={searchQuery}
+                      onValueChange={(query: string) => {
+                        setSearchQuery(query);
+                      }}
+                    />
+                    <CommandList>
+                      {filteredRoles.length > 0 && (
+                        <CommandGroup heading="Available Roles">
+                          {filteredRoles.map((role) => (
+                            <CommandItem key={role} value={role} onSelect={handleSelect}>
+                              <Check
+                                className={cn("mr-2 h-4 w-4", role === field.value ? "opacity-100" : "opacity-0")}
+                              />
+                              {role}
+                            </CommandItem>
+                          ))}
+                        </CommandGroup>
+                      )}
+                      {suggestions.length > 0 && (
+                        <CommandGroup heading="Create New Role">
+                          {suggestions.map((role) => (
+                            <CommandItem key={role} value={role} onSelect={handleSelect}>
+                              <Check
+                                className={cn("mr-2 h-4 w-4", role === field.value ? "opacity-100" : "opacity-0")}
+                              />
+                              {role}
+                            </CommandItem>
+                          ))}
+                        </CommandGroup>
+                      )}
+                    </CommandList>
+                  </Command>
                 </PopoverContent>
               </Popover>
-            </Command>
-            <FormMessage />
-          </FormItem>
-        )}
+              <FormMessage />
+            </FormItem>
+          );
+        }}
       />
 
       <FormField

--- a/frontend/app/(dashboard)/people/FormFields.tsx
+++ b/frontend/app/(dashboard)/people/FormFields.tsx
@@ -71,7 +71,7 @@ export default function FormFields() {
                       size="small"
                       variant="outline"
                     >
-                      <div className="truncate">{field.value || "Select or type a role..."}</div>
+                      <div className="truncate">{field.value || "Search or enter a role..."}</div>
                       <ChevronDown className="ml-2 size-4 shrink-0 opacity-50" />
                     </Button>
                   </FormControl>
@@ -85,7 +85,7 @@ export default function FormFields() {
                 >
                   <Command value={field.value}>
                     <CommandInput
-                      placeholder="Select or type a role..."
+                      placeholder="Search or enter a role..."
                       value={searchQuery}
                       onValueChange={(query: string) => {
                         setSearchQuery(query);

--- a/frontend/app/(dashboard)/people/page.tsx
+++ b/frontend/app/(dashboard)/people/page.tsx
@@ -208,6 +208,7 @@ const inviteSchema = formSchema.merge(documentSchema).extend({
   startDate: z.instanceof(CalendarDate),
   contractSignedElsewhere: z.boolean().default(false),
 });
+
 const ActionPanel = () => {
   const company = useCurrentCompany();
   const queryClient = useQueryClient();


### PR DESCRIPTION
### Ref
- #1132

### What's Happening?
1. Tests adding a new contractor with existing data navigate to `/people` and click on `Add Contractor`
2. The dialog which contains the form fails to open causing test failures

### Why?
1. `ActionPanel` manages the `Add Contractor` dialog state
2. `/people` route conditionally renderers `ActionPanel` at different location. One besides the header when contractor list is empty and another inside the `DataTable` header when number of contractors > 0
3. In test environments, when the number of contractors > 0, playwright clicks the `Add Contractor` button while data is still loading. This opens the dialog in the initial `ActionPanel` instance (beside the header), which then gets unmounted when the contractor list populates triggering a new `ActionPanel` instance to be created inside `DataTable` header.
4. This new `ActionPanel` instance doesn't have the dialog open state set which results in test deadlock, as the expected dialog never materializes

Video of the root cause. It's slow and long, skip to ~50s for a quick preview.

https://github.com/user-attachments/assets/16ece227-f73a-4a30-8df4-0b8b2b64b582

### The fix (Several Options)
1. Wait for `networkidle`
2. Wait for contractor list API to fulfill before performing a click on `Add Contractor`
3. Change first load UX to defer displaying action buttons until the contractor list is available for rendering (In this PR)
    - This defers the clicking logic in test, and prevents the wrong dialog from opening up

### Flaky tests addressed from [main run](https://github.com/antiwork/flexile/actions/runs/17673213398/job/50229393183)
1. `e2e/tests/company/administrator/new-contract.spec.ts:102:3 › New Contractor › pre-fills form with last contractor's values`
2. `e2e/tests/company/administrator/role-autocomplete.spec.ts:68:3 › Role autocomplete › suggests existing roles when inviting a new contractor`

<img width="1456" height="831" alt="flaky" src="https://github.com/user-attachments/assets/b1309883-61b8-409a-96ab-4b2ca8f68524" />


### AI Usage
None

### Checklist
- [x] Self-Reviewed

<hr />

### Update after

- #1159

The above PR introduced `{!isLoading && workers.length === 0 ? <ActionPanel /> : null}` from https://github.com/antiwork/flexile/pull/1191/commits/0e9a5c4a49097e3053df187aaa11b22127dcad29 into the code base which resolved the issue related to open dialog state for

1. `e2e/tests/company/administrator/new-contract.spec.ts:102:3 › New Contractor › pre-fills form with last contractor's values`
2. `e2e/tests/company/administrator/role-autocomplete.spec.ts:68:3 › Role autocomplete › suggests existing roles when inviting a new contractor`

However, there's another problem with `e2e/tests/company/administrator/role-autocomplete.spec.ts:68:3 › Role autocomplete › suggests existing roles when inviting a new contractor` which popped up in the [merge commit run](https://github.com/antiwork/flexile/actions/runs/18000246289/job/51207627327) from this PR 

<img width="1462" height="838" alt="enter press" src="https://github.com/user-attachments/assets/826eb3d5-3124-425a-9b3c-bf3bac28e31a" />

As seen in the video below, role selection on `Enter` is buggy

https://github.com/user-attachments/assets/ed5b6bcc-da20-415f-8522-0ca811d33d94

### After
[TBF]

https://github.com/user-attachments/assets/027551a4-1e2d-48f2-8157-66fda36db9b2
