### PR TITLE
fix: Add URL validation and normalization to links in company update RichText editor

### DIFF
--- a/frontend/components/RichText.tsx
+++ b/frontend/components/RichText.tsx
@@ -98,7 +98,7 @@ export const Editor = ({
 
   const normalizeUrl = (url: string): string => {
     // If already has http:// or https://, return as is
-    if (url.match(/^https?:\/\//u)) {
+    if (/^https?:\/\//u.exec(url)) {
       return url;
     }
     // If it looks like a domain/URL, add https://


### PR DESCRIPTION
ref #911 

## Problem:
- Link URLs without http/https were treated as relative paths (e.g., `example.com` became `localhost:3000/updates/example.com`)
- No validation for invalid URLs, allowing broken links to be inserted

## Solution:
- added validation, and normalization(example.com -> https://example.com)

## AI Disclosure:
- cursor autosuggestions, though changes are verified by me.

### Before:
https://github.com/user-attachments/assets/33b074f3-9862-4861-94cf-12ead558f5a9

### After:
https://github.com/user-attachments/assets/26c537ed-a46f-4da5-a10d-582accc9f6d1

