### PR TITLE
fix unnecessary vertical scrolling on mobile

### DIFF
--- a/frontend/app/(dashboard)/layout.tsx
+++ b/frontend/app/(dashboard)/layout.tsx
@@ -198,8 +198,8 @@ function DashboardLayout({ children }: { children: React.ReactNode }) {
       </Sidebar>
 
       <SidebarInset>
-        <div className="flex flex-col not-print:h-screen not-print:overflow-hidden">
-          <main className={cn("flex flex-1 flex-col pb-20 not-print:overflow-y-auto sm:pb-4")}>
+        <div className="flex flex-col not-print:md:h-screen not-print:md:overflow-hidden">
+          <main className={cn("flex flex-1 flex-col pb-20 sm:pb-4 not-print:md:overflow-y-auto")}>
             <div className="flex flex-col gap-2 md:gap-4">{children}</div>
           </main>
         </div>


### PR DESCRIPTION
ref #911 

## Issue
Dashboard pages (like Updates) were showing vertical scrolling on mobile screens even when content was short and didn't require scrolling.

## Result
- Mobile: No forced scrolling when content is short, natural scrolling when content overflows
- Desktop: Unchanged behavior with controlled scrolling containers

## before

https://github.com/user-attachments/assets/6490f616-d574-463a-912f-13352f62d55a



## after

https://github.com/user-attachments/assets/0a4b5756-6380-492b-813d-404739361cff

