### PR TITLE
fix text overflow on invoice page

### DIFF
--- a/frontend/app/(dashboard)/invoices/[id]/page.tsx
+++ b/frontend/app/(dashboard)/invoices/[id]/page.tsx
@@ -441,7 +441,7 @@ export default function InvoicePage() {
 
               {invoice.lineItems.length > 0 ? (
                 <div className="w-full overflow-x-auto">
-                  <Table className="w-full min-w-[600px] table-fixed md:max-w-full md:min-w-full print:my-3 print:w-full print:border-collapse print:text-xs">
+                  <Table className="w-full min-w-fit print:my-3 print:w-full print:border-collapse print:text-xs">
                     <TableHeader>
                       <TableRow className="print:border-b print:border-gray-300">
                         <PrintTableHeader className="w-[50%] md:w-[60%] print:text-left">


### PR DESCRIPTION
red #911 

## Issue
The "Services and Consulting" text line was not fully visible because it became scrollable within its section. Users had to scroll horizontally within the Services table to view complete line item details.

## before

<img width="680" height="727" alt="Screenshot 2025-09-19 at 1 19 03 AM" src="https://github.com/user-attachments/assets/22be3714-3bd6-4321-931f-7364eae723fc" />


## after

<img width="688" height="731" alt="Screenshot 2025-09-19 at 1 11 49 AM" src="https://github.com/user-attachments/assets/15a19f03-c06b-4ec9-a7c2-db781c0dcdfd" />


## AI Usage
No AI was used to generate any of this code.

## Self-Review
I have self-reviewed all the code that I have written.
