### PR TITLE
Invoice stale data

### DIFF
--- a/e2e/tests/company/invoices/edit.spec.ts
+++ b/e2e/tests/company/invoices/edit.spec.ts
@@ -1,12 +1,14 @@
 import { db, takeOrThrow } from "@test/db";
 import { companiesFactory } from "@test/factories/companies";
 import { companyContractorsFactory } from "@test/factories/companyContractors";
+import { invoicesFactory } from "@test/factories/invoices";
 import { usersFactory } from "@test/factories/users";
 import { fillDatePicker } from "@test/helpers";
 import { login } from "@test/helpers/auth";
 import { expect, test } from "@test/index";
 import { desc, eq } from "drizzle-orm";
-import { invoices } from "@/db/schema";
+import { companyContractors, invoiceLineItems, invoices } from "@/db/schema";
+import { assert } from "@/utils/assert";
 
 test.describe("invoice editing", () => {
   let company: Awaited<ReturnType<typeof companiesFactory.create>>;
@@ -95,5 +97,79 @@ test.describe("invoice editing", () => {
       "Updated notes: This invoice covers the Q1 development sprint including new features, bug fixes, and additional enhancements. Please process within 30 days.",
     );
     expect(updatedInvoice.invoiceNumber).toBe("INV-EDIT-001");
+  });
+
+  test("displays fresh data after editing and returning to the edit page", async ({ page }) => {
+    // Create an invoice with initial data
+    const existingContractor = await db.query.companyContractors.findFirst({
+      where: eq(companyContractors.companyId, company.company.id),
+    });
+    assert(existingContractor !== undefined);
+
+    const invoiceData = await invoicesFactory.create({
+      companyContractorId: existingContractor.id,
+      invoiceNumber: "INV-STALE-TEST",
+      notes: "Original notes.",
+    });
+
+    const existingLineItem = await db.query.invoiceLineItems.findFirst({
+      where: eq(invoiceLineItems.invoiceId, invoiceData.invoice.id),
+    });
+    assert(existingLineItem !== undefined);
+
+    await db
+      .update(invoiceLineItems)
+      .set({
+        description: "Development work",
+        quantity: "1",
+        payRateInSubunits: 6000,
+      })
+      .where(eq(invoiceLineItems.id, existingLineItem.id));
+
+    await login(page, contractorUser);
+
+    await page.goto("/invoices");
+    await expect(page.getByRole("heading", { name: "Invoices" })).toBeVisible();
+    await expect(page.getByRole("cell", { name: "INV-STALE-TEST" })).toBeVisible();
+
+    await page.getByRole("cell", { name: "INV-STALE-TEST" }).click();
+    await page.getByRole("link", { name: "Edit invoice" }).click();
+    await expect(page.getByRole("link", { name: "Edit invoice" })).toBeVisible();
+
+    // Verify initial data is loaded correctly
+    await expect(page.getByPlaceholder("Enter notes about your invoice (optional)")).toHaveValue("Original notes.");
+    await expect(page.getByPlaceholder("Description").first()).toHaveValue("Development work");
+
+    // Update the invoice data
+    await page.getByPlaceholder("Enter notes about your invoice (optional)").fill("Updated notes after first edit.");
+    await page.getByPlaceholder("Description").first().fill("Updated development work");
+    await page.getByRole("button", { name: "Resubmit" }).click();
+
+    await expect(page.getByRole("heading", { name: "Invoices" })).toBeVisible();
+
+    // Navigate back to edit page
+    await page.getByRole("cell", { name: "INV-STALE-TEST" }).click();
+    await page.getByRole("link", { name: "Edit invoice" }).click();
+    await expect(page.getByRole("heading", { name: "Edit invoice" })).toBeVisible();
+
+    // Verify fresh data is displayed (not stale cached data)
+    await expect(page.getByPlaceholder("Description").first()).toHaveValue("Updated development work");
+    await expect(page.getByPlaceholder("Enter notes about your invoice (optional)")).toHaveValue(
+      "Updated notes after first edit.",
+    );
+
+    // Confirm database has the correct data
+    const updatedInvoice = await db.query.invoices
+      .findFirst({ where: eq(invoices.id, invoiceData.invoice.id) })
+      .then(takeOrThrow);
+    expect(updatedInvoice.notes).toBe("Updated notes after first edit.");
+
+    // Verify line items were updated in database
+    const updatedLineItems = await db.query.invoiceLineItems.findMany({
+      where: eq(invoiceLineItems.invoiceId, invoiceData.invoice.id),
+    });
+    expect(updatedLineItems).toHaveLength(1);
+    const lineItem = updatedLineItems[0];
+    expect(lineItem?.description).toBe("Updated development work");
   });
 });

--- a/frontend/app/(dashboard)/invoices/Edit.tsx
+++ b/frontend/app/(dashboard)/invoices/Edit.tsx
@@ -3,7 +3,7 @@
 import { ArrowUpTrayIcon, PlusIcon } from "@heroicons/react/16/solid";
 import { PaperClipIcon, TrashIcon } from "@heroicons/react/24/outline";
 import { type DateValue, parseDate } from "@internationalized/date";
-import { useMutation, useSuspenseQuery } from "@tanstack/react-query";
+import { useMutation, useQueryClient, useSuspenseQuery } from "@tanstack/react-query";
 import { List } from "immutable";
 import { CircleAlert } from "lucide-react";
 import Link from "next/link";
@@ -102,6 +102,7 @@ const Edit = () => {
   const [errorField, setErrorField] = useState<string | null>(null);
   const router = useRouter();
   const trpcUtils = trpc.useUtils();
+  const queryClient = useQueryClient();
   const worker = user.roles.worker;
   assert(worker != null);
 
@@ -117,6 +118,7 @@ const Edit = () => {
       return dataSchema.parse(await response.json());
     },
   });
+
   const payRateInSubunits = data.user.pay_rate_in_subunits;
 
   const [invoiceNumber, setInvoiceNumber] = useState(data.invoice.invoice_number);
@@ -189,6 +191,10 @@ const Edit = () => {
       });
       await trpcUtils.invoices.list.invalidate({ companyId: company.id });
       await trpcUtils.documents.list.invalidate();
+      if (id) {
+        await trpcUtils.invoices.get.invalidate({ companyId: company.id, id });
+        await queryClient.invalidateQueries({ queryKey: ["invoice", id] });
+      }
       router.push("/invoices");
     },
   });


### PR DESCRIPTION
### Bug / Problem:
- stale data was displayed on the invoice edit page after a user successfully updated an invoice and then navigated back to the edit page.

### Solution:
- invalidate the cached data after update mutation succeeds.

### AI Disclosure:
- some help to write test

# Before: 
https://github.com/user-attachments/assets/97d747a8-543a-4e04-ae92-26a0aa1ef906

# After:
https://github.com/user-attachments/assets/ab3e4c7a-6917-48c0-a3f6-7515e25e8e7b


