### PR TITLE
fix(bug): Seed data for primary administrator isn't updated correctly in database

### DIFF
--- a/backend/app/services/seed_data_generator_from_template.rb
+++ b/backend/app/services/seed_data_generator_from_template.rb
@@ -111,9 +111,10 @@ class SeedDataGeneratorFromTemplate
       company = nil
       Timecop.travel(Time.zone.parse(model_attributes["created_at"])) do
         company_name = model_attributes.fetch("name")
+        primary_admin_name = company_data.fetch("primary_administrator").fetch("model_attributes").fetch("preferred_name")
         result = SignUpCompany.new(
           user_attributes: {
-            email: config.fetch("email"),
+            email: generate_email(primary_admin_name),
             password: DEFAULT_PASSWORD,
             confirmed_at: Time.current,
           },


### PR DESCRIPTION
ref #911 

### Problem:
- when seeding data we're wrongly using `email: config.fetch("email")` which isn't correct primary admin email.

### What PR Does?
- correctly update primary administrator email with `email: generate_email(primary_admin_name),`


### AI Disclosure:
- no AI used

# Before:
https://github.com/user-attachments/assets/49e4a739-a57f-4186-afa3-8eb826abb7ae

# After:
https://github.com/user-attachments/assets/22d65003-dd22-44ae-a167-68dcc4c1e139

