### PR TITLE
refactor(cap_table): make cap_table a singular resource

### DIFF
--- a/backend/config/routes/internal.rb
+++ b/backend/config/routes/internal.rb
@@ -38,7 +38,7 @@ scope path: :internal, module: :internal do
 
       resources :stripe_microdeposit_verifications, only: :create
       resources :equity_grants, only: [:create]
-      resources :cap_tables, only: [:create]
+      resource :cap_table, only: [:create]
     end
 
     resource :switch, only: :create, controller: "switch"

--- a/frontend/trpc/routes/capTable.ts
+++ b/frontend/trpc/routes/capTable.ts
@@ -15,7 +15,7 @@ import {
 } from "@/db/schema";
 import type { CapTableInvestor, CapTableInvestorForAdmin } from "@/models/investor";
 import { companyProcedure, createRouter } from "@/trpc";
-import { company_administrator_cap_tables_url } from "@/utils/routes";
+import { company_administrator_cap_table_url } from "@/utils/routes";
 
 export const capTableRouter = createRouter({
   show: companyProcedure.input(z.object({ newSchema: z.boolean().optional() })).query(async ({ ctx, input }) => {
@@ -234,7 +234,7 @@ export const capTableRouter = createRouter({
       if (!ctx.companyAdministrator) throw new TRPCError({ code: "FORBIDDEN" });
       if (!ctx.company.equityEnabled) throw new TRPCError({ code: "FORBIDDEN", message: "Equity must be enabled" });
 
-      const response = await fetch(company_administrator_cap_tables_url(ctx.company.externalId), {
+      const response = await fetch(company_administrator_cap_table_url(ctx.company.externalId), {
         method: "POST",
         headers: {
           "Content-Type": "application/json",

--- a/frontend/utils/routes.d.ts
+++ b/frontend/utils/routes.d.ts
@@ -588,24 +588,24 @@ export const balance_credit_webhooks_wise_index_path: ((
 
 /**
  * Generates rails route to
- * /internal/companies/:company_id/administrator/cap_tables(.:format)
+ * /internal/companies/:company_id/administrator/cap_table(.:format)
  * @param {any} company_id
  * @param {object | undefined} options
  * @returns {string} route path
  */
-export const company_administrator_cap_tables_url: ((
+export const company_administrator_cap_table_url: ((
   company_id: RequiredRouteParameter,
   options?: {format?: OptionalRouteParameter} & RouteOptions
 ) => string) & RouteHelperExtras;
 
 /**
  * Generates rails route to
- * /internal/companies/:company_id/administrator/cap_tables(.:format)
+ * /internal/companies/:company_id/administrator/cap_table(.:format)
  * @param {any} company_id
  * @param {object | undefined} options
  * @returns {string} route path
  */
-export const company_administrator_cap_tables_path: ((
+export const company_administrator_cap_table_path: ((
   company_id: RequiredRouteParameter,
   options?: {format?: OptionalRouteParameter} & RouteOptions
 ) => string) & RouteHelperExtras;

--- a/frontend/utils/routes.js
+++ b/frontend/utils/routes.js
@@ -935,21 +935,21 @@ export const balance_credit_webhooks_wise_index_path = /*#__PURE__*/ __jsr.r({"f
 
 /**
  * Generates rails route to
- * /internal/companies/:company_id/administrator/cap_tables(.:format)
+ * /internal/companies/:company_id/administrator/cap_table(.:format)
  * @param {any} company_id
  * @param {object | undefined} options
  * @returns {string} route path
  */
-export const company_administrator_cap_tables_url = /*#__PURE__*/ __jsr.r({"company_id":{"r":true},"format":{}}, [2,[7,"/"],[2,[6,"internal"],[2,[7,"/"],[2,[6,"companies"],[2,[7,"/"],[2,[3,"company_id"],[2,[7,"/"],[2,[6,"administrator"],[2,[7,"/"],[2,[6,"cap_tables"],[1,[2,[8,"."],[3,"format"]]]]]]]]]]]]], true);
+export const company_administrator_cap_table_url = /*#__PURE__*/ __jsr.r({"company_id":{"r":true},"format":{}}, [2,[7,"/"],[2,[6,"internal"],[2,[7,"/"],[2,[6,"companies"],[2,[7,"/"],[2,[3,"company_id"],[2,[7,"/"],[2,[6,"administrator"],[2,[7,"/"],[2,[6,"cap_table"],[1,[2,[8,"."],[3,"format"]]]]]]]]]]]]], true);
 
 /**
  * Generates rails route to
- * /internal/companies/:company_id/administrator/cap_tables(.:format)
+ * /internal/companies/:company_id/administrator/cap_table(.:format)
  * @param {any} company_id
  * @param {object | undefined} options
  * @returns {string} route path
  */
-export const company_administrator_cap_tables_path = /*#__PURE__*/ __jsr.r({"company_id":{"r":true},"format":{}}, [2,[7,"/"],[2,[6,"internal"],[2,[7,"/"],[2,[6,"companies"],[2,[7,"/"],[2,[3,"company_id"],[2,[7,"/"],[2,[6,"administrator"],[2,[7,"/"],[2,[6,"cap_tables"],[1,[2,[8,"."],[3,"format"]]]]]]]]]]]]]);
+export const company_administrator_cap_table_path = /*#__PURE__*/ __jsr.r({"company_id":{"r":true},"format":{}}, [2,[7,"/"],[2,[6,"internal"],[2,[7,"/"],[2,[6,"companies"],[2,[7,"/"],[2,[3,"company_id"],[2,[7,"/"],[2,[6,"administrator"],[2,[7,"/"],[2,[6,"cap_table"],[1,[2,[8,"."],[3,"format"]]]]]]]]]]]]]);
 
 /**
  * Generates rails route to


### PR DESCRIPTION
- It is semantically correct to use a single Rails resource since a company only has one cap table. 
This modification ensures consistency in the rails backend, improves API semantics, and removes ambiguity.

---

<img width="1002" height="236" alt="image" src="https://github.com/user-attachments/assets/247f3948-6d1c-4487-a5af-485b1c85b41d" />
<img width="2940" height="1912" alt="image" src="https://github.com/user-attachments/assets/ac1ebada-c001-4ad0-9266-58f6392a93c4" />

> [!NOTE]
> AI assistance was used in preparing this PR:
> - **Cursor Pro (GPT-5)**: for code scaffolding and refactoring suggestions  
> - **Claude Sonnet 4**: for explanation drafts and wording improvements
