### PR TITLE
improvement: disable save changes button when no changes to save / update

### DIFF
--- a/frontend/app/settings/administrator/details/page.tsx
+++ b/frontend/app/settings/administrator/details/page.tsx
@@ -50,10 +50,13 @@ export default function Details() {
     },
   });
 
+  const { isDirty } = form.formState;
+
   const updateSettings = trpc.companies.update.useMutation({
     onSuccess: async () => {
       await utils.companies.settings.invalidate();
       await queryClient.invalidateQueries({ queryKey: ["currentUser"] });
+      form.reset(form.getValues());
       setTimeout(() => updateSettings.reset(), 2000);
     },
   });
@@ -203,6 +206,7 @@ export default function Details() {
           loadingText="Saving..."
           successText="Changes saved"
           className="w-fit"
+          disabled={!isDirty}
         >
           Save changes
         </MutationStatusButton>

--- a/frontend/app/settings/administrator/equity/page.tsx
+++ b/frontend/app/settings/administrator/equity/page.tsx
@@ -43,6 +43,7 @@ export default function Equity() {
     onSuccess: async () => {
       await utils.companies.settings.invalidate();
       await queryClient.invalidateQueries({ queryKey: ["currentUser"] });
+      form.reset(form.getValues());
       setTimeout(() => updateSettings.reset(), 2000);
     },
   });
@@ -64,6 +65,8 @@ export default function Equity() {
     },
     disabled: requiresCompanyName,
   });
+
+  const { isDirty } = form.formState;
 
   const submit = form.handleSubmit((values) =>
     updateSettings.mutateAsync({
@@ -169,6 +172,7 @@ export default function Equity() {
                 mutation={updateSettings}
                 loadingText="Saving..."
                 successText="Changes saved"
+                disabled={!isDirty}
               >
                 Save changes
               </MutationStatusButton>

--- a/frontend/app/settings/administrator/page.tsx
+++ b/frontend/app/settings/administrator/page.tsx
@@ -36,6 +36,8 @@ export default function SettingsPage() {
     },
   });
 
+  const { isDirty } = form.formState;
+
   const [logoFile, setLogoFile] = useState<File | null>(null);
   const logoUrl = useMemo(
     () => (logoFile ? URL.createObjectURL(logoFile) : (company.logo_url ?? defaultLogo.src)),
@@ -80,7 +82,10 @@ export default function SettingsPage() {
       await refetch();
       await queryClient.invalidateQueries({ queryKey: ["currentUser"] });
     },
-    onSuccess: () => setTimeout(() => saveMutation.reset(), 2000),
+    onSuccess: () => {
+      form.reset(form.getValues());
+      setTimeout(() => saveMutation.reset(), 2000);
+    },
   });
   const submit = form.handleSubmit((values) => saveMutation.mutate(values));
 
@@ -174,6 +179,7 @@ export default function SettingsPage() {
             successText="Changes saved"
             loadingText="Saving..."
             className="w-fit"
+            disabled={!isDirty}
           >
             Save changes
           </MutationStatusButton>

--- a/frontend/app/settings/page.tsx
+++ b/frontend/app/settings/page.tsx
@@ -45,6 +45,8 @@ const DetailsSection = () => {
     },
   });
 
+  const { isDirty } = form.formState;
+
   const saveMutation = useMutation({
     mutationFn: async (values: { email: string; preferredName: string }) => {
       const response = await request({
@@ -56,7 +58,10 @@ const DetailsSection = () => {
       if (!response.ok)
         throw new Error(z.object({ error_message: z.string() }).parse(await response.json()).error_message);
     },
-    onSuccess: () => setTimeout(() => saveMutation.reset(), 2000),
+    onSuccess: () => {
+      form.reset(form.getValues());
+      setTimeout(() => saveMutation.reset(), 2000);
+    },
   });
   const submit = form.handleSubmit((values) => saveMutation.mutate(values));
 
@@ -99,6 +104,7 @@ const DetailsSection = () => {
           mutation={saveMutation}
           loadingText="Saving..."
           successText="Saved!"
+          disabled={!isDirty}
         >
           Save
         </MutationStatusButton>

--- a/frontend/app/settings/payouts/page.tsx
+++ b/frontend/app/settings/payouts/page.tsx
@@ -61,6 +61,8 @@ const EquitySection = () => {
     defaultValues: { equityPercentage: worker.equityPercentage },
     resolver: zodResolver(equityFormSchema),
   });
+
+  const { isDirty } = form.formState;
   const payRateInSubunits = worker.payRateInSubunits ?? 0;
   const equityPercentage = form.watch("equityPercentage");
 
@@ -74,7 +76,10 @@ const EquitySection = () => {
         assertOk: true,
       });
     },
-    onSuccess: () => setTimeout(() => saveMutation.reset(), 2000),
+    onSuccess: () => {
+      form.reset(form.getValues());
+      setTimeout(() => saveMutation.reset(), 2000);
+    },
   });
 
   const submit = form.handleSubmit((values) => saveMutation.mutate(values));
@@ -137,6 +142,7 @@ const EquitySection = () => {
               loadingText="Saving..."
               successText="Saved!"
               className="justify-self-end"
+              disabled={!isDirty}
             >
               Save changes
             </MutationStatusButton>
@@ -178,6 +184,8 @@ const DividendSection = () => {
     resolver: zodResolver(dividendsFormSchema),
   });
 
+  const { isDirty } = form.formState;
+
   const saveMutation = useMutation({
     mutationFn: async (values: z.infer<typeof dividendsFormSchema>) => {
       await request({
@@ -192,7 +200,10 @@ const DividendSection = () => {
         assertOk: true,
       });
     },
-    onSuccess: () => setTimeout(() => saveMutation.reset(), 2000),
+    onSuccess: () => {
+      form.reset(form.getValues());
+      setTimeout(() => saveMutation.reset(), 2000);
+    },
   });
 
   const submit = form.handleSubmit((values) => saveMutation.mutate(values));
@@ -233,6 +244,7 @@ const DividendSection = () => {
               loadingText="Saving..."
               successText="Saved!"
               className="justify-self-end"
+              disabled={!isDirty}
             >
               Save changes
             </MutationStatusButton>


### PR DESCRIPTION
ref #911 

### What PR Does?
- disable save changes button when no changes to save / update, after every save change, it disable until further update.

### AI Disclosure:
- no AI used

# Before:
https://github.com/user-attachments/assets/c9d29474-e847-4a16-bd6e-ab7bf61cc013

#After:
https://github.com/user-attachments/assets/7bbe46ac-7725-42db-810c-21a3ed5fa48e

