### PR TITLE
Don't delete `CompanyInvestor` when leaving a workspace

### DIFF
--- a/backend/app/policies/user_policy.rb
+++ b/backend/app/policies/user_policy.rb
@@ -10,6 +10,6 @@ class UserPolicy < ApplicationPolicy
   end
 
   def leave_company?
-    (company_worker.present? || company_investor.present? || company_lawyer.present?) && company_administrator.blank?
+    (company_worker.present? || company_lawyer.present?) && company_administrator.blank?
   end
 end

--- a/backend/app/services/leave_company_service.rb
+++ b/backend/app/services/leave_company_service.rb
@@ -35,8 +35,7 @@ class LeaveCompanyService
       # Set ended_at for contractors to mark contract end date (preserve contract history)
       user.company_workers.where(company: company).update_all(ended_at: Time.current)
 
-      # Remove investors and lawyers completely (no contract history needed)
-      user.company_investors.where(company: company).delete_all
+      # Remove lawyers completely (no contract history needed)
       user.company_lawyers.where(company: company).delete_all
     end
 
@@ -46,7 +45,6 @@ class LeaveCompanyService
 
     def user_has_leavable_role?
       user.company_workers.active.exists?(company: company) ||
-        user.company_investors.exists?(company: company) ||
         user.company_lawyers.exists?(company: company)
     end
 end

--- a/backend/spec/services/leave_company_service_spec.rb
+++ b/backend/spec/services/leave_company_service_spec.rb
@@ -69,8 +69,8 @@ RSpec.describe LeaveCompanyService do
       it "returns failure" do
         result = service.call
 
-        expect(result[:success]).to be true
-        expect(result[:error]).to be_nil
+        expect(result[:success]).to be false
+        expect(result[:error]).to eq "You do not have permission to leave this company."
       end
 
       it "does not remove the investor role" do

--- a/backend/spec/services/leave_company_service_spec.rb
+++ b/backend/spec/services/leave_company_service_spec.rb
@@ -95,6 +95,7 @@ RSpec.describe LeaveCompanyService do
 
     context "when user has multiple roles" do
       let!(:company_worker) { create(:company_worker, user: user, company: company) }
+      let!(:company_investor) { create(:company_investor, user: user, company: company) }
       let!(:company_lawyer) { create(:company_lawyer, user: user, company: company) }
 
       it "returns success" do
@@ -106,6 +107,7 @@ RSpec.describe LeaveCompanyService do
 
       it "removes all user roles" do
         expect { service.call }.to change { user.company_lawyers.count }.by(-1)
+          .and change { user.company_investors.count }.by(0) # We don't delete the `company_investors` data as it referenced in other tables
 
         # Worker should have ended_at set instead of being deleted
         worker = user.company_workers.where(company: company).first
@@ -172,11 +174,11 @@ RSpec.describe LeaveCompanyService do
       end
 
       it "rolls back all changes on error" do
-        initial_worker_count = user.company_workers.count
+        initial_worker_count = user.company_workers.active.count
 
         service.call
 
-        expect(user.company_workers.count).to eq initial_worker_count
+        expect(user.company_workers.active.count).to eq initial_worker_count
       end
     end
   end

--- a/e2e/tests/settings/leave-company.spec.ts
+++ b/e2e/tests/settings/leave-company.spec.ts
@@ -110,7 +110,7 @@ test.describe("Leave company", () => {
 
     expect(contractor?.endedAt).toBeTruthy();
     expect(lawyer).toBeUndefined();
-    expect(investor?.id).not.toBeNull();
+    expect(investor).toBeUndefined(); // We don't delete the `company_investors` data as it referenced in other tables
   });
 
   test("user can cancel leaving workspace", async ({ page }) => {
@@ -135,7 +135,7 @@ test.describe("Leave company", () => {
     const lawyer = await db.query.companyLawyers.findFirst({
       where: and(eq(companyLawyers.companyId, company.id), eq(companyLawyers.userId, user.id)),
     });
-    expect(lawyer?.id).not.toBeNull();
+    expect(lawyer).toBeDefined();
   });
 
   test("user with roles in other companies can leave current company successfully", async ({ page }) => {
@@ -170,7 +170,7 @@ test.describe("Leave company", () => {
       where: and(eq(companyLawyers.companyId, companyB.id), eq(companyLawyers.userId, user.id)),
     });
 
-    expect(lawyerA?.id).not.toBeNull();
+    expect(lawyerA).toBeDefined();
     expect(lawyerB).toBeUndefined();
   });
 });

--- a/e2e/tests/settings/leave-company.spec.ts
+++ b/e2e/tests/settings/leave-company.spec.ts
@@ -44,31 +44,6 @@ test.describe("Leave company", () => {
     expect(contractor?.endedAt).toBeTruthy();
   });
 
-  test("investor can leave successfully", async ({ page }) => {
-    const { company } = await companiesFactory.createCompletedOnboarding();
-    const { user } = await usersFactory.create();
-
-    await companyInvestorsFactory.create({
-      companyId: company.id,
-      userId: user.id,
-    });
-
-    await login(page, user);
-    await page.getByRole("link", { name: "Settings" }).click();
-
-    await page.getByRole("button", { name: "Leave workspace" }).click();
-
-    await expect(page.getByText("Leave this workspace?")).toBeVisible();
-    await page.getByRole("button", { name: "Leave" }).click();
-
-    await expect(page).toHaveURL("/login");
-
-    const investor = await db.query.companyInvestors.findFirst({
-      where: and(eq(companyInvestors.companyId, company.id), eq(companyInvestors.userId, user.id)),
-    });
-    expect(investor).toBeUndefined();
-  });
-
   test("lawyer can leave successfully", async ({ page }) => {
     const { company } = await companiesFactory.createCompletedOnboarding();
     const { user } = await usersFactory.create();
@@ -103,6 +78,11 @@ test.describe("Leave company", () => {
       userId: user.id,
     });
 
+    await companyLawyersFactory.create({
+      companyId: company.id,
+      userId: user.id,
+    });
+
     await companyInvestorsFactory.create({
       companyId: company.id,
       userId: user.id,
@@ -121,19 +101,23 @@ test.describe("Leave company", () => {
     const contractor = await db.query.companyContractors.findFirst({
       where: and(eq(companyContractors.companyId, company.id), eq(companyContractors.userId, user.id)),
     });
+    const lawyer = await db.query.companyLawyers.findFirst({
+      where: and(eq(companyInvestors.companyId, company.id), eq(companyInvestors.userId, user.id)),
+    });
     const investor = await db.query.companyInvestors.findFirst({
       where: and(eq(companyInvestors.companyId, company.id), eq(companyInvestors.userId, user.id)),
     });
 
     expect(contractor?.endedAt).toBeTruthy();
-    expect(investor).toBeUndefined();
+    expect(lawyer).toBeUndefined();
+    expect(investor?.id).not.toBeNull();
   });
 
   test("user can cancel leaving workspace", async ({ page }) => {
     const { company } = await companiesFactory.createCompletedOnboarding();
     const { user } = await usersFactory.create();
 
-    await companyInvestorsFactory.create({
+    await companyLawyersFactory.create({
       companyId: company.id,
       userId: user.id,
     });
@@ -148,10 +132,10 @@ test.describe("Leave company", () => {
 
     await expect(page.getByText("Leave this workspace?")).not.toBeVisible();
 
-    const investor = await db.query.companyInvestors.findFirst({
-      where: and(eq(companyInvestors.companyId, company.id), eq(companyInvestors.userId, user.id)),
+    const lawyer = await db.query.companyLawyers.findFirst({
+      where: and(eq(companyLawyers.companyId, company.id), eq(companyLawyers.userId, user.id)),
     });
-    expect(investor).toBeDefined();
+    expect(lawyer?.id).not.toBeNull();
   });
 
   test("user with roles in other companies can leave current company successfully", async ({ page }) => {
@@ -159,7 +143,7 @@ test.describe("Leave company", () => {
     const { company: companyB } = await companiesFactory.createCompletedOnboarding({ name: "Company B" });
     const { user } = await usersFactory.create();
 
-    await companyInvestorsFactory.create({
+    await companyLawyersFactory.create({
       companyId: companyA.id,
       userId: user.id,
     });
@@ -179,14 +163,14 @@ test.describe("Leave company", () => {
 
     await expect(page.getByRole("button", { name: "Company A" })).toBeVisible();
 
-    const investor = await db.query.companyInvestors.findFirst({
-      where: and(eq(companyInvestors.companyId, companyA.id), eq(companyInvestors.userId, user.id)),
+    const lawyerA = await db.query.companyLawyers.findFirst({
+      where: and(eq(companyLawyers.companyId, companyA.id), eq(companyLawyers.userId, user.id)),
     });
-    const lawyer = await db.query.companyLawyers.findFirst({
+    const lawyerB = await db.query.companyLawyers.findFirst({
       where: and(eq(companyLawyers.companyId, companyB.id), eq(companyLawyers.userId, user.id)),
     });
 
-    expect(investor).toBeDefined();
-    expect(lawyer).toBeUndefined();
+    expect(lawyerA?.id).not.toBeNull();
+    expect(lawyerB).toBeUndefined();
   });
 });

--- a/e2e/tests/settings/leave-company.spec.ts
+++ b/e2e/tests/settings/leave-company.spec.ts
@@ -110,7 +110,7 @@ test.describe("Leave company", () => {
 
     expect(contractor?.endedAt).toBeTruthy();
     expect(lawyer).toBeUndefined();
-    expect(investor).toBeUndefined(); // We don't delete the `company_investors` data as it referenced in other tables
+    expect(investor).toBeDefined(); // We don't delete the `company_investors` data as it referenced in other tables
   });
 
   test("user can cancel leaving workspace", async ({ page }) => {
@@ -154,14 +154,14 @@ test.describe("Leave company", () => {
 
     await login(page, user);
 
-    await expect(page.getByRole("button", { name: "Company B" })).toBeVisible();
+    await expect(page.getByRole("button", { name: "Company A" })).toBeVisible();
     await page.getByRole("link", { name: "Settings" }).click();
 
     await page.getByRole("button", { name: "Leave workspace" }).click();
     await expect(page.getByText("Leave this workspace?")).toBeVisible();
     await page.getByRole("button", { name: "Leave" }).click();
 
-    await expect(page.getByRole("button", { name: "Company A" })).toBeVisible();
+    await expect(page.getByRole("button", { name: "Company B" })).toBeVisible();
 
     const lawyerA = await db.query.companyLawyers.findFirst({
       where: and(eq(companyLawyers.companyId, companyA.id), eq(companyLawyers.userId, user.id)),
@@ -170,7 +170,7 @@ test.describe("Leave company", () => {
       where: and(eq(companyLawyers.companyId, companyB.id), eq(companyLawyers.userId, user.id)),
     });
 
-    expect(lawyerA).toBeDefined();
-    expect(lawyerB).toBeUndefined();
+    expect(lawyerA).toBeUndefined();
+    expect(lawyerB).toBeDefined();
   });
 });

--- a/frontend/app/settings/page.tsx
+++ b/frontend/app/settings/page.tsx
@@ -158,7 +158,7 @@ const LeaveWorkspaceSection = () => {
   }
 
   // Don't show leave option if user has no leavable roles
-  if (!user.roles.worker && !user.roles.investor && !user.roles.lawyer) {
+  if (!user.roles.worker && !user.roles.lawyer) {
     return null;
   }
 


### PR DESCRIPTION
### What

Don't delete a `CompanyInvestor` record from the system when a user is leaving a company's workspace.

### Why

A company investor record is referenced by multiple tables in the database. Also, even if it were a soft-delete, we shouldn't allow the investor themself to do it. It should be administrator/system-initiated, so we only do it after the investor holds no securities of the company.

This was discovered because the dividends page was broken for a customer. It seems an investor deleted their own record in the system using this feature.

### Notes

AI Usage: Cursor Tab
Ref: https://github.com/antiwork/flexile/issues/1115#issuecomment-3319889166, https://anti--work.slack.com/archives/C068HHZ64M9/p1757889317135169?thread_ts=1757333132.357889&cid=C068HHZ64M9