### PR TITLE
fix: invoice submission silently fails with "total must be greater than 99 cents" error when line items have blank descriptions

### DIFF
--- a/e2e/tests/company/invoices/create.spec.ts
+++ b/e2e/tests/company/invoices/create.spec.ts
@@ -278,30 +278,19 @@ test.describe("invoice creation", () => {
   test("allows submitting line items with blank descriptions via 'Add more info' flow", async ({ page }) => {
     await login(page, contractorUser, "/invoices");
 
-    await page.getByRole("button", { name: "Add more info" }).click();
-    await expect(page.getByRole("heading", { name: "New invoice" })).toBeVisible();
-
-    await page.getByLabel("Hours / Qty").fill("2:00");
+    await page.getByText("Add more info").click();
+    await page.getByLabel("Hours / Qty").fill("1:00");
     await page.getByLabel("Rate").fill("60");
-
-    await expect(page.getByText("Total$120")).toBeVisible();
-
     await page.getByRole("button", { name: "Send invoice" }).click();
-    await expect(page.getByRole("heading", { name: "Invoices" })).toBeVisible();
-
-    await expect(page.locator("tbody")).toContainText("$120");
+    await expect(page.getByRole("cell", { name: "Awaiting approval (0/2)" })).toBeVisible();
 
     const invoice = await db.query.invoices
       .findFirst({ where: eq(invoices.companyId, company.id), orderBy: desc(invoices.id) })
       .then(takeOrThrow);
 
-    expect(invoice.totalAmountInUsdCents).toBe(12000n);
-
     const lineItem = await db.query.invoiceLineItems
       .findFirst({ where: eq(invoiceLineItems.invoiceId, invoice.id) })
       .then(takeOrThrow);
-
     expect(lineItem.description).toBe("-");
-    expect(Number(lineItem.quantity)).toBe(2);
   });
 });

--- a/e2e/tests/company/invoices/create.spec.ts
+++ b/e2e/tests/company/invoices/create.spec.ts
@@ -274,4 +274,34 @@ test.describe("invoice creation", () => {
 
     expect(Number(lineItem.quantity)).toBe(2.5);
   });
+
+  test("allows submitting line items with blank descriptions via 'Add more info' flow", async ({ page }) => {
+    await login(page, contractorUser, "/invoices");
+
+    await page.getByRole("button", { name: "Add more info" }).click();
+    await expect(page.getByRole("heading", { name: "New invoice" })).toBeVisible();
+
+    await page.getByLabel("Hours / Qty").fill("2:00");
+    await page.getByLabel("Rate").fill("60");
+
+    await expect(page.getByText("Total$120")).toBeVisible();
+
+    await page.getByRole("button", { name: "Send invoice" }).click();
+    await expect(page.getByRole("heading", { name: "Invoices" })).toBeVisible();
+
+    await expect(page.locator("tbody")).toContainText("$120");
+
+    const invoice = await db.query.invoices
+      .findFirst({ where: eq(invoices.companyId, company.id), orderBy: desc(invoices.id) })
+      .then(takeOrThrow);
+
+    expect(invoice.totalAmountInUsdCents).toBe(12000n);
+
+    const lineItem = await db.query.invoiceLineItems
+      .findFirst({ where: eq(invoiceLineItems.invoiceId, invoice.id) })
+      .then(takeOrThrow);
+
+    expect(lineItem.description).toBe("-");
+    expect(Number(lineItem.quantity)).toBe(2);
+  });
 });

--- a/frontend/app/(dashboard)/invoices/Edit.tsx
+++ b/frontend/app/(dashboard)/invoices/Edit.tsx
@@ -158,11 +158,11 @@ const Edit = () => {
       formData.append("invoice[invoice_number]", invoiceNumber);
       formData.append("invoice[invoice_date]", issueDate.toString());
       for (const lineItem of lineItems) {
-        if (!lineItem.description || !lineItem.quantity) continue;
+        if (!lineItem.quantity) continue;
         if (lineItem.id) {
           formData.append("invoice_line_items[][id]", lineItem.id.toString());
         }
-        formData.append("invoice_line_items[][description]", lineItem.description);
+        formData.append("invoice_line_items[][description]", lineItem.description || "-");
         formData.append("invoice_line_items[][quantity]", lineItem.quantity.toString());
         formData.append("invoice_line_items[][hourly]", lineItem.hourly.toString());
         formData.append("invoice_line_items[][pay_rate_in_subunits]", lineItem.pay_rate_in_subunits.toString());
@@ -241,7 +241,6 @@ const Edit = () => {
       lineItems.update(index, (lineItem) => {
         const updated = { ...assertDefined(lineItem), ...update };
         updated.errors = [];
-        if (updated.description.length === 0) updated.errors.push("description");
         if (!updated.quantity || parseQuantity(updated.quantity) < 0.01) updated.errors.push("quantity");
         return updated;
       }),


### PR DESCRIPTION
ref #1204 #911 

### Problem:
Users adding line items with amounts but leaving descriptions blank we get "Total amount in USD cents must be greater than 99" in backend response (which we don't show anywhere on frontend) and it seems like invoice submitted.

example: (also in before video)
when a user adds a line item with amount but no description:
- Frontend shows total including that amount (let's say 500$)
- Frontend filters out the line item during submission
- Backend receives 0 total → fails validation with misleading "must be greater than 99" error(invoice submission fails, and error never gets shown on frontend)

### Solution:
- we allow empty description, which is the case when (send for approval) from /invoices page, and we handle them by automatically adding `-` as description.
<img width="1260" height="352" alt="Screenshot 2025-09-24 at 3 45 03 AM" src="https://github.com/user-attachments/assets/8c8e910d-6f51-4fca-a7b8-9c583cb0ccd6" />
- so now i've made changes to do the same when submitting invoice from new invoice dashboard (add `-` for empty descriptions rather than filtering them.

## Before: 
https://github.com/user-attachments/assets/d51d5323-c412-44d9-8b51-9896ebb60efb

## After:
https://github.com/user-attachments/assets/514096bf-3ffb-40e3-952e-8ad8d6829fc6

### AI Disclosure:
- cursor used to debug issue faster, and add test

