### PR TITLE
fix excessive bottom spacing in settings pages

### DIFF
--- a/frontend/app/settings/administrator/details/page.tsx
+++ b/frontend/app/settings/administrator/details/page.tsx
@@ -73,7 +73,7 @@ export default function Details() {
   };
 
   return (
-    <form onSubmit={(e) => void onSubmit(e)} className="mb-24 grid gap-8">
+    <form onSubmit={(e) => void onSubmit(e)} className="grid gap-8">
       <hgroup>
         <h2 className="mb-1 text-3xl font-bold">Details</h2>
         <p className="text-muted-foreground text-base">

--- a/frontend/app/settings/layout.tsx
+++ b/frontend/app/settings/layout.tsx
@@ -92,7 +92,7 @@ function SettingsLayout({ children }: { children: React.ReactNode }) {
               <span className="font-medium">Back to app</span>
             </Link>
           </div>
-          <main className="mx-auto w-full max-w-3xl flex-1 p-6 pb-32 md:p-16">{children}</main>
+          <main className="mx-auto w-full max-w-3xl flex-1 p-6 pb-6 md:p-16">{children}</main>
         </SidebarInset>
       </div>
     </SidebarProvider>


### PR DESCRIPTION
ref #911 
## Problem
Settings pages (particularly Company Details) had excessive white space at the bottom, creating a poor user experience with unnecessary scrolling and awkward spacing after the "Save changes" button.

## before

https://github.com/user-attachments/assets/c9f3bf2f-856f-4749-a731-ceb4b67625a1


## after


https://github.com/user-attachments/assets/0c591431-4ddc-43ea-8b70-0786b4558ef1




## AI Usage
No AI was used to generate any of this code.

## Self-Review
I have self-reviewed all the code that I have written.