### PR TITLE
test: fix payouts failing tests

### DIFF
--- a/e2e/tests/settings/payouts/add-bank-account.spec.ts
+++ b/e2e/tests/settings/payouts/add-bank-account.spec.ts
@@ -47,7 +47,7 @@ test.describe("Bank account settings", () => {
     onboardingUser = (await usersFactory.create({ state: "Hawaii" })).user;
     await companyContractorsFactory.create(
       { companyId: company.id, userId: onboardingUser.id },
-      { withUnsignedContract: true },
+      { withoutBankAccount: true, withUnsignedContract: true },
     );
 
     await login(page, onboardingUser, "/settings/payouts");


### PR DESCRIPTION
### Description:

All 34 tests are failing on `main` for payout due to recent changes.

**Cause**: Recent changes create bank account by default if `withoutBankAccount` is not passed.

### Before / After:

#### Before:

<img width="1432" height="726" alt="Screenshot 2025-09-25 at 7 38 09 PM" src="https://github.com/user-attachments/assets/da3ac36d-f049-4573-b230-af500d08a742" />

#### After:
<img width="1296" height="682" alt="Screenshot 2025-09-25 at 7 38 30 PM" src="https://github.com/user-attachments/assets/8d2b8678-4f75-4d3f-92c8-0f1d22d214d6" />


> [!Note]
> AI Disclosure: No AI was used to generate any of this code.