### PR TITLE
fix: correct user compliance info assertions in tax settings tests

### DIFF
--- a/e2e/tests/settings/tax.spec.ts
+++ b/e2e/tests/settings/tax.spec.ts
@@ -164,10 +164,10 @@ test.describe("Tax settings", () => {
 
       expect(updatedUser.userComplianceInfos).toHaveLength(2);
 
-      expect(updatedUser.userComplianceInfos[0]?.deletedAt).not.toBeNull();
+      expect(updatedUser.userComplianceInfos[0]?.deletedAt).toBeNull();
+      expect(updatedUser.userComplianceInfos[0]?.taxInformationConfirmedAt).not.toBeNull();
 
-      expect(updatedUser.userComplianceInfos[1]?.taxInformationConfirmedAt).not.toBeNull();
-      expect(updatedUser.userComplianceInfos[1]?.deletedAt).toBeNull();
+      expect(updatedUser.userComplianceInfos[1]?.deletedAt).not.toBeNull();
     });
 
     test.describe("tax ID validity", () => {


### PR DESCRIPTION
## Problem
The test "allows confirming tax information" was failing because it had incorrect assertions about which compliance info records should be active vs deleted.

When a user updates their tax information the system then - 
1. Creates a new `userComplianceInfo` record with updated data
2. Marks the old record as deleted (`deletedAt` is set)
3. Orders results by `createdAt DESC` (newest first)

<img width="1711" height="642" alt="Screenshot 2025-09-26 012549" src="https://github.com/user-attachments/assets/632c3a27-b573-41dd-91a6-989d6f40108e" />



The test was incorrectly expecting:
- `userComplianceInfos[0]` (newest) to be deleted 
- `userComplianceInfos[1]` (oldest) to be active 


### Fix

Corrected the assertions to properly expect:
- `userComplianceInfos[0]` (newest) to be active (`deletedAt = null`) 
- `userComplianceInfos[0]` to have `taxInformationConfirmedAt` set 
- `userComplianceInfos[1]` (oldest) to be deleted (`deletedAt != null`)

## Changes
- Fixed test assertions in `e2e/tests/settings/tax.spec.ts`
- No functional code changes, only test corrections

Result Screenshot - 

<img width="1838" height="527" alt="image" src="https://github.com/user-attachments/assets/a02d05fd-3020-45c7-b77c-197fe6a940a3" />

Ref https://github.com/antiwork/flexile/issues/1132

AI Disclosure:
No AI was used
