### PR TITLE
fix billing spec

### DIFF
--- a/e2e/tests/settings/administrator/billing.spec.ts
+++ b/e2e/tests/settings/administrator/billing.spec.ts
@@ -5,7 +5,7 @@ import { expect, test } from "@test/index";
 test.describe("Company billing settings", () => {
   test("billing settings gated until company name is set", async ({ page }) => {
     const { adminUser } = await companiesFactory.createCompletedOnboarding(
-      { name: null },
+      { name: null, stripeCustomerId: null },
       { withoutBankAccount: true },
     );
 

--- a/e2e/tests/settings/administrator/billing.spec.ts
+++ b/e2e/tests/settings/administrator/billing.spec.ts
@@ -2,6 +2,8 @@ import { companiesFactory } from "@test/factories/companies";
 import { login } from "@test/helpers/auth";
 import { expect, test } from "@test/index";
 
+// allow green builds on OSS PRs that don't have a stripe sandbox key, but fail on CI if something changes on Stripe's end
+test.skip(() => process.env.STRIPE_SECRET_KEY === "dummy");
 test.describe("Company billing settings", () => {
   test("billing settings gated until company name is set", async ({ page }) => {
     const { adminUser } = await companiesFactory.createCompletedOnboarding(


### PR DESCRIPTION
Part of #1132 

AI Disclosure:
No AI used

Description:
The stripecustomerId should be passed as null for tests when creating company, otherwise the company factory creates a random id 

Failing test : e2e/tests/settings/administrator/billing.spec.ts
Failing CI Run : https://github.com/antiwork/flexile/actions/runs/18017207360/job/51265139296


E2E
<img width="500" height="400" alt="image" src="https://github.com/user-attachments/assets/69182e9c-da7f-46b7-8712-9a79bbb3c021" />
