### PR TITLE
payment spec fix due to playwright strict mode violation

### DIFF
--- a/e2e/tests/company/invoices/one-off-payments.spec.ts
+++ b/e2e/tests/company/invoices/one-off-payments.spec.ts
@@ -372,7 +372,7 @@ test.describe("One-off payments", () => {
 
       await login(page, adminUser, "/invoices");
 
-      await expect(page.locator("tbody")).toBeVisible();
+      await expect(page.locator("tbody").first()).toBeVisible();
 
       const invoiceRow = await findRequiredTableRow(page, {
         Amount: "$500",


### PR DESCRIPTION
## Problem
The "shows 'Pay again' button for failed payments" test was failing with a Playwright strict mode violation(default setting):


<img width="794" height="968" alt="image" src="https://github.com/user-attachments/assets/5d82acb9-35c7-4dac-bd01-5e3c36e335b4" />

This occurred because there were multiple `<tbody>` elements on the page, and Playwright's strict mode requires locators to resolve to exactly one element.

Allowing first occurence to be visible is consistently passing the test.

<img width="1488" height="661" alt="image" src="https://github.com/user-attachments/assets/dc745735-7192-49ef-a915-45b0be92eeeb" />

fixes https://github.com/antiwork/flexile/issues/1132

AI Disclosure:
No AI tools used