### PR TITLE
Fix spec failures caused by table skeleton

### DIFF
--- a/frontend/components/TableSkeleton.tsx
+++ b/frontend/components/TableSkeleton.tsx
@@ -49,14 +49,11 @@ export default function TableSkeleton({
   }
 
   return (
-    <>
-      <Table className="hidden md:table">
-        <TableBody>{desktopSkeletonRows}</TableBody>
-      </Table>
-
-      <Table className="grid gap-4 md:hidden">
-        <TableBody>{mobileSkeletonRows}</TableBody>
-      </Table>
-    </>
+    <Table>
+      <TableBody>
+        {desktopSkeletonRows}
+        {mobileSkeletonRows}
+      </TableBody>
+    </Table>
   );
 }


### PR DESCRIPTION
AI Disclosure:
No AI used

Ref : #1132 

Description
The table skeleton was rendering multiple tables (one for mobile and one for desktop) this was causing multiple spec failures and flakiness. One such example is `e2e/tests/company/invoices/one-off-payments.spec.ts:362` on the CI run https://github.com/antiwork/flexile/actions/runs/18017207360/job/51265139296

Fix
Moved both the skeleton views under the same table without impacting the UI

After 

https://github.com/user-attachments/assets/fced52ac-1cbb-4dad-b00a-6aaf0c6e45c4

E2E
<img width="785" height="115" alt="Screenshot 2025-09-26 at 3 02 44 AM" src="https://github.com/user-attachments/assets/749a8356-5451-4ed5-b8e3-ab80f04f3f93" />

