### PR TITLE
fix: flaky role auto complete spec

### DIFF
--- a/e2e/tests/company/administrator/role-autocomplete.spec.ts
+++ b/e2e/tests/company/administrator/role-autocomplete.spec.ts
@@ -60,7 +60,7 @@ test.describe("Role autocomplete", () => {
     await expect(page.getByRole("option", { name: role1 })).toBeVisible();
     await expect(page.getByRole("option", { name: role2 })).toBeVisible();
     await expect(page.getByRole("option", { name: role3 })).not.toBeVisible();
-    await roleField.press("Enter");
+    await page.getByRole("option", { name: role1 }).click();
     await expect(roleField).toHaveValue(role1);
     await expect(page.getByRole("option")).not.toBeVisible();
   };


### PR DESCRIPTION
Ref : https://github.com/antiwork/flexile/issues/1132

**Issue**
 
" suggests existing roles when inviting a new contractor" is flaky.

**Fix**
 Click on the specific option instead of pressing Enter 

https://github.com/antiwork/flexile/actions/runs/18021144445/job/51278496907?pr=1262

No AI Usage.