### PR TITLE
refactor(TableSkeleton): avoid duplication of `tbody` for mobile and desktop view 

### DIFF
--- a/frontend/components/TableSkeleton.tsx
+++ b/frontend/components/TableSkeleton.tsx
@@ -14,49 +14,35 @@ export default function TableSkeleton({
   rows = 5,
   renderRowsOnly = false,
 }: TableSkeletonProps) {
-  const desktopSkeletonRows = Array.from({ length: rows }).map((_, rowIndex) => (
-    <TableRow key={`desktop-${rowIndex}`} className="hidden md:table-row">
+  const skeletonRows = Array.from({ length: rows }).map((_, rowIndex) => (
+    <TableRow key={rowIndex}>
       {hasSelection ? (
-        <TableCell className="w-12 min-w-12 py-2">
+        <TableCell className="hidden w-12 min-w-12 py-2 md:table-cell">
           <Skeleton className="mx-auto h-4 w-4 rounded" />
         </TableCell>
       ) : null}
+      <TableCell className="mb-2 flex flex-col gap-3 border-none p-4 md:hidden">
+        <Skeleton className="h-4 w-48 rounded" /> {/* Subtitle */}
+        <div className="flex justify-between">
+          <Skeleton className="h-4 w-20 rounded" /> {/* Left info */}
+          <Skeleton className="h-4 w-16 rounded" /> {/* Button */}
+        </div>
+      </TableCell>
       {Array.from({ length: columns }).map((_, colIndex) => (
-        <TableCell key={colIndex} className="py-2">
+        <TableCell key={colIndex} className="hidden py-2 md:table-cell">
           <Skeleton className="h-4 w-20 rounded" />
         </TableCell>
       ))}
     </TableRow>
   ));
 
-  const mobileSkeletonRows = Array.from({ length: 3 }).map((_, rowIndex) => (
-    <TableRow key={`mobile-${rowIndex}`} className="mb-2 flex flex-col gap-3 p-4 md:hidden">
-      <Skeleton className="h-4 w-48 rounded" /> {/* Subtitle */}
-      <div className="flex justify-between">
-        <Skeleton className="h-4 w-20 rounded" /> {/* Left info */}
-        <Skeleton className="h-4 w-16 rounded" /> {/* Button */}
-      </div>
-    </TableRow>
-  ));
-
   if (renderRowsOnly) {
-    return (
-      <>
-        {desktopSkeletonRows}
-        {mobileSkeletonRows}
-      </>
-    );
+    return skeletonRows;
   }
 
   return (
-    <>
-      <Table className="hidden md:table">
-        <TableBody>{desktopSkeletonRows}</TableBody>
-      </Table>
-
-      <Table className="grid gap-4 md:hidden">
-        <TableBody>{mobileSkeletonRows}</TableBody>
-      </Table>
-    </>
+    <Table>
+      <TableBody>{skeletonRows}</TableBody>
+    </Table>
   );
 }


### PR DESCRIPTION
Ref:
- #1136
- https://github.com/antiwork/flexile/pull/1148#discussion_r2372686230
- #1132


Skeleton loader from #1136 causes `page.locator("tbody")` to incur strict mode violation breaking the below mentioned specs.

<table>
  <thead>
    <tr>
      <th width="5%">#</th>
      <th width="25%">Affected Specs</th>
      <th width="70%">Screenshot</th>
    </tr>
  </thead>
  <tbody>
    <tr>
      <td>1</td>
      <td>tests/company/invoices/one-off-payments.spec.ts:362 › One-off payments › invoice list visibility › shows 'Pay again' button for failed payments</td>
      <td><img width="988" height="593" alt="1" src="https://github.com/user-attachments/assets/dfabcac5-2dc7-4977-b9a1-57b9ceef22a1" /></td>
    </tr>
    <tr>
      <td>2</td>
      <td>tests/company/invoices/create.spec.ts:147 › invoice creation › allows adding multiple expense rows</td>
      <td><img width="988" height="593" alt="2" src="https://github.com/user-attachments/assets/86c264fe-060e-47a8-89fd-0cee6e87bcce" /></td>
    </tr>
    <tr>
      <td>3</td>
      <td>tests/company/invoices/rejection-flow.spec.ts:35 › invoice rejection flow › handles invoice rejection workflow including contractor editing</td>
      <td><img width="988" height="593" alt="3" src="https://github.com/user-attachments/assets/67378b1e-17fe-4099-9b1b-a2b0dc418a54" /></td>
    </tr>
  </tbody>
</table>

### PR Changes

Cleaned up `TableSkeleton` by using,

1. One responsive `Table` component instead of two. This ensures `page.locator("tbody")`  to always point to a single element
2. Each `TableRow` contains both mobile and desktop layouts using responsive classes
3. Mobile view now shows the same number of rows as desktop (controlled by rows prop) instead of fixed 3 rows

### Before

https://github.com/user-attachments/assets/09ee7f14-7546-47bf-ab27-6bc38ab0b0bd

### After

https://github.com/user-attachments/assets/3fc5b4d6-428d-49c9-ace7-308e652e08f2

### AI Usage
None
