### PR TITLE
Fix modal interactions in onboarding checklist test

### DIFF
--- a/e2e/tests/company/onboarding/checklist.spec.ts
+++ b/e2e/tests/company/onboarding/checklist.spec.ts
@@ -57,6 +57,8 @@ test.describe("Onboarding checklist", () => {
     await expect(page.getByRole("heading", { name: "People" })).toBeVisible();
     await page.getByRole("button", { name: "Add contractor" }).click();
 
+    await expect(page.getByRole("dialog").first()).toBeVisible();
+
     await withinModal(
       async (modal) => {
         await expect(modal.getByText("Who's joining?")).toBeVisible();
@@ -64,11 +66,17 @@ test.describe("Onboarding checklist", () => {
         await modal.getByLabel("Role").fill("Software Engineer");
         await modal.getByLabel("Hourly").check();
         await modal.getByLabel("Rate").fill("100");
-        await page.getByRole("button", { name: "Continue" }).click();
-        await modal.getByLabel("Already signed contract elsewhere").check({ force: true });
+        await modal.getByRole("button", { name: "Continue" }).click();
+        const signedElsewhereLabel = modal.getByText("Already signed contract elsewhere");
+        await expect(signedElsewhereLabel).toBeVisible();
+        await signedElsewhereLabel.click();
+        await expect(modal.getByRole("switch", { name: "Already signed contract elsewhere" })).toHaveAttribute(
+          "aria-checked",
+          "true",
+        );
         await modal.getByRole("button", { name: "Send invite" }).click();
       },
-      { page, title: "Who's joining?" },
+      { page },
     );
 
     const checkProgress = async () => {


### PR DESCRIPTION
Improvements made to potentially replace PR https://github.com/antiwork/flexile/pull/1268

Refer to above PR for images

This is to avoid creating test specific modals.

### Problem
The onboarding checklist e2e test was failing with multiple timeout errors:

1. **Modal detection issue**: `getByRole('dialog', { name: 'Who\'s joining?' })` couldn't find the modal because it doesn't expose that text as its accessible name
2. **Switch interaction failure**: The "Already signed contract elsewhere" switch had `pointer-events: none` and couldn't be clicked directly
3. **Element scoping issues**: Using `page.getByRole()` instead of `modal.getByRole()` was targeting wrong elements

### Fix
Updated the checklist test to handle modal interactions more robustly without adding specialized utility functions:

- **Added pre-modal wait** with extended timeout: `await expect(page.getByRole("dialog").first()).toBeVisible()`
- **Removed problematic title parameter** from `withinModal` since the modal doesn't expose the expected accessible name  
- **Fixed switch interaction** by clicking the visible label text instead of the switch control
- **Improved button scoping** by using `modal.getByRole()` instead of `page.getByRole()`
- **Added state verification** to ensure the switch actually toggles to `aria-checked="true"`

### Test Passing

<img width="1862" height="703" alt="image" src="https://github.com/user-attachments/assets/af86a1b2-fa95-45e5-88c7-966f8866d90b" />

fixes https://github.com/antiwork/flexile/issues/1132

AI Disclosure:
AI tools used to understand existing functionality
