### PR TITLE
replace CSS-only breakpoints with `isMobile` in `TableSkeleton`

### DIFF
--- a/frontend/components/TableSkeleton.tsx
+++ b/frontend/components/TableSkeleton.tsx
@@ -1,5 +1,6 @@
 import { Skeleton } from "@/components/ui/skeleton";
 import { Table, TableBody, TableCell, TableRow } from "@/components/ui/table";
+import { useIsMobile } from "@/utils/use-mobile";
 
 interface TableSkeletonProps {
   columns?: number;
@@ -14,8 +15,9 @@ export default function TableSkeleton({
   rows = 5,
   renderRowsOnly = false,
 }: TableSkeletonProps) {
+  const isMobile = useIsMobile();
   const desktopSkeletonRows = Array.from({ length: rows }).map((_, rowIndex) => (
-    <TableRow key={`desktop-${rowIndex}`} className="hidden md:table-row">
+    <TableRow key={`desktop-${rowIndex}`}>
       {hasSelection ? (
         <TableCell className="w-12 min-w-12 py-2">
           <Skeleton className="mx-auto h-4 w-4 rounded" />
@@ -30,7 +32,7 @@ export default function TableSkeleton({
   ));
 
   const mobileSkeletonRows = Array.from({ length: 3 }).map((_, rowIndex) => (
-    <TableRow key={`mobile-${rowIndex}`} className="mb-2 flex flex-col gap-3 p-4 md:hidden">
+    <TableRow key={`mobile-${rowIndex}`} className="mb-2 flex flex-col gap-3 p-4">
       <Skeleton className="h-4 w-48 rounded" /> {/* Subtitle */}
       <div className="flex justify-between">
         <Skeleton className="h-4 w-20 rounded" /> {/* Left info */}
@@ -40,23 +42,12 @@ export default function TableSkeleton({
   ));
 
   if (renderRowsOnly) {
-    return (
-      <>
-        {desktopSkeletonRows}
-        {mobileSkeletonRows}
-      </>
-    );
+    return isMobile ? mobileSkeletonRows : desktopSkeletonRows;
   }
 
   return (
-    <>
-      <Table className="hidden md:table">
-        <TableBody>{desktopSkeletonRows}</TableBody>
-      </Table>
-
-      <Table className="grid gap-4 md:hidden">
-        <TableBody>{mobileSkeletonRows}</TableBody>
-      </Table>
-    </>
+    <Table className={isMobile ? "grid gap-4" : "table"}>
+      <TableBody>{isMobile ? mobileSkeletonRows : desktopSkeletonRows}</TableBody>
+    </Table>
   );
 }


### PR DESCRIPTION
ref: #1132 
<img width="2940" height="1912" alt="image" src="https://github.com/user-attachments/assets/6a937728-2a4e-4c4a-a600-8216897a1af9" />




* Uses the `useIsMobile` hook to render only the layout that’s actually needed, instead of keeping both mobile and desktop skeletons rendered at once.

* Avoids rendering hidden `<tbody>` elements altogether (the root cause of the Playwright strict mode error in `e2e/tests/company/invoices/one-off-payments.spec.ts`).

* Keeps the component logic cleaner and easier to understand.
* Makes the component easier to maintain in the long term.
* Reduces flakiness in tests going forward.


> [!NOTE]
> AI assistance was used in preparing this PR:
> - **Cursor Pro (GPT-5)**: for code scaffolding and refactoring suggestions  
> - **Claude Sonnet 4**: for explanation drafts and wording improvements