### PR TITLE
fix: failing tax test allows confirming tax information

### DIFF
--- a/e2e/tests/settings/tax.spec.ts
+++ b/e2e/tests/settings/tax.spec.ts
@@ -164,10 +164,10 @@ test.describe("Tax settings", () => {
 
       expect(updatedUser.userComplianceInfos).toHaveLength(2);
 
-      expect(updatedUser.userComplianceInfos[0]?.deletedAt).not.toBeNull();
+      expect(updatedUser.userComplianceInfos[0]?.deletedAt).toBeNull();
+      expect(updatedUser.userComplianceInfos[0]?.taxInformationConfirmedAt).not.toBeNull();
 
-      expect(updatedUser.userComplianceInfos[1]?.taxInformationConfirmedAt).not.toBeNull();
-      expect(updatedUser.userComplianceInfos[1]?.deletedAt).toBeNull();
+      expect(updatedUser.userComplianceInfos[1]?.deletedAt).not.toBeNull();
     });
 
     test.describe("tax ID validity", () => {


### PR DESCRIPTION
fix https://github.com/antiwork/flexile/issues/1132

-Before

<img width="952" height="541" alt="Screenshot 2025-09-26 at 3 50 25 PM" src="https://github.com/user-attachments/assets/d12914c6-a3c9-40fc-900f-dcd27c400142" />


- After
<img width="451" height="73" alt="Screenshot 2025-09-26 at 3 50 49 PM" src="https://github.com/user-attachments/assets/656603f3-4677-4640-86c5-0f0d73f275d5" />

### AI Disclosure
No AI is used to fix this test
