### PR TITLE
fix(ui) : better readability at `marketing page`

### DIFF
--- a/frontend/app/(marketing)/page.tsx
+++ b/frontend/app/(marketing)/page.tsx
@@ -109,7 +109,7 @@ export default async function HomePage() {
           </div>
         </Section>
 
-        <Section className="flex bg-gray-50 py-8 md:py-16">
+        <Section className="flex bg-gray-50 py-8 text-black md:py-16">
           <div className="mx-auto flex w-full max-w-5xl flex-col gap-8 px-4 md:gap-12">
             <h2 className="text-4xl font-medium md:text-6xl">Clear, straight forward pricing</h2>
             <div className="text-2xl md:text-3xl">1.5% + $0.50, capped at $15/payment</div>


### PR DESCRIPTION
ref #911 

## Summary

- Better readable section at `marketing page` 

### Before : 

<img width="1884" height="1003" alt="Screenshot 2025-09-26 at 4 53 45 PM" src="https://github.com/user-attachments/assets/51a805d5-c9ec-443e-8390-b4d85b947ddc" />



### After :

<img width="1917" height="999" alt="Screenshot 2025-09-26 at 5 01 58 PM" src="https://github.com/user-attachments/assets/059a4435-2b04-4647-828e-ff4d73d9053d" />


### Before : 

<img width="369" height="853" alt="Screenshot 2025-09-26 at 5 04 30 PM" src="https://github.com/user-attachments/assets/419d30c6-b510-4b81-b136-957350c8dbd7" />


### After :

<img width="374" height="850" alt="Screenshot 2025-09-26 at 5 04 38 PM" src="https://github.com/user-attachments/assets/ce22a779-d527-44e5-a6b0-6f328a6c77e5" />


## AI Usage
No AI was used to generate any of this code.

## Self-Review
I have self-reviewed all the code that I have written.
