### PR TITLE
feat: add dark mode for public pages

### DIFF
--- a/frontend/app/(public)/layout.tsx
+++ b/frontend/app/(public)/layout.tsx
@@ -5,12 +5,12 @@ import logo from "@/images/flexile-logo.svg";
 export default function PublicLayout({ children }: { children: React.ReactNode }) {
   return (
     <div className="flex h-full flex-col print:block">
-      <header className="flex w-full items-center justify-center bg-black p-6 text-white print:hidden">
-        <a href="https://flexile.com/" className="invert" rel="noopener noreferrer">
+      <header className="bg-secondary border-sidebar-border flex w-full items-center justify-center border-b p-6 print:hidden">
+        <a href="https://flexile.com/" className="dark:invert" rel="noopener noreferrer">
           <Image src={logo} alt="Flexile" />
         </a>
       </header>
-      <main className="bg-background flex flex-1 flex-col items-center overflow-y-auto px-3 py-3 print:overflow-visible">
+      <main className="bg-secondary flex flex-1 flex-col items-center overflow-y-auto px-3 py-3 print:overflow-visible">
         <div className="my-auto grid gap-4 pt-7">{children}</div>
       </main>
     </div>

--- a/frontend/app/(public)/layout.tsx
+++ b/frontend/app/(public)/layout.tsx
@@ -10,7 +10,7 @@ export default function PublicLayout({ children }: { children: React.ReactNode }
           <Image src={logo} alt="Flexile" />
         </a>
       </header>
-      <main className="flex flex-1 flex-col items-center overflow-y-auto px-3 py-3 print:overflow-visible">
+      <main className="bg-background flex flex-1 flex-col items-center overflow-y-auto px-3 py-3 print:overflow-visible">
         <div className="my-auto grid gap-4 pt-7">{children}</div>
       </main>
     </div>

--- a/frontend/app/(public)/privacy/page.tsx
+++ b/frontend/app/(public)/privacy/page.tsx
@@ -27,7 +27,7 @@ export default function Privacy() {
       </p>
       <div role="navigation" className={cn("grid gap-1", "not-prose")}>
         {sections.map((section, index) => (
-          <a key={index} href={`#jump_${index + 1}`} className="flex items-center text-gray-500 no-underline">
+          <a key={index} href={`#jump_${index + 1}`} className="text-muted-foreground flex items-center no-underline">
             <Badge variant="outline" className="mr-1 shrink-0">
               {index + 1}
             </Badge>

--- a/frontend/app/(public)/privacy/page.tsx
+++ b/frontend/app/(public)/privacy/page.tsx
@@ -27,7 +27,11 @@ export default function Privacy() {
       </p>
       <div role="navigation" className={cn("grid gap-1", "not-prose")}>
         {sections.map((section, index) => (
-          <a key={index} href={`#jump_${index + 1}`} className="text-muted-foreground flex items-center no-underline">
+          <a
+            key={index}
+            href={`#jump_${index + 1}`}
+            className="text-foreground hover:text-link flex items-center no-underline"
+          >
             <Badge variant="outline" className="mr-1 shrink-0">
               {index + 1}
             </Badge>

--- a/frontend/app/(public)/terms/page.tsx
+++ b/frontend/app/(public)/terms/page.tsx
@@ -41,7 +41,7 @@ export default function Terms() {
       </p>
       <div role="navigation" className={cn("grid gap-1", "not-prose")}>
         {sections.map((section, index) => (
-          <a key={index} href={`#jump_${index + 1}`} className="flex items-center text-gray-500 no-underline">
+          <a key={index} href={`#jump_${index + 1}`} className="text-muted-foreground flex items-center no-underline">
             <Badge variant="outline" className="mr-1 shrink-0">
               {index + 1}
             </Badge>

--- a/frontend/app/(public)/terms/page.tsx
+++ b/frontend/app/(public)/terms/page.tsx
@@ -41,7 +41,11 @@ export default function Terms() {
       </p>
       <div role="navigation" className={cn("grid gap-1", "not-prose")}>
         {sections.map((section, index) => (
-          <a key={index} href={`#jump_${index + 1}`} className="text-muted-foreground flex items-center no-underline">
+          <a
+            key={index}
+            href={`#jump_${index + 1}`}
+            className="text-foreground hover:text-link flex items-center no-underline"
+          >
             <Badge variant="outline" className="mr-1 shrink-0">
               {index + 1}
             </Badge>

--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -166,6 +166,14 @@
   --color-selected-bg: var(--selected-bg);
 }
 
+.prose {
+  --tw-prose-body: inherit;
+  --tw-prose-headings: inherit;
+  --tw-prose-links: inherit;
+  --tw-prose-bold: inherit;
+  --tw-prose-counters: inherit;
+}
+
 body {
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;


### PR DESCRIPTION
### Description:

Add dark mode for public pages:
- Privacy policy
- Terms 

Part of #911 
Linked to #984 

### Before / After:

- Privacy policy:

 <table>
 <tr><th>Before</th><th>After</th></tr>
 <tr>
 <td> 
<img width="1438" height="811" alt="Screenshot 2025-09-26 at 6 13 22 PM" src="https://github.com/user-attachments/assets/d349e85c-2d96-4d36-9ddc-323a376e11ef" />
</td>
  <td> 
<img width="1438" height="810" alt="Screenshot 2025-09-26 at 6 12 49 PM" src="https://github.com/user-attachments/assets/4a92a431-2df0-4944-acf7-e0232e375ace" />
 </td>
 </tr>
 <tr>
 <td> 
<img width="1437" height="809" alt="Screenshot 2025-09-26 at 6 28 50 PM" src="https://github.com/user-attachments/assets/65962200-2f7a-416f-a5e9-6c1f37bbf2e1" />
</td>
  <td> 
<img width="1440" height="811" alt="Screenshot 2025-09-26 at 6 14 06 PM" src="https://github.com/user-attachments/assets/0f73427f-a0d1-471c-bf09-d03d561b7465" />
 </td>
 </tr>
 </table>
 
- Terms:

 <table>
 <tr><th>Before</th><th>After</th></tr>
 <tr>
 <td> 
<img width="1438" height="802" alt="Screenshot 2025-09-26 at 6 13 08 PM" src="https://github.com/user-attachments/assets/10fa8865-0792-4236-b3b0-fddf68bac55b" />
</td>
  <td> 
<img width="1437" height="810" alt="Screenshot 2025-09-26 at 6 12 33 PM" src="https://github.com/user-attachments/assets/6b492b2b-32ee-477a-b037-f86bce9eaab5" />
 </td>
 </tr>
 <tr>
 <td> 
<img width="1440" height="806" alt="Screenshot 2025-09-26 at 6 29 02 PM" src="https://github.com/user-attachments/assets/a04e9b27-b9b3-48f0-bfbb-03b5a67e62bb" />
</td>
  <td> 
<img width="1439" height="810" alt="Screenshot 2025-09-26 at 6 14 18 PM" src="https://github.com/user-attachments/assets/8a69fe55-07c1-4512-8969-0ab47cf3b865" />
 </td>
 </tr>
 </table>

> [!Note]
> AI Disclosure: No AI was used to generate any of this code.

