### PR TITLE
fix: rich text editor

### DIFF
--- a/frontend/components/RichText.tsx
+++ b/frontend/components/RichText.tsx
@@ -57,7 +57,7 @@ export const Editor = ({
         ...(ariaLabel ? { "aria-label": ariaLabel } : {}),
         class: cn(
           className,
-          "prose text-foreground dark:prose-invert border-muted my-2 max-h-100 overflow-y-auto rounded-md border px-8 py-4 p-4 min-h-60 max-h-96 overflow-y-auto max-w-full rounded-b-md outline-none",
+          "prose text-foreground dark:prose-invert max-h-100 overflow-y-auto rounded-md px-8 py-4 p-4 min-h-60 max-h-96 overflow-y-auto max-w-full outline-none",
         ),
       },
     },


### PR DESCRIPTION
Ref:- https://github.com/antiwork/flexile/issues/911
reopen : #1195 


## Description 

Fix the Rich text editor 

### Before
<img width="1038" height="769" alt="Screenshot from 2025-09-26 20-10-09" src="https://github.com/user-attachments/assets/67eff86e-1090-4f63-9f94-499a108fd820" />

### After


[Screencast from 2025-09-26 20-11-23.webm](https://github.com/user-attachments/assets/29b193ab-e7e4-4de7-b6b3-a88f788737e6)


#### AI Disclosure:-
I have not used any AI assistance in this PR