### PR TITLE
fix: restrict the EIN number length

### DIFF
--- a/frontend/app/settings/administrator/details/page.tsx
+++ b/frontend/app/settings/administrator/details/page.tsx
@@ -107,6 +107,7 @@ export default function Details() {
                     {...field}
                     placeholder="XX-XXXXXXX"
                     onChange={(e) => field.onChange(formatTaxId(e.target.value))}
+                    maxLength={10}
                   />
                 </FormControl>
                 <FormMessage />


### PR DESCRIPTION
REF //  https://github.com/antiwork/flexile/issues/911

## Description 

Users were able to type more than 9 digits in the EIN field. Although validation prevented invalid EINs from being saved, this created a poor user experience.
- Added input length restriction.

### Before
<img width="1013" height="729" alt="image" src="https://github.com/user-attachments/assets/a46ef447-73d3-423c-b7cb-a113bde1efc8" />


### After

Not able to type more
<img width="1013" height="729" alt="image" src="https://github.com/user-attachments/assets/0d0b2d83-be1f-4a28-beac-8e24aaf1e5d3" />


#### AI Disclosure:-
I have not used any AI assistance in this PR