### PR TITLE
Improve dark mode of Cap table page on smaller screens

### DIFF
--- a/frontend/app/(dashboard)/equity/investors/add/page.tsx
+++ b/frontend/app/(dashboard)/equity/investors/add/page.tsx
@@ -226,10 +226,10 @@ const MobileInvestorCard = ({
             {formFields.SharesField}
           </div>
 
-          <div className="border-muted border-t pt-2">
-            <div className="flex justify-between text-sm">
-              <span className="text-muted-foreground">Ownership:</span>
-              <span className="font-medium">{percentage.toFixed(1)}%</span>
+          <div className="pt-2">
+            <div className="flex justify-between text-sm font-medium">
+              <span>Ownership:</span>
+              <span>{percentage.toFixed(1)}%</span>
             </div>
           </div>
         </div>
@@ -478,11 +478,9 @@ const AddCapTablePage = () => {
                 Add new investor
               </Button>
 
-              <div className="flex items-center justify-between px-4">
-                <span className="text-sm font-semibold">Total</span>
-                <div className="font-semibold">
-                  {calculateTotalShares(form.watch("investors")).toLocaleString()} shares
-                </div>
+              <div className="flex items-center justify-between px-4 text-sm font-semibold">
+                <span>Total</span>
+                <div>{calculateTotalShares(form.watch("investors")).toLocaleString()} shares</div>
               </div>
             </div>
           ) : (

--- a/frontend/app/(dashboard)/equity/investors/add/page.tsx
+++ b/frontend/app/(dashboard)/equity/investors/add/page.tsx
@@ -478,7 +478,7 @@ const AddCapTablePage = () => {
                 Add new investor
               </Button>
 
-              <Card className="bg-gray-50">
+              <Card className="bg-secondary">
                 <CardContent className="p-4">
                   <div className="flex items-center justify-between">
                     <span className="text-sm font-semibold">Total</span>

--- a/frontend/app/(dashboard)/equity/investors/add/page.tsx
+++ b/frontend/app/(dashboard)/equity/investors/add/page.tsx
@@ -226,7 +226,7 @@ const MobileInvestorCard = ({
             {formFields.SharesField}
           </div>
 
-          <div className="border-t border-gray-100 pt-2">
+          <div className="border-muted border-t pt-2">
             <div className="flex justify-between text-sm">
               <span className="text-muted-foreground">Ownership:</span>
               <span className="font-medium">{percentage.toFixed(1)}%</span>

--- a/frontend/app/(dashboard)/equity/investors/add/page.tsx
+++ b/frontend/app/(dashboard)/equity/investors/add/page.tsx
@@ -226,11 +226,9 @@ const MobileInvestorCard = ({
             {formFields.SharesField}
           </div>
 
-          <div className="pt-2">
-            <div className="flex justify-between text-sm font-medium">
-              <span>Ownership:</span>
-              <span>{percentage.toFixed(1)}%</span>
-            </div>
+          <div className="flex justify-between pt-2 text-sm font-medium">
+            <span>Ownership:</span>
+            <span>{percentage.toFixed(1)}%</span>
           </div>
         </div>
       </CardContent>

--- a/frontend/app/(dashboard)/equity/investors/add/page.tsx
+++ b/frontend/app/(dashboard)/equity/investors/add/page.tsx
@@ -478,16 +478,12 @@ const AddCapTablePage = () => {
                 Add new investor
               </Button>
 
-              <Card className="bg-secondary">
-                <CardContent className="p-4">
-                  <div className="flex items-center justify-between">
-                    <span className="text-sm font-semibold">Total</span>
-                    <div className="font-semibold">
-                      {calculateTotalShares(form.watch("investors")).toLocaleString()} shares
-                    </div>
-                  </div>
-                </CardContent>
-              </Card>
+              <div className="flex items-center justify-between px-4">
+                <span className="text-sm font-semibold">Total</span>
+                <div className="font-semibold">
+                  {calculateTotalShares(form.watch("investors")).toLocaleString()} shares
+                </div>
+              </div>
             </div>
           ) : (
             <DataTable table={table} />


### PR DESCRIPTION
Part of #911 

| Before | After| 
|-----------|---------|
|<img width="402" height="833" alt="image" src="https://github.com/user-attachments/assets/007388d3-c521-4c1c-8100-5b567a061cf3" /> | <img width="402" height="833" alt="image" src="https://github.com/user-attachments/assets/a7c0c2b0-41e8-47e1-af8c-69b75b40c2e3" />

## AI Disclosure
No usage of AI