### PR TITLE
Remove extra close icon on investors page dialog

### DIFF
--- a/frontend/app/(dashboard)/equity/investors/page.tsx
+++ b/frontend/app/(dashboard)/equity/investors/page.tsx
@@ -363,7 +363,10 @@ const InvestorBulkActionsBar = ({
   onClose: () => void;
 }) => (
   <Dialog open={selectedCount > 0} modal={false}>
-    <DialogContent className="border-border fixed right-auto bottom-16 left-1/2 w-auto -translate-x-1/2 transform rounded-xl border p-0">
+    <DialogContent
+      className="border-border fixed right-auto bottom-16 left-1/2 w-auto -translate-x-1/2 transform rounded-xl border p-0"
+      showCloseButton={false}
+    >
       <DialogHeader className="sr-only">
         <DialogTitle>Selected investors</DialogTitle>
       </DialogHeader>


### PR DESCRIPTION
Part of #911 

| Before | After| 
|-----------|---------|
| <img width="396" height="824" alt="Screenshot From 2025-09-28 20-41-12" src="https://github.com/user-attachments/assets/4038c7df-8123-42e6-8ebe-cf3689a36d4d" /> |  <img width="396" height="824" alt="Screenshot From 2025-09-28 20-41-27" src="https://github.com/user-attachments/assets/af8e0af9-739a-49c8-a8e0-cddcde179362" />

## AI Disclosure
No usage of AI
