### PR TITLE
Fix duplicate dividend emails by excluding pending signup status

### DIFF
--- a/backend/app/models/dividend_round.rb
+++ b/backend/app/models/dividend_round.rb
@@ -18,7 +18,7 @@ class DividendRound < ApplicationRecord
 
   def send_dividend_emails
     company.company_investors.joins(:dividends)
-      .where(dividends: { dividend_round_id: id })
+      .where(dividends: { dividend_round_id: id, status: Dividend::ISSUED })
       .group(:id)
       .each do |investor|
         investor_dividend_round = investor.investor_dividend_rounds.find_or_create_by!(dividend_round_id: id)


### PR DESCRIPTION
Part of #1132 

AI Disclosure: Used for only for syntax, logic and code review Manually

### Problem
The DividendRound#send_dividend_emails method was sending duplicate emails to investors. The issue occurred because the method was sending emails to all investors regardless of their dividend status, including those with "Pending signup" status who should not receive emails.

### Flakey/Before:https://github.com/antiwork/flexile/actions/runs/18100685894/job/51502574963

###  Root Cause
The original query in send_dividend_emails was:
.where(dividends: { dividend_round_id: id })

<img width="901" height="596" alt="Screenshot 2025-09-29 at 10 10 34 PM" src="https://github.com/user-attachments/assets/aebe8d7b-39d3-43fa-8b9a-3a272d5bdd05" />

###  It was falling Locally Also


### Solution
Added a status filter to only send emails to investors with "Issued" dividends:
.where(dividends: { dividend_round_id: id, status: Dividend::ISSUED })

After:
<img width="847" height="497" alt="Screenshot 2025-09-29 at 10 11 46 PM" src="https://github.com/user-attachments/assets/0ca219cf-0ae6-4c64-976c-34698b0df268" />

### I have added test to verify it 

<img width="813" height="320" alt="Screenshot 2025-09-29 at 10 13 41 PM" src="https://github.com/user-attachments/assets/f235f8a9-7a90-4c17-8106-a7f9bd36e2a0" />

Files Change:
backend/app/models/dividend_round.rb
backend/spec/models/dividend_round_spec.rb

Fixes: #1132 