### PR TITLE
fix failing billing spec on OSS PRs

### DIFF
--- a/e2e/tests/settings/administrator/billing.spec.ts
+++ b/e2e/tests/settings/administrator/billing.spec.ts
@@ -5,7 +5,7 @@ import { expect, test } from "@test/index";
 test.describe("Company billing settings", () => {
   test("billing settings gated until company name is set", async ({ page }) => {
     const { adminUser } = await companiesFactory.createCompletedOnboarding(
-      { name: null },
+      { name: null, stripeCustomerId: null },
       { withoutBankAccount: true },
     );
 

--- a/e2e/tests/settings/administrator/billing.spec.ts
+++ b/e2e/tests/settings/administrator/billing.spec.ts
@@ -2,6 +2,8 @@ import { companiesFactory } from "@test/factories/companies";
 import { login } from "@test/helpers/auth";
 import { expect, test } from "@test/index";
 
+// allow green builds on OSS PRs that don't have a stripe sandbox key, but fail on CI if something changes on Stripe's end
+test.skip(() => process.env.STRIPE_SECRET_KEY === "dummy");
 test.describe("Company billing settings", () => {
   test("billing settings gated until company name is set", async ({ page }) => {
     const { adminUser } = await companiesFactory.createCompletedOnboarding(

--- a/e2e/tests/settings/administrator/billing.spec.ts
+++ b/e2e/tests/settings/administrator/billing.spec.ts
@@ -7,7 +7,7 @@ test.skip(() => process.env.STRIPE_SECRET_KEY === "dummy");
 test.describe("Company billing settings", () => {
   test("billing settings gated until company name is set", async ({ page }) => {
     const { adminUser } = await companiesFactory.createCompletedOnboarding(
-      { name: null, stripeCustomerId: null },
+      { name: null },
       { withoutBankAccount: true },
     );
 


### PR DESCRIPTION
Part of #1132 

AI Disclosure:
No AI used

Description:
This test fails on OSS Pr's as the stripe keys are unavailable. 
As per the previous PR : https://github.com/antiwork/flexile/pull/979/files#diff-f51196fbad01f77fc26dd265f1ee7d5c7ab08f4e47d0ca8c81bdcf009aebe715L9

This change allows green builds on OSS PR's but ensures tests still run on the CI with stripe key available.

https://github.com/antiwork/flexile/actions/runs/18105980050/job/51520503092
https://github.com/antiwork/flexile/actions/runs/18065004788/job/51406562507
https://github.com/antiwork/flexile/actions/runs/18064705359/job/51405926228
https://github.com/antiwork/flexile/actions/runs/18060870491/job/51396947053
https://github.com/antiwork/flexile/actions/runs/18042214492/job/51343892676


E2E
<img width="500" height="400" alt="image" src="https://github.com/user-attachments/assets/69182e9c-da7f-46b7-8712-9a79bbb3c021" />
