### PR TITLE
refactor: improve equity section

### DIFF
--- a/frontend/app/settings/payouts/page.tsx
+++ b/frontend/app/settings/payouts/page.tsx
@@ -74,7 +74,10 @@ const EquitySection = () => {
         assertOk: true,
       });
     },
-    onSuccess: () => setTimeout(() => saveMutation.reset(), 2000),
+    onSuccess: () => {
+      form.reset(form.getValues());
+      setTimeout(() => saveMutation.reset(), 2000);
+    },
   });
 
   const submit = form.handleSubmit((values) => saveMutation.mutate(values));
@@ -134,6 +137,7 @@ const EquitySection = () => {
               type="submit"
               size="small"
               mutation={saveMutation}
+              disabled={!form.formState.isDirty}
               loadingText="Saving..."
               successText="Saved!"
               className="justify-self-end"

--- a/frontend/components/RangeInput.tsx
+++ b/frontend/components/RangeInput.tsx
@@ -99,7 +99,7 @@ const RangeInput = ({
         max={max}
         step={1}
         aria-hidden
-        className="grow"
+        className="grow cursor-pointer"
         disabled={disabled ?? false}
       />
       <div className="relative flex h-8 items-center">


### PR DESCRIPTION
Ref:- https://github.com/antiwork/flexile/issues/911

on /settings/payouts page 

1) The slider should have curosr pointer
2) Save button should be disabled when there is no change

Before:-

https://github.com/user-attachments/assets/2f0052d5-5d6e-4f43-8ce5-19cc32020537

After:-

https://github.com/user-attachments/assets/20321bb3-3c16-40f3-9abe-d827b449c457





AI Disclosure:-
No AI assitance was used in this PR
