### PR TITLE
test: fix equity grant failing test

### DIFF
--- a/e2e/tests/company/equity/grants.spec.ts
+++ b/e2e/tests/company/equity/grants.spec.ts
@@ -68,7 +68,7 @@ test.describe("Equity Grants", () => {
 
     await selectComboboxOption(page, "Shares will vest", "As invoices are paid");
     await page.getByRole("button", { name: "Continue" }).click();
-    await page.getByLabel("Contract").setInputFiles({
+    await page.getByLabel("Contract", { exact: true }).setInputFiles({
       name: "contract.pdf",
       mimeType: "application/pdf",
       buffer: Buffer.from("very signed contract"),


### PR DESCRIPTION
### Description:

The test for equity grant is failing on  `main` :
- e2e/tests/company/equity/grants.spec.ts › Equity Grants › allows issuing equity grants
- https://github.com/antiwork/flexile/actions/runs/18114036910/job/51546199475#step:12:271

**Cause**: getByLabel('Contract') in test resolved to 2 elements - dialog title and input 

Part of #1132 

### Before / After:

#### Before:
<img width="1417" height="610" alt="Screenshot 2025-09-30 at 8 32 05 AM" src="https://github.com/user-attachments/assets/a1b48476-1f4e-4d04-81db-40cbae82a2f0" />


#### After:

<img width="1288" height="187" alt="Screenshot 2025-09-30 at 8 25 22 AM" src="https://github.com/user-attachments/assets/5ec7466e-ef0b-4572-9a74-7c7c8b99bed7" />



> [!Note]
> AI Disclosure: No AI was used to generate any of this code.


