### PR TITLE
fix: Invoice Admin Flow Approving Invoice - Flaky Test

### DIFF
--- a/frontend/components/DataTable.tsx
+++ b/frontend/components/DataTable.tsx
@@ -358,7 +358,7 @@ export default function DataTable<T extends RowData>({
                   <Checkbox
                     checked={table.getIsSomeRowsSelected() ? "indeterminate" : table.getIsAllRowsSelected()}
                     aria-label="Select all"
-                    onCheckedChange={() => table.toggleAllRowsSelected()}
+                    onCheckedChange={(checked) => table.toggleAllRowsSelected(checked === true)}
                   />
                 </TableHead>
               ) : null}


### PR DESCRIPTION
Ref: https://github.com/antiwork/flexile/issues/1132

**Problem**: Multiple e2e tests were failing because the "Select all" checkbox in data tables was not changing its state when clicked. The tests would click the checkbox but it remained unchecked, causing subsequent assertions to fail.

CI fails: 

https://github.com/antiwork/flexile/actions/runs/18117547954/job/51556123850
https://github.com/antiwork/flexile/actions/runs/18109676915/job/51532770491

**Root Cause**: The `onCheckedChange` callback in the DataTable component was calling `table.toggleAllRowsSelected()` without any arguments, ignoring the `checked` parameter passed by the Radix Checkbox component. This caused the checkbox state to not sync properly with the table selection state.

In other places it does - `onClick={() => investorsTable.toggleAllRowsSelected(false)}` or `table.toggleAllRowsSelected(!table.getIsAllRowsSelected())`

**Solution**: Updated the onCheckedChange callback to properly handle the checked parameter and pass it to table.toggleAllRowsSelected(). This ensures the checkbox state correctly reflects the intended selection state.

This fixes tests - 

- `e2e/tests/company/invoices/list.spec.ts:233:7 › Invoices admin flow › approving and paying invoices › with sufficient Flexile account balance › allows approving invoices and paying invoices awaiting final approval immediately `

AI Disclosure:
GitHub copilot used to brainstorm