### PR TITLE
fix(flaky): Invoice create/edit specs

### DIFF
--- a/e2e/tests/company/invoices/complete-flow.spec.ts
+++ b/e2e/tests/company/invoices/complete-flow.spec.ts
@@ -45,12 +45,7 @@ test.describe("Invoice submission, approval and rejection", () => {
     await page.getByPlaceholder("Description").nth(1).fill("second item");
     await page.getByLabel("Hours / Qty").nth(1).fill("10");
     await page.getByPlaceholder("Enter notes about your").fill("A note in the invoice");
-    await Promise.all([
-      page.waitForResponse((r) => r.url().includes("/internal/companies/") && r.status() === 201),
-      // TRPC Clubs into 207 multi-status when repsonses are batched from server
-      page.waitForResponse((r) => r.url().includes("invoices.list") && r.status() >= 200 && r.status() < 300),
-      page.getByRole("button", { name: "Send invoice" }).click(),
-    ]);
+    await page.getByRole("button", { name: "Send invoice" }).click();
 
     await expect(page.getByRole("cell", { name: "CUSTOM-1" })).toBeVisible();
     await expect(page.locator("tbody")).toContainText("Nov 1, 2024");
@@ -73,14 +68,8 @@ test.describe("Invoice submission, approval and rejection", () => {
     await page.getByRole("link", { name: "Edit invoice" }).click();
     await expect(page.getByRole("heading", { name: "Edit invoice" })).toBeVisible();
     await page.getByPlaceholder("Description").first().fill("first item updated");
-    const timeField = page.getByLabel("Hours / Qty").first();
-    await timeField.fill("04:30");
-    await timeField.blur(); // work around a test-specific issue; this works fine in a real browser
-    await Promise.all([
-      page.waitForResponse((r) => r.url().includes("/internal/companies/") && r.status() === 204),
-      page.waitForResponse((r) => r.url().includes("invoices.list") && r.status() >= 200 && r.status() < 300),
-      page.getByRole("button", { name: "Resubmit" }).click(),
-    ]);
+    await page.getByLabel("Hours / Qty").first().fill("04:30");
+    await page.getByRole("button", { name: "Resubmit" }).click();
 
     await expect(page.getByRole("cell", { name: "$870" })).toBeVisible();
     await expect(locateOpenInvoicesBadge(page)).not.toBeVisible();
@@ -196,11 +185,7 @@ test.describe("Invoice submission, approval and rejection", () => {
     await page.getByRole("cell", { name: workerUserB.legalName ?? "never" }).click();
     await page.getByRole("link", { name: "View invoice" }).click();
     await expect(page.getByRole("heading", { name: "Invoice" })).toBeVisible();
-    await Promise.all([
-      page.waitForResponse((r) => r.url().includes("/invoices/approve") && r.status() === 204),
-      page.locator("header").filter({ hasText: "Invoice" }).getByRole("button", { name: "Pay now" }).click(),
-    ]);
-
+    await page.locator("header").filter({ hasText: "Invoice" }).getByRole("button", { name: "Pay now" }).click();
     await expect(openInvoicesBadge).not.toBeVisible();
 
     await logout(page);
@@ -218,16 +203,12 @@ test.describe("Invoice submission, approval and rejection", () => {
     await page.getByLabel("Hours / Qty").fill("02:30");
     await page.getByPlaceholder("Enter notes about your").fill("fixed hours");
     await page.getByRole("button", { name: "Resubmit" }).click();
-    await expect(page.getByRole("heading", { name: "Invoices" })).toBeVisible();
 
     await expect(rejectedInvoiceRow.getByRole("cell", { name: "Rejected" })).not.toBeVisible();
     await expect(rejectedInvoiceRow.getByRole("cell", { name: "Awaiting approval" })).toBeVisible();
 
     await logout(page);
-    await Promise.all([
-      page.waitForResponse((r) => r.url().includes("invoices.list") && r.status() >= 200 && r.status() < 300),
-      login(page, adminUser),
-    ]);
+    await login(page, adminUser);
 
     await expect(locateOpenInvoicesBadge(page)).toContainText("1");
     await expect(page.locator("tbody tr")).toHaveCount(1);

--- a/e2e/tests/company/invoices/create.spec.ts
+++ b/e2e/tests/company/invoices/create.spec.ts
@@ -62,8 +62,6 @@ test.describe("invoice creation", () => {
 
     await login(page, contractorUser, "/invoices/new");
 
-    await page.getByPlaceholder("Description").fill("I worked on invoices");
-    await page.getByLabel("Hours").fill("03:25");
     await expect(page.getByText("Total services$60")).toBeVisible();
     await expect(page.getByText("Swapped for equity (not paid in cash)$0")).toBeVisible();
     await expect(page.getByText("Net amount in cash$60")).toBeVisible();

--- a/frontend/app/(dashboard)/invoices/QuantityInput.tsx
+++ b/frontend/app/(dashboard)/invoices/QuantityInput.tsx
@@ -13,28 +13,32 @@ const QuantityInput = ({
   onChange: (value: Value) => void;
 } & Omit<React.ComponentProps<"input">, "value" | "onChange">) => {
   const [rawValue, setRawValue] = useState("");
-  useEffect(
-    () => setRawValue(value ? (value.hourly ? formatDuration(value.quantity) : value.quantity.toString()) : ""),
-    [value],
-  );
+
+  const parseRawValue = (raw: string): Value => {
+    if (!raw.length) return null;
+    const valueSplit = raw.split(":");
+    if (valueSplit.length === 1) return { quantity: parseFloat(valueSplit[0] ?? "0"), hourly: false };
+    const hours = parseInt(valueSplit[0] ?? "0", 10);
+    const minutes = parseInt(valueSplit[1] ?? "0", 10);
+    return {
+      quantity: Math.floor(isNaN(hours) ? 0 : hours * 60) + (isNaN(minutes) ? 0 : minutes),
+      hourly: true,
+    };
+  };
+
+  useEffect(() => {
+    const parsedValue = parseRawValue(rawValue);
+    if (!(parsedValue?.quantity === value?.quantity && parsedValue?.hourly === value?.hourly))
+      setRawValue(value ? (value.hourly ? formatDuration(value.quantity) : value.quantity.toString()) : "");
+  }, [value, rawValue, parseRawValue]);
 
   return (
     <Input
       {...props}
       value={rawValue}
-      onChange={(e) => setRawValue(e.target.value)}
-      onBlur={() => {
-        if (!rawValue.length) return onChange(null);
-
-        const valueSplit = rawValue.split(":");
-        if (valueSplit.length === 1) return onChange({ quantity: parseFloat(valueSplit[0] ?? "0"), hourly: false });
-
-        const hours = parseFloat(valueSplit[0] ?? "0");
-        const minutes = parseFloat(valueSplit[1] ?? "0");
-        onChange({
-          quantity: Math.floor(isNaN(hours) ? 0 : hours * 60) + (isNaN(minutes) ? 0 : minutes),
-          hourly: true,
-        });
+      onChange={(e) => {
+        setRawValue(e.target.value);
+        onChange(parseRawValue(e.target.value));
       }}
     />
   );

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -13,10 +13,10 @@ export default defineConfig({
   forbidOnly: !!process.env.CI,
   retries: process.env.CI ? 1 : 0,
   workers: process.env.CI ? "100%" : undefined,
-  reporter: process.env.CI ? [["list"], ["html"]] : "list",
+  reporter: [["list"], ["html", { open: process.env.CI ? "never" : "on-failure" }]],
   use: {
     baseURL: "http://localhost:3100",
-    trace: "on-first-retry",
+    trace: "retain-on-failure",
     video: "retain-on-failure",
     screenshot: "only-on-failure",
     locale: "en-US",


### PR DESCRIPTION
### Ref 
- #1132

### What's Happening?
1. `Edit` spec

### What's Changed?
1. Re-factored `QuantityInput` to sync it's state with parent on every keystroke
2. For invoice `create/edit` flow, pass form item state snapshot to submit mutation to account for timing issues with stale values in test environment
3. Test Configuration
    - Improve debugging for tests by enabling trace retention for every failure and HTML reporting for local runs
4. Test Stability Improvements
    - Removed few `waitForResponse` debug assertions which were introduced in #1013

### Before

https://github.com/user-attachments/assets/f8b4a91c-70b6-4134-a1d2-e6de5a39a567

### After

https://github.com/user-attachments/assets/5362026e-3b19-46e4-b196-582f97610a87


### Flaky tests addresssed from [main run](https://github.com/antiwork/flexile/actions/runs/17673257066/job/50229870622) of #1142 
1. `e2e/tests/company/invoices/create.spec.ts:51:3 › invoice creation › considers the invoice year when calculating equity`
2. `e2e/tests/company/invoices/complete-flow.spec.ts:36:3 › Invoice submission, approval and rejection › allows contractor to submit/delete invoices and admin to approve/reject them `

<img width="1085" height="476" alt="main 2 flaky" src="https://github.com/user-attachments/assets/41e020eb-d15d-47a3-8666-5af1ca467504" />

3. `e2e/tests/company/invoices/edit.spec.ts:28:3 › invoice editing › preserves form fields when editing an invoice`

<img width="1085" height="533" alt="main 1 flaky" src="https://github.com/user-attachments/assets/03bba672-f7be-4108-9685-2b4f6547f427" />


4. `e2e/tests/company/invoices/rejection-flow.spec.ts:35:3 › invoice rejection flow › handles invoice rejection workflow including contractor editing`

|[Old run on main](https://github.com/antiwork/flexile/actions/runs/17165183654/job/48703852869)|[#1150's run](https://github.com/antiwork/flexile/actions/runs/17691144495/job/50284780378)|
|-------|------|
|<img width="1084" height="819" alt="old" src="https://github.com/user-attachments/assets/9c003922-460d-4fd8-b41c-589b025a6dc0" />|<img width="1422" height="644" alt="#1150 run" src="https://github.com/user-attachments/assets/00b0242d-39f2-463c-a18b-99a009fba7d7" />|

### [Verification for Addressed Test Passing](https://github.com/antiwork/flexile/actions/runs/17692009771/job/50286824448)


<img width="1469" height="830" alt="tests passing" src="https://github.com/user-attachments/assets/8a3c2180-6652-4a74-90e6-8b569b043441" />


### AI Usage:
1. claude for editing `QuantityInput`