### PR TITLE
Improve `updatesPage` skeleton spacing layout

### DIFF
--- a/frontend/components/TableSkeleton.tsx
+++ b/frontend/components/TableSkeleton.tsx
@@ -32,7 +32,7 @@ export default function TableSkeleton({
   ));
 
   const mobileSkeletonRows = Array.from({ length: 3 }).map((_, rowIndex) => (
-    <TableRow key={`mobile-${rowIndex}`} className="md:hidden">
+    <TableRow key={`mobile-${rowIndex}`} className="flex flex-col md:hidden">
       <TableCell className="mb-2 flex flex-col gap-3 p-4">
         <Skeleton className="h-4 w-48 rounded" /> {/* Subtitle */}
         <div className="flex justify-between">


### PR DESCRIPTION
Part of #911

|Before|After|
|-|-|
|<img width="392" height="329" alt="image" src="https://github.com/user-attachments/assets/7af18473-8746-4028-bca6-9f6a734dafc1" />|<img width="392" height="329" alt="image" src="https://github.com/user-attachments/assets/f46e673f-05a0-4f4f-9fef-06091441b6c2" />
## AI Disclosure
No usage of AI