### PR TITLE
fix: invalidate invoice get endpoint on re-submission

### DIFF
--- a/frontend/app/(dashboard)/invoices/Edit.tsx
+++ b/frontend/app/(dashboard)/invoices/Edit.tsx
@@ -219,6 +219,7 @@ const Edit = () => {
         assertOk: true,
       });
       await trpcUtils.invoices.list.invalidate({ companyId: company.id });
+      await trpcUtils.invoices.get.invalidate({ companyId: company.id, id });
       await trpcUtils.documents.list.invalidate();
       if (id) {
         await refetch();


### PR DESCRIPTION
Invoice view page has stale data after re-submission

### Re-production steps

1. Open a single invoice
2. Click on edit and make changes
3. Re-submit the invoice
4. Open the invoice view again (has stale data)

### The fix
Invaliate get endpoint on successful re-submission

### Before

https://github.com/user-attachments/assets/ac40cca3-b8cf-4b06-8897-deae47a9054a

### After

https://github.com/user-attachments/assets/0854a30b-4255-43fe-b595-725382cff27f

### AI Usage 
None