### PR TITLE
Add automatic URL and email linking to invoice text fields

### DIFF
--- a/e2e/tests/company/invoices/auto-linked-text.spec.ts
+++ b/e2e/tests/company/invoices/auto-linked-text.spec.ts
@@ -1,0 +1,85 @@
+import { companiesFactory } from "@test/factories/companies";
+import { companyContractorsFactory } from "@test/factories/companyContractors";
+import { usersFactory } from "@test/factories/users";
+import { login } from "@test/helpers/auth";
+import { expect, test } from "@test/index";
+
+test.describe("AutoLinkedText functionality", () => {
+  let company: Awaited<ReturnType<typeof companiesFactory.createCompletedOnboarding>>;
+  let contractorUser: Awaited<ReturnType<typeof usersFactory.create>>["user"];
+
+  test.beforeEach(async () => {
+    company = await companiesFactory.createCompletedOnboarding();
+    contractorUser = (await usersFactory.create()).user;
+    await companyContractorsFactory.create({
+      companyId: company.company.id,
+      userId: contractorUser.id,
+      payRateInSubunits: 7500,
+    });
+  });
+
+  test("renders URLs as clickable links in line item descriptions", async ({ page }) => {
+    await login(page, contractorUser);
+
+    // Create an invoice with a URL in the description
+    await page.goto("/invoices/new");
+    await page.getByPlaceholder("Description").fill("Check documentation at https://docs.example.com");
+    await page.getByLabel("Hours / Qty").fill("1:00");
+    await page.getByRole("button", { name: "Send invoice" }).click();
+
+    // Navigate to the created invoice
+    await expect(page.getByRole("heading", { name: "Invoices" })).toBeVisible();
+    await page.locator("tbody tr").first().click();
+
+    // Verify the URL is rendered as a clickable link
+    const urlLink = page.locator('a[href="https://docs.example.com"]');
+    await expect(urlLink).toBeVisible();
+    await expect(urlLink).toHaveText("https://docs.example.com");
+    await expect(urlLink).toHaveAttribute("target", "_blank");
+  });
+
+  test("renders email addresses as clickable mailto links in line item descriptions", async ({ page }) => {
+    await login(page, contractorUser);
+
+    // Create an invoice with an email in the description
+    await page.goto("/invoices/new");
+    await page.getByPlaceholder("Description").fill("Contact support@example.com for questions");
+    await page.getByLabel("Hours / Qty").fill("1:00");
+    await page.getByRole("button", { name: "Send invoice" }).click();
+
+    // Navigate to the created invoice
+    await expect(page.getByRole("heading", { name: "Invoices" })).toBeVisible();
+    await page.locator("tbody tr").first().click();
+
+    // Verify the email is rendered as a clickable mailto link
+    const emailLink = page.locator('a[href="mailto:support@example.com"]');
+    await expect(emailLink).toBeVisible();
+    await expect(emailLink).toHaveText("support@example.com");
+  });
+
+  test("renders URLs and emails as clickable links in invoice notes", async ({ page }) => {
+    await login(page, contractorUser);
+
+    // Create an invoice with URLs and emails in the notes
+    await page.goto("/invoices/new");
+    await page.getByPlaceholder("Description").fill("Development work");
+    await page.getByLabel("Hours / Qty").fill("1:00");
+    await page
+      .getByPlaceholder("Enter notes about your invoice (optional)")
+      .fill("Visit https://example.com or contact admin@example.com for support.");
+    await page.getByRole("button", { name: "Send invoice" }).click();
+
+    // Navigate to the created invoice
+    await expect(page.getByRole("heading", { name: "Invoices" })).toBeVisible();
+    await page.locator("tbody tr").first().click();
+
+    // Verify the links are rendered correctly in notes
+    const urlLink = page.locator('a[href="https://example.com"]');
+    await expect(urlLink).toBeVisible();
+    await expect(urlLink).toHaveText("https://example.com");
+
+    const emailLink = page.locator('a[href="mailto:admin@example.com"]');
+    await expect(emailLink).toBeVisible();
+    await expect(emailLink).toHaveText("admin@example.com");
+  });
+});

--- a/frontend/app/(dashboard)/invoices/[id]/page.tsx
+++ b/frontend/app/(dashboard)/invoices/[id]/page.tsx
@@ -8,6 +8,7 @@ import Link from "next/link";
 import { useParams, useRouter, useSearchParams } from "next/navigation";
 import React, { useMemo, useState } from "react";
 import AttachmentListCard from "@/components/AttachmentsList";
+import AutoLinkedText from "@/components/AutoLinkedText";
 import { DashboardHeader } from "@/components/DashboardHeader";
 import { linkClasses } from "@/components/Link";
 import MutationButton from "@/components/MutationButton";
@@ -464,7 +465,7 @@ export default function InvoicePage() {
                         <TableRow key={index}>
                           <PrintTableCell className="w-[50%] align-top md:w-[60%] print:align-top">
                             <div className="max-w-full overflow-hidden pr-2 break-words whitespace-normal">
-                              {lineItem.description}
+                              <AutoLinkedText text={lineItem.description || ""} />
                             </div>
                           </PrintTableCell>
                           <PrintTableCell className="w-[20%] text-right align-top tabular-nums md:w-[15%] print:text-right print:align-top">
@@ -517,10 +518,8 @@ export default function InvoicePage() {
                   {invoice.notes ? (
                     <div>
                       <b className="print:text-sm print:font-bold">Notes</b>
-                      <div>
-                        <div className="text-xs">
-                          <p className="whitespace-pre-wrap print:mt-1 print:text-xs">{invoice.notes}</p>
-                        </div>
+                      <div className="text-xs print:mt-1 print:text-xs">
+                        <AutoLinkedText text={invoice.notes} preserveWhitespace className="whitespace-pre-wrap" />
                       </div>
                     </div>
                   ) : null}

--- a/frontend/components/AutoLinkedText.tsx
+++ b/frontend/components/AutoLinkedText.tsx
@@ -33,7 +33,7 @@ const AutoLinkedText: React.FC<AutoLinkedTextProps> = ({ text, className, preser
 
     return parts
       .map((part) => {
-        if (part.match(/^<a[^>]*>.*?<\/a>$/iu)) {
+        if (/^<a[^>]*>.*?<\/a>$/iu.exec(part)) {
           return part;
         }
         return part.replace(urlRegex, (match) => {

--- a/frontend/components/AutoLinkedText.tsx
+++ b/frontend/components/AutoLinkedText.tsx
@@ -1,0 +1,88 @@
+import { EditorContent, useEditor } from "@tiptap/react";
+import React, { useEffect, useMemo } from "react";
+import { richTextExtensions } from "@/utils/richText";
+
+interface AutoLinkedTextProps {
+  text: string;
+  className?: string;
+  /** Whether to preserve newlines and double spaces in the text */
+  preserveWhitespace?: boolean;
+}
+
+/**
+ * Component that automatically converts URLs and email addresses to clickable links.
+ * Uses TipTap editor for rich text rendering with link support.
+ */
+const AutoLinkedText: React.FC<AutoLinkedTextProps> = ({ text, className, preserveWhitespace = false }) => {
+  /**
+   * Converts URLs and email addresses in text to clickable links.
+   * First processes emails to avoid conflicts, then handles URLs while preserving existing links.
+   */
+  const linkifyText = (inputText: string): string => {
+    if (!inputText) return "";
+
+    let currentText = inputText;
+
+    const emailRegex = /([a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,})/giu;
+    currentText = currentText.replace(emailRegex, (match) => `<a href="mailto:${match}">${match}</a>`);
+
+    const urlRegex = /(https?:\/\/[^\s<>"]+|www\.[^\s<>"]+|(?:[a-zA-Z0-9-]+\.)+[a-zA-Z]{2,}(?:\/[^\s<>"]*)?)/giu;
+
+    // Split by existing anchor tags to avoid double-linking
+    const parts = currentText.split(/(<a[^>]*>.*?<\/a>)/giu);
+
+    return parts
+      .map((part) => {
+        if (part.match(/^<a[^>]*>.*?<\/a>$/iu)) {
+          return part;
+        }
+        return part.replace(urlRegex, (match) => {
+          const href = match.startsWith("http") ? match : `https://${match}`;
+          return `<a href="${href}" target="_blank" rel="noopener noreferrer">${match}</a>`;
+        });
+      })
+      .join("");
+  };
+
+  const processedContent = useMemo(() => {
+    if (!text) return "";
+
+    let processedText = linkifyText(text);
+
+    if (preserveWhitespace) {
+      processedText = processedText.replace(/\n/gu, "<br>").replace(/ {2}/gu, " &nbsp;");
+    }
+    return `<p>${processedText}</p>`;
+  }, [text, preserveWhitespace]);
+
+  // TipTap editor in read-only mode with link extensions for proper rendering
+  const editor = useEditor({
+    extensions: richTextExtensions,
+    content: processedContent,
+    editable: false,
+    immediatelyRender: false,
+    editorProps: {
+      attributes: {
+        class: `prose prose-sm max-w-none text-inherit ${className || ""}`.trim(),
+      },
+    },
+  });
+
+  useEffect(() => {
+    if (editor && processedContent !== editor.getHTML()) {
+      editor.commands.setContent(processedContent, false);
+    }
+  }, [processedContent, editor]);
+
+  if (!text) {
+    return null;
+  }
+
+  return (
+    <div className="auto-linked-text">
+      <EditorContent editor={editor} />
+    </div>
+  );
+};
+
+export default AutoLinkedText;


### PR DESCRIPTION
## Summary
Automatically converts URLs and email addresses to clickable links in invoice text fields using a new `AutoLinkedText` component powered by TipTap editor.

## What's Changed
- **New Component**: `AutoLinkedText` component that processes plain text and converts URLs/emails to clickable links
- **Invoice Integration**: Applied to invoice line item descriptions and invoice notes
- **Link Handling**: 
  - URLs open in new tab with `target="_blank"` and security attributes
  - Email addresses become `mailto:` links
  - Supports various URL formats (http/https, www.*, domain.tld)
- **Whitespace Preservation**: Optional support for preserving newlines and spacing in invoice notes

## Technical Implementation
- Uses TipTap editor with rich text extensions for proper link rendering
- Regex-based text processing that avoids double-linking existing anchor tags
- Memoized content processing for performance
- Read-only editor mode for display-only functionality

## Where Applied
- Invoice line item descriptions
- Invoice notes section
-  Uses existing TipTap infrastructure

## Screen Recording

https://github.com/user-attachments/assets/78139c3e-96da-4b17-a14f-941fcae59e5c

## Testing
- Comprehensive e2e tests covering URL and email linking scenarios
- Tests verify proper `href` attributes and link behavior
- Coverage for both line item descriptions and invoice notes

<img width="1012" height="208" alt="Screenshot 2025-09-30 at 6 20 33 PM" src="https://github.com/user-attachments/assets/67974f40-294c-42e2-b67f-f1890beb8aac" />

## AI disclosure
AI was used for the initial draft of the PR.