### PR TITLE
fix alignment and font color

### DIFF
--- a/frontend/app/settings/administrator/roles/page.tsx
+++ b/frontend/app/settings/administrator/roles/page.tsx
@@ -249,9 +249,15 @@ export default function RolesPage() {
             <div className="min-w-0">
               <div className="flex items-center gap-1 font-medium">
                 <span className="truncate">{user.name}</span>
-                {isCurrentUser ? <span className="text-muted-foreground shrink-0 text-xs">(You)</span> : null}
               </div>
-              <div className="text-muted-foreground truncate text-sm">{user.email}</div>
+              <div className="text-muted-foreground flex items-baseline gap-1 text-sm">
+                <span className="min-w-0 flex-1 truncate text-black md:overflow-visible md:whitespace-normal">
+                  {user.email}
+                </span>
+                {isCurrentUser ? (
+                  <span className="text-muted-foreground shrink-0 text-xs whitespace-nowrap">(You)</span>
+                ) : null}
+              </div>
             </div>
           );
         },


### PR DESCRIPTION
part of #911 

Description:
Fixed alignment and text color of Name.

### Before / After
| Before | After |
|--------|-------|
| <img width="378" height="751" src="https://github.com/user-attachments/assets/3a58a4dd-1989-47b5-8ed7-71d8345b0ae2" /> | <img width="378" height="751" src="https://github.com/user-attachments/assets/554b36b6-f25e-45dd-8cc6-b21cfa457c25" /> |

### AI Disclosure
No usage of AI.
