### PR TITLE
fix: update invoice creation test to use correct label for hours and avoid race condition

### DIFF
--- a/e2e/tests/company/invoices/create.spec.ts
+++ b/e2e/tests/company/invoices/create.spec.ts
@@ -63,13 +63,14 @@ test.describe("invoice creation", () => {
     await login(page, contractorUser, "/invoices/new");
 
     await page.getByPlaceholder("Description").fill("I worked on invoices");
-    await page.getByLabel("Hours").fill("03:25");
+    await fillDatePicker(page, "Date", "08/08/2021");
+    await page.getByLabel("Hours / Qty").fill("03:25");
     await expect(page.getByText("Total services$60")).toBeVisible();
     await expect(page.getByText("Swapped for equity (not paid in cash)$0")).toBeVisible();
     await expect(page.getByText("Net amount in cash$60")).toBeVisible();
 
-    await fillDatePicker(page, "Date", "08/08/2021");
     await page.getByLabel("Hours / Qty").fill("100:00");
+    await page.getByPlaceholder("Description").click();
     await page.getByPlaceholder("Description").fill("I worked on invoices");
 
     await expect(page.getByText("Total services$6,000")).toBeVisible();


### PR DESCRIPTION
Ref: https://github.com/antiwork/flexile/issues/1132

Fixed the failing e2e test "considers the invoice year when calculating equity" by correcting the test flow and ensuring proper form state management during invoice creation.

Recent Jobs failures:
https://github.com/antiwork/flexile/actions/runs/18118626892/job/51559129985
https://github.com/antiwork/flexile/actions/runs/18118141344/job/51557771102

### Failing Test 

[video.webm](https://github.com/user-attachments/assets/16e2b393-0d56-44b7-bcdd-f93677805393)

This happens because of hours 100:00 not being populated in the field and this condition failing - `await expect(page.getByText("Total services$6,000")).toBeVisible();`

This comes from behaviour of QuantityInput component (frontend/app/(dashboard)/invoices/QuantityInput.tsx) where these values are filled in which performs the calculation of amount when onBlur is invoked implicitly.

This where the changes of `await page.getByPlaceholder("Description").click();` is added so that **Clicking the Description input moves focus off the Hours input, causing the native blur event to fire on that input.**

The date filling has been moved up as was experiencing UI and it seems race condition - 

- User types in Hours / Qty → `QuantityInput` stores the typed string in local `rawValue` state (no commit yet).
- When the input loses focus (native blur) `QuantityInput` runs its onBlur:
    - If string contains ":", it parses hours/minutes and converts to minutes.
    - Calls the parent `onChange` with `{ quantity: minutes, hourly: true }`.
- Clicking or blurring the hours input fires QuantityInput.onBlur which:
       - parses "100:00" → minutes and calls parent onChange,
       - parent updates state → UI re-renders,
       - TRPC calculation may run and then update the DOM further.
- If the test calls fillDatePicker while the DOM is mid-update, Playwright can send keystrokes to an element that gets replaced, producing partial values.

Below example with partial values due to race condition:

[video2.webm](https://github.com/user-attachments/assets/bd46a0ae-e7bd-489f-afcd-222256f2fe21)

This was fixed by moving `fillDatePicker` at top of these changes to consistently have correct dates without such race condition.

I hope this makes it clearer and should be best fix for this issue. Working locally:

<img width="1027" height="1157" alt="image" src="https://github.com/user-attachments/assets/d6225923-9560-4054-b16f-601d5e2a76b5" />

AI Disclosure:
GitHub copilot for brainstorming