### PR TITLE
fix(test): ensure optional bank name field is displayed for business accounts

### DIFF
--- a/frontend/app/settings/payouts/BankAccountModal.tsx
+++ b/frontend/app/settings/payouts/BankAccountModal.tsx
@@ -28,6 +28,7 @@ const KEY_ACCOUNT_HOLDER_NAME = "accountHolderName";
 const KEY_ACCOUNT_ROUTING_NUMBER = "abartn";
 const KEY_ADDRESS_COUNTRY = "address.country";
 const KEY_ADDRESS_STATE = "address.state";
+const KEY_BANK_NAME = "bankName";
 const KEY_ADDRESS_CITY = "address.city";
 const KEY_ADDRESS_POST_CODE = "address.postCode";
 const KEY_ADDRESS_FIRST_LINE = "address.firstLine";
@@ -131,8 +132,7 @@ const validateCPF = (cpf: string): boolean => {
 
   return parseInt(digits.charAt(10), 10) === secondCheckDigit;
 };
-
-const OPTIONAL_VISIBLE_FIELD_KEYS = new Set<string>(["bankName"]);
+const ALWAYS_VISIBLE_FIELD_KEYS = new Set([KEY_ADDRESS_STATE, KEY_BANK_NAME]);
 
 const fieldGroups: string[][] = [
   [
@@ -256,7 +256,7 @@ const BankAccountModal = ({ open, billingDetails, bankAccount, onComplete, onClo
       allFields
         ?.filter(
           (field) =>
-            (field.required || field.key === KEY_ADDRESS_STATE || OPTIONAL_VISIBLE_FIELD_KEYS.has(field.key)) &&
+            (field.required || ALWAYS_VISIBLE_FIELD_KEYS.has(field.key)) &&
             !((field.type === "select" || field.type === "radio") && !field.valuesAllowed) &&
             field.key !== KEY_LEGAL_TYPE,
         )

--- a/frontend/app/settings/payouts/BankAccountModal.tsx
+++ b/frontend/app/settings/payouts/BankAccountModal.tsx
@@ -132,6 +132,8 @@ const validateCPF = (cpf: string): boolean => {
   return parseInt(digits.charAt(10), 10) === secondCheckDigit;
 };
 
+const OPTIONAL_VISIBLE_FIELD_KEYS = new Set<string>(["bankName"]);
+
 const fieldGroups: string[][] = [
   [
     "ifscCode",
@@ -254,7 +256,7 @@ const BankAccountModal = ({ open, billingDetails, bankAccount, onComplete, onClo
       allFields
         ?.filter(
           (field) =>
-            (field.required || field.key === KEY_ADDRESS_STATE) &&
+            (field.required || field.key === KEY_ADDRESS_STATE || OPTIONAL_VISIBLE_FIELD_KEYS.has(field.key)) &&
             !((field.type === "select" || field.type === "radio") && !field.valuesAllowed) &&
             field.key !== KEY_LEGAL_TYPE,
         )


### PR DESCRIPTION

## Description

This PR fixes a test timeout issue in the bank account settings by ensuring the Wise "Bank name" field remains always visible in the bank account modal.

- Introduced a dedicated key constant for the Wise "Bank name" field. 
- Marked the field as always visible, similar to the address state field handling logic.
- Ensured consistent rendering of required fields to prevent timing issues during automated tests.

## Why

Automated tests were timing out because the "Bank name" field was not reliably rendered in the DOM when expected. Making it always visible prevents flaky tests and aligns it with other mandatory fields in the modal

## Flaky test in the main branch
https://github.com/antiwork/flexile/actions/runs/18129189994/job/51591463961

## Before
<img width="1388" height="864" alt="Screenshot_2025-09-30_18-02-55" src="https://github.com/user-attachments/assets/5c449d90-9e41-4c94-a5f3-ff4e1720142f" />

## After 

<img width="1325" height="552" alt="Screenshot_2025-10-01_07-01-24" src="https://github.com/user-attachments/assets/fbec5e5f-800e-434d-b385-317d43ecb7f4" />

## AI usage
None

Ref  #1132 