### PR TITLE
fix: settings responsiveness

### DIFF
--- a/frontend/app/settings/page.tsx
+++ b/frontend/app/settings/page.tsx
@@ -183,7 +183,7 @@ const LeaveWorkspaceSection = () => {
       <div className="grid gap-4">
         <h3 className="text mt-4 font-medium">Workspace access</h3>
         <Card>
-          <CardHeader className="flex items-center justify-between">
+          <CardHeader className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
             <div className="flex items-center gap-4">
               <Avatar className="size-8 rounded-md">
                 <AvatarImage src={company.logo_url ?? defaultLogo.src} alt="Company logo" />
@@ -191,16 +191,14 @@ const LeaveWorkspaceSection = () => {
               </Avatar>
               <span className="font-medium">{company.name}</span>
             </div>
-            <CardAction>
-              <Button
-                variant="outline"
-                size="small"
-                className="text-destructive hover:text-destructive"
-                onClick={() => setIsModalOpen(true)}
-              >
-                Leave workspace
-              </Button>
-            </CardAction>
+            <Button
+              variant="outline"
+              size="small"
+              className="text-destructive hover:text-destructive w-full sm:w-auto"
+              onClick={() => setIsModalOpen(true)}
+            >
+              Leave workspace
+            </Button>
           </CardHeader>
         </Card>
       </div>

--- a/frontend/app/settings/page.tsx
+++ b/frontend/app/settings/page.tsx
@@ -19,7 +19,7 @@ import {
 } from "@/components/ui/alert-dialog";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { Button } from "@/components/ui/button";
-import { Card, CardAction, CardHeader } from "@/components/ui/card";
+import { Card, CardHeader } from "@/components/ui/card";
 import { Form, FormControl, FormField, FormItem, FormLabel, FormMessage } from "@/components/ui/form";
 import { Input } from "@/components/ui/input";
 import { useCurrentCompany, useCurrentUser, useUserStore } from "@/global";

--- a/frontend/app/settings/page.tsx
+++ b/frontend/app/settings/page.tsx
@@ -191,11 +191,7 @@ const LeaveWorkspaceSection = () => {
               </Avatar>
               <span className="font-medium">{company.name}</span>
             </div>
-            <Button
-              variant="destructive"
-              className="w-full sm:w-auto"
-              onClick={() => setIsModalOpen(true)}
-            >
+            <Button variant="destructive" className="w-full sm:w-auto" onClick={() => setIsModalOpen(true)}>
               Leave workspace
             </Button>
           </CardHeader>


### PR DESCRIPTION
Reopening PR https://github.com/antiwork/flexile/pull/1357 after fixing conflicts

Before:-

Because of the text "Gumroad Demo" and "Leave Workspace" the button was overflowing the container on mobile

![Screenshot 2025-10-01 at 4 06 29 AM](https://github.com/user-attachments/assets/32543335-a5d5-458e-9f74-22d18c484214)

After:-

![Screenshot 2025-10-01 at 4 25 05 AM](https://github.com/user-attachments/assets/ac9783e6-fb26-4288-b8a2-c97e60768d53)

![Screenshot 2025-10-01 at 4 24 55 AM](https://github.com/user-attachments/assets/39ae73d9-fd66-47ad-b7e7-3a28e57c76c1)

AI Disclosure:-
No AI assistance was used in this PR
