### PR TITLE
fix(flaky test): flaky contractor invite link spec 

### DIFF
--- a/e2e/tests/company/administrator/contractor-invite-link.spec.ts
+++ b/e2e/tests/company/administrator/contractor-invite-link.spec.ts
@@ -12,9 +12,12 @@ test.describe("Contractor Invite Link", () => {
     await page.getByRole("link", { name: "People" }).click();
     await expect(page.getByRole("heading", { name: "People" })).toBeVisible();
 
+    await page.waitForResponse((response) => response.url().includes("contractors.list") && response.status() === 200);
+
     await page.getByRole("button", { name: "Invite link" }).click();
     await expect(page.getByRole("heading", { name: "Invite Link" })).toBeVisible();
 
+    await expect(page.getByRole("textbox", { name: "Link" })).not.toHaveValue("");
     await expect(page.getByRole("button", { name: "Copy" })).toBeEnabled();
     await expect(page.getByRole("textbox", { name: "Link" })).toBeVisible();
 


### PR DESCRIPTION
ref: #1132

### AI Disclosure:
- cursor used in auto mode for debugging purposes with prompts: 
- can you modify frontend code to artificially make invite link loading slow
- is copy button enabled before invite link is loaded loaded? 
- is there any possible pending request when model is open? (that's how i find contractors.list request can be pending)
- can you add 3 seconds delay to contractors.list fetching (i checked, and model got closed as fetch finished)
- is there way to target specific contractors.list request rather than waiting for networkidle

### failing CI link:
https://github.com/antiwork/flexile/actions/runs/18168791709/job/51718019423?pr=1367#step:12:284
<img width="1071" height="681" alt="Screenshot 2025-10-01 at 11 47 04 PM" src="https://github.com/user-attachments/assets/09a2ee25-a7c4-4cdc-a5f5-1920356ee530" />

# Problem:
- contractor.list fetch was pending in background, and we open invite link modal
- contractor.list fetch completes and page re-render, cause invite link modal to close before we copied the link
- now we're unable to find copy button, and test fails.

# Solution:
- wait for contractor.list to complete before opening invite link modal to avoid race condition.

## local run:
<img width="861" height="248" alt="Screenshot 2025-10-02 at 12 00 55 AM" src="https://github.com/user-attachments/assets/154ed492-45c8-4041-95fa-9e5058e44a03" />
