### PR TITLE
fix: bottom bar and dropdown visible on printout in mobile

### DIFF
--- a/frontend/app/(dashboard)/invoices/[id]/page.tsx
+++ b/frontend/app/(dashboard)/invoices/[id]/page.tsx
@@ -134,7 +134,7 @@ export default function InvoicePage() {
               <DropdownMenuTrigger className="p-2">
                 <MoreHorizontal className="size-5 text-blue-600" strokeWidth={1.75} />
               </DropdownMenuTrigger>
-              <DropdownMenuContent align="end" className="">
+              <DropdownMenuContent align="end" className="print:hidden">
                 {user.roles.administrator && isActionable(invoice) ? (
                   <>
                     <DropdownMenuItem

--- a/frontend/components/navigation/MobileBottomNav.tsx
+++ b/frontend/components/navigation/MobileBottomNav.tsx
@@ -421,7 +421,7 @@ export function MobileBottomNav() {
     <nav
       role="navigation"
       aria-label="Mobile navigation"
-      className="bg-background border-border pointer-events-auto fixed right-0 bottom-0 left-0 z-60 h-15"
+      className="bg-background border-border pointer-events-auto fixed right-0 bottom-0 left-0 z-60 h-15 print:hidden"
     >
       <ul role="list" className="flex items-center justify-around">
         {mainItems.map((item) => (


### PR DESCRIPTION
## Description
Fixes an issue where the dropdown and bottom navigation bar were being included in the print view on mobile devices.

### Before
https://github.com/user-attachments/assets/09990adf-1c08-493a-9244-cd2a76300bf2

### After 
Tested by printing approved, rejected and awaiting invoices

https://github.com/user-attachments/assets/ee982f0c-285f-4aeb-9ed9-a9efd51b95ac

## AI Disclosure
No ai was used in this PR